### PR TITLE
feat: add the application state machine, numbering and audit trail

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,7 +28,12 @@ src/worker/            Cloudflare Worker (Hono)
     mappers.ts         row to model conversion
     repository.ts      parameterised queries grouped per aggregate
     errors.ts          constraint-violation translation
+  services/            business rules; no SQL, no HTTP
+    state-machine.ts   validated, idempotent, concurrency-safe transitions
+    numbering.ts       application and receipt numbers
+    audit.ts           audit trail with an allowlist for metadata
   lib/logger.ts        allowlist logger; the only sanctioned console sink
+  lib/time.ts          Asia/Bangkok conversion and Buddhist-era years
   lib/http.ts          API error codes and applicant-safe messages
   lib/crypto.ts        citizen ID encryption and duplicate-lookup hashing
   lib/citizen-id.ts    citizen ID normalisation and check-digit validation
@@ -72,6 +77,39 @@ Confirmed properties of the schema, enforced by `migrations/0001_create_core_sch
 - Timestamp ทั้งหมดเป็น ISO 8601 UTC และแปลงเป็น Asia/Bangkok เฉพาะตอนแสดงผล
 - `status`, `membership_type`, `photo_source`, email `type`/`status` และ `actor_type` ถูกจำกัดด้วย `CHECK` constraint
 - `metadata_json` ของ audit event รับได้เฉพาะ object แบนที่มีค่าเป็น primitive และถูกกรองอีกครั้งตอนอ่าน
+
+## Application state machine
+
+```text
+DRAFT ──> AWAITING_PAYMENT ──> PAYMENT_VERIFIED ──> SUBMITTED
+  │              │                    │                 │
+  │              │                    │                 ▼
+  │              │                    │           MANAGER_NOTIFIED
+  │              │                    │                 │
+  │              │                    │                 ▼
+  │              │                    │           NBTC_PROCESSING
+  │              │                    │                 │
+  │              │                    │                 ▼
+  │              │                    │            NBTC_RECORDED ──> COMPLETED
+  │              │                    │
+  └──> CANCELLED ┘                    └──> REFUND_REQUIRED ──> REFUNDED
+
+REJECTED reachable from AWAITING_PAYMENT onwards, and leads to REFUND_REQUIRED
+CANCELLED reachable only before a payment exists
+COMPLETED, CANCELLED and REFUNDED are terminal
+```
+
+คุณสมบัติที่บังคับไว้ใน `src/worker/services/state-machine.ts` และมี test ครอบทั้งสามข้อ
+
+- **Validated** transition ที่ไม่อยู่ในตารางถูกปฏิเสธ ไม่มี code path ใดกระโดดข้ามขั้นได้
+- **Idempotent** การขอสถานะที่เป็นอยู่แล้วเป็น no-op ไม่บันทึก audit event ซ้ำ และไม่ทำ side effect ซ้ำ
+- **Concurrency-safe** การเขียนเป็น compare-and-set บนสถานะที่อ่านมาจริง ไม่ใช่บนชุด predecessor ทั้งหมด เพื่อให้ `from` ใน audit event เป็นค่าที่เคยเป็นจริงเสมอ
+
+## Numbering
+
+`VRA-{พ.ศ.}-{running}` และ `VRA-RC-{พ.ศ.}-{running}` โดย prefix และความยาว sequence เป็น config ปี พ.ศ. คำนวณจากเวลา Asia/Bangkok ไม่ใช่จากวัน UTC ใบสมัครที่ส่งเวลา 23:30 UTC ของวันที่ 31 ธันวาคม จึงได้เลขของปีถัดไป
+
+ความไม่ซ้ำเป็นการรับประกันจาก `UNIQUE` constraint ไม่ใช่จาก application layer ระบบเสนอเลขจากค่าสูงสุดที่ออกไปแล้วบวกหนึ่ง แล้วให้ constraint ตัดสิน ผู้แพ้อ่านค่าสูงสุดใหม่และลองอีกครั้ง จึงได้ลำดับที่ไม่ซ้ำและไม่มีเลขขาดหาย
 
 ## Decision records
 

--- a/src/worker/db/repository.ts
+++ b/src/worker/db/repository.ts
@@ -81,6 +81,12 @@ export interface ApplicationRepository {
   /** Assigns the application number. Fails with `UniqueConstraintError` if taken. */
   setReferenceNo(id: string, referenceNo: string): Promise<void>;
   /**
+   * Highest reference number matching a `like` pattern, or null when none
+   * exists. The sequence is zero-padded to a fixed width, so the lexicographic
+   * maximum is also the numeric maximum.
+   */
+  findMaxReferenceNo(pattern: string): Promise<string | null>;
+  /**
    * Compare-and-set on `status`. Returns false when the row was not in `from`,
    * which is how the state machine stays safe under concurrent requests
    * without a transaction.
@@ -118,6 +124,8 @@ export interface ReceiptRepository {
   create(input: ReceiptInput): Promise<ReceiptRecord>;
   findByApplicationId(applicationId: string): Promise<ReceiptRecord | null>;
   findByReceiptNo(receiptNo: string): Promise<ReceiptRecord | null>;
+  /** Highest receipt number matching a `like` pattern, or null when none exists. */
+  findMaxReceiptNo(pattern: string): Promise<string | null>;
   markEmailSent(id: string, sentAt?: string): Promise<void>;
 }
 
@@ -304,6 +312,20 @@ export function createRepository(db: D1Database, options: RepositoryOptions = {}
         // that has already been printed on a document.
         throw new UniqueConstraintError('applications.reference_no');
       }
+    },
+
+    async findMaxReferenceNo(pattern) {
+      const row = await first(
+        db
+          .prepare(
+            `select reference_no from applications
+             where reference_no like ?
+             order by reference_no desc limit 1`,
+          )
+          .bind(pattern),
+      );
+      const value = row?.['reference_no'];
+      return typeof value === 'string' ? value : null;
     },
 
     async updateStatusIf(id, from, to, timestamps) {
@@ -520,6 +542,20 @@ export function createRepository(db: D1Database, options: RepositoryOptions = {}
         db.prepare('select * from receipts where receipt_no = ?').bind(receiptNo),
       );
       return row ? toReceiptRecord(row) : null;
+    },
+
+    async findMaxReceiptNo(pattern) {
+      const row = await first(
+        db
+          .prepare(
+            `select receipt_no from receipts
+             where receipt_no like ?
+             order by receipt_no desc limit 1`,
+          )
+          .bind(pattern),
+      );
+      const value = row?.['receipt_no'];
+      return typeof value === 'string' ? value : null;
     },
 
     async markEmailSent(id, sentAt) {

--- a/src/worker/db/repository.ts
+++ b/src/worker/db/repository.ts
@@ -803,11 +803,16 @@ export function createRepository(db: D1Database, options: RepositoryOptions = {}
     },
 
     async listByApplicationId(applicationId) {
+      // `rowid` breaks ties, not `id`. Events written in the same batch share a
+      // millisecond, and `id` is a random UUID, so ordering by it would shuffle
+      // the timeline the admin screen shows - putting STATUS_CHANGED before the
+      // domain event that caused it. `rowid` follows insert order, which is the
+      // causal order.
       const rows = await all(
         db
           .prepare(
             `select * from application_events where application_id = ?
-             order by created_at asc, id asc`,
+             order by created_at asc, rowid asc`,
           )
           .bind(applicationId),
       );

--- a/src/worker/db/repository.ts
+++ b/src/worker/db/repository.ts
@@ -50,6 +50,11 @@ export interface RepositoryOptions {
 const DEFAULT_LIST_LIMIT = 50;
 const MAXIMUM_LIST_LIMIT = 200;
 
+/** Timestamps that a status change may set. Existing values are never cleared. */
+export type StatusTimestamps = Partial<
+  Record<'submittedAt' | 'managerAcknowledgedAt' | 'nbtcRecordedAt', string>
+> & { nbtcRecordedBy?: string };
+
 function isoNow(now: () => Date): string {
   return now().toISOString();
 }
@@ -90,15 +95,35 @@ export interface ApplicationRepository {
    * Compare-and-set on `status`. Returns false when the row was not in `from`,
    * which is how the state machine stays safe under concurrent requests
    * without a transaction.
+   *
+   * Records no audit event. Prefer `transitionStatus`, which cannot leave a
+   * status change without its trail.
    */
   updateStatusIf(
     id: string,
     from: readonly ApplicationStatus[],
     to: ApplicationStatus,
-    timestamps?: Partial<
-      Record<'submittedAt' | 'managerAcknowledgedAt' | 'nbtcRecordedAt', string>
-    > & { nbtcRecordedBy?: string },
+    timestamps?: StatusTimestamps,
   ): Promise<boolean>;
+  /**
+   * Compare-and-set on `status` plus its audit events, in one D1 batch and
+   * therefore one transaction.
+   *
+   * Writing the status and then the events as two round trips leaves a window
+   * where a failure produces a status change with no trail, and Issue #1
+   * requires the trail to be complete. Each event insert is guarded on the row
+   * already holding `to`, so if the compare-and-set did not apply, the events
+   * are skipped rather than recording something that did not happen.
+   *
+   * Returns false when the row was not in `from`.
+   */
+  transitionStatus(input: {
+    id: string;
+    from: ApplicationStatus;
+    to: ApplicationStatus;
+    timestamps?: StatusTimestamps;
+    events: readonly ApplicationEventInput[];
+  }): Promise<boolean>;
   list(query?: ApplicationListQuery): Promise<ApplicationRecord[]>;
 }
 
@@ -175,6 +200,69 @@ export function createRepository(db: D1Database, options: RepositoryOptions = {}
 
   const run = async (statement: D1PreparedStatement): Promise<D1Result> =>
     withTranslatedErrors(async () => statement.run());
+
+  /** Compare-and-set on status. Never clears a timestamp that is already set. */
+  const statusUpdate = (
+    id: string,
+    from: readonly ApplicationStatus[],
+    to: ApplicationStatus,
+    timestamps: StatusTimestamps | undefined,
+  ): D1PreparedStatement =>
+    db
+      .prepare(
+        `update applications set
+           status = ?,
+           submitted_at = coalesce(?, submitted_at),
+           manager_acknowledged_at = coalesce(?, manager_acknowledged_at),
+           nbtc_recorded_at = coalesce(?, nbtc_recorded_at),
+           nbtc_recorded_by = coalesce(?, nbtc_recorded_by),
+           updated_at = ?
+         where id = ? and status in (${from.map(() => '?').join(', ')})`,
+      )
+      .bind(
+        to,
+        timestamps?.submittedAt ?? null,
+        timestamps?.managerAcknowledgedAt ?? null,
+        timestamps?.nbtcRecordedAt ?? null,
+        timestamps?.nbtcRecordedBy ?? null,
+        isoNow(now),
+        id,
+        ...from,
+      );
+
+  /**
+   * Inserts an audit event only if the application still holds `requiredStatus`.
+   *
+   * This must be the status *before* the transition, and these inserts must be
+   * batched *before* the status update. Guarding on the target status instead
+   * looks equivalent but is not: once one request has committed the change,
+   * every concurrent loser also sees the target status, so all of them would
+   * insert an event for a change only one of them made.
+   */
+  const guardedEventInsert = (
+    event: ApplicationEventInput,
+    applicationId: string,
+    requiredStatus: ApplicationStatus,
+  ): D1PreparedStatement =>
+    db
+      .prepare(
+        `insert into application_events (
+           id, application_id, event_type, metadata_json, actor_type, actor_id, created_at
+         )
+         select ?, ?, ?, ?, ?, ?, ?
+         where exists (select 1 from applications where id = ? and status = ?)`,
+      )
+      .bind(
+        newId(),
+        applicationId,
+        event.eventType,
+        event.metadata ? JSON.stringify(event.metadata) : null,
+        event.actorType,
+        event.actorId ?? null,
+        isoNow(now),
+        applicationId,
+        requiredStatus,
+      );
 
   const applications: ApplicationRepository = {
     async create(input) {
@@ -329,31 +417,29 @@ export function createRepository(db: D1Database, options: RepositoryOptions = {}
     },
 
     async updateStatusIf(id, from, to, timestamps) {
-      const placeholders = from.map(() => '?').join(', ');
-      const result = await run(
-        db
-          .prepare(
-            `update applications set
-               status = ?,
-               submitted_at = coalesce(?, submitted_at),
-               manager_acknowledged_at = coalesce(?, manager_acknowledged_at),
-               nbtc_recorded_at = coalesce(?, nbtc_recorded_at),
-               nbtc_recorded_by = coalesce(?, nbtc_recorded_by),
-               updated_at = ?
-             where id = ? and status in (${placeholders})`,
-          )
-          .bind(
-            to,
-            timestamps?.submittedAt ?? null,
-            timestamps?.managerAcknowledgedAt ?? null,
-            timestamps?.nbtcRecordedAt ?? null,
-            timestamps?.nbtcRecordedBy ?? null,
-            isoNow(now),
-            id,
-            ...from,
-          ),
-      );
+      const result = await run(statusUpdate(id, from, to, timestamps));
       return result.meta.changes > 0;
+    },
+
+    async transitionStatus({ id, from, to, timestamps, events }) {
+      if (from === to) {
+        // Both the guard and the update key off `from`, so a same-status call
+        // would record a transition that never happened.
+        throw new Error('A status transition must change the status');
+      }
+
+      // Events first, each guarded on the pre-transition status, then the
+      // compare-and-set. Every statement therefore keys off the same `from`, so
+      // either all of them apply or none of them do.
+      const statements = [
+        ...events.map((event) => guardedEventInsert(event, id, from)),
+        statusUpdate(id, [from], to, timestamps),
+      ];
+
+      const results = await withTranslatedErrors(async () => db.batch(statements));
+      // D1 runs a batch as one transaction. The update is last, so its change
+      // count is the answer to "did this transition apply".
+      return (results.at(-1)?.meta.changes ?? 0) > 0;
     },
 
     async list(query = {}) {

--- a/src/worker/lib/time.ts
+++ b/src/worker/lib/time.ts
@@ -1,0 +1,104 @@
+/**
+ * Time handling.
+ *
+ * The database stores ISO 8601 UTC instants. Everything an applicant or the
+ * association manager sees is expressed in Asia/Bangkok, and every generated
+ * number carries a Buddhist-era year derived from Bangkok local time
+ * (Issue #1 sections 69 and 70).
+ *
+ * The offset is never hard-coded and the year is never taken from the UTC date:
+ * an application submitted at 23:30 UTC belongs to the next Bangkok day, and on
+ * 31 December that also means the next Buddhist year.
+ */
+
+export const BANGKOK_TIME_ZONE = 'Asia/Bangkok';
+
+/** Difference between the Buddhist and Gregorian calendar years. */
+const BUDDHIST_ERA_OFFSET = 543;
+
+export interface BangkokDateParts {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+}
+
+const partsFormatter = new Intl.DateTimeFormat('en-CA', {
+  timeZone: BANGKOK_TIME_ZONE,
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  // `h23` rather than `hour12: false`, which renders midnight as hour 24 in
+  // some ICU versions.
+  hourCycle: 'h23',
+});
+
+type NumericPart = 'year' | 'month' | 'day' | 'hour' | 'minute' | 'second';
+
+/** Gregorian calendar parts of `instant` as seen in Bangkok. */
+export function toBangkokParts(instant: Date): BangkokDateParts {
+  const values = new Map<string, string>(
+    partsFormatter.formatToParts(instant).map((part) => [part.type, part.value]),
+  );
+
+  const read = (type: NumericPart): number => {
+    const value = values.get(type);
+    if (value === undefined) {
+      throw new Error(`Bangkok date part is missing: ${type}`);
+    }
+    const parsed = Number(value);
+    if (!Number.isInteger(parsed)) {
+      throw new Error(`Bangkok date part is not numeric: ${type}`);
+    }
+    return parsed;
+  };
+
+  return {
+    year: read('year'),
+    month: read('month'),
+    day: read('day'),
+    hour: read('hour'),
+    minute: read('minute'),
+    second: read('second'),
+  };
+}
+
+/** Buddhist-era year of `instant` in Bangkok, e.g. 2569 for 2026. */
+export function bangkokBuddhistYear(instant: Date): number {
+  return toBangkokParts(instant).year + BUDDHIST_ERA_OFFSET;
+}
+
+/** `YYYY-MM-DD` of `instant` in Bangkok, Gregorian. */
+export function bangkokIsoDate(instant: Date): string {
+  const { year, month, day } = toBangkokParts(instant);
+  return `${String(year).padStart(4, '0')}-${String(month).padStart(2, '0')}-${String(day).padStart(
+    2,
+    '0',
+  )}`;
+}
+
+const thaiDateFormatter = new Intl.DateTimeFormat('th-TH-u-ca-buddhist', {
+  timeZone: BANGKOK_TIME_ZONE,
+  dateStyle: 'long',
+});
+
+const thaiDateTimeFormatter = new Intl.DateTimeFormat('th-TH-u-ca-buddhist', {
+  timeZone: BANGKOK_TIME_ZONE,
+  dateStyle: 'long',
+  timeStyle: 'short',
+});
+
+/** Thai display date in the Buddhist calendar, e.g. for a receipt. */
+export function formatThaiDate(instant: Date): string {
+  return thaiDateFormatter.format(instant);
+}
+
+/** Thai display date and time in the Buddhist calendar. */
+export function formatThaiDateTime(instant: Date): string {
+  return thaiDateTimeFormatter.format(instant);
+}

--- a/src/worker/services/audit.ts
+++ b/src/worker/services/audit.ts
@@ -1,4 +1,4 @@
-import type { ActorType, EventMetadata, Repository } from '../db';
+import type { ActorType, ApplicationEventInput, EventMetadata, Repository } from '../db';
 
 /**
  * Audit trail.
@@ -71,27 +71,34 @@ export interface AuditLog {
   recordOnce(input: AuditEventInput): Promise<boolean>;
 }
 
-export function createAuditLog(db: Repository): AuditLog {
+/** Shape accepted by the repository, with metadata already sanitised. */
+export function toEventInput(input: AuditEventInput): ApplicationEventInput {
+  const metadata = sanitizeAuditMetadata(input.metadata);
   return {
-    async record(input) {
-      const metadata = sanitizeAuditMetadata(input.metadata);
-      await db.events.append({
-        applicationId: input.applicationId,
-        eventType: input.eventType,
-        actorType: input.actorType,
-        actorId: input.actorId ?? null,
-        ...(metadata ? { metadata } : {}),
-      });
-    },
-
-    async recordOnce(input) {
-      // Not atomic on its own; callers that must be exactly-once pair this with
-      // a compare-and-set on the row the event describes.
-      if (await db.events.existsForApplication(input.applicationId, input.eventType)) {
-        return false;
-      }
-      await this.record(input);
-      return true;
-    },
+    applicationId: input.applicationId,
+    eventType: input.eventType,
+    actorType: input.actorType,
+    actorId: input.actorId ?? null,
+    ...(metadata ? { metadata } : {}),
   };
+}
+
+export function createAuditLog(db: Repository): AuditLog {
+  // Standalone functions rather than methods that reach for `this`, so a
+  // destructured `const { recordOnce } = audit` keeps working.
+  const record = async (input: AuditEventInput): Promise<void> => {
+    await db.events.append(toEventInput(input));
+  };
+
+  const recordOnce = async (input: AuditEventInput): Promise<boolean> => {
+    // Not atomic on its own; callers that must be exactly-once pair this with
+    // a compare-and-set on the row the event describes.
+    if (await db.events.existsForApplication(input.applicationId, input.eventType)) {
+      return false;
+    }
+    await record(input);
+    return true;
+  };
+
+  return { record, recordOnce };
 }

--- a/src/worker/services/audit.ts
+++ b/src/worker/services/audit.ts
@@ -1,0 +1,97 @@
+import type { ActorType, EventMetadata, Repository } from '../db';
+
+/**
+ * Audit trail.
+ *
+ * `application_events` is the record of what happened to an application
+ * (Issue #1 sections 49-50). It is written on every state change and by every
+ * service that performs a meaningful action.
+ *
+ * Metadata uses the same defence as the logger: an allowlist of keys, primitive
+ * values only. `EventMetadata` already restricts value types at compile time,
+ * but the allowlist is what stops a future caller from appending a name, an
+ * address, a citizen ID or an email address to the audit trail - which would
+ * turn the trail itself into a store of personal data.
+ */
+
+const ALLOWED_METADATA_KEYS = [
+  'from',
+  'to',
+  'source',
+  'membershipType',
+  'amountSatang',
+  'referenceNo',
+  'receiptNo',
+  'emailType',
+  'provider',
+  'providerStatus',
+  'reason',
+  'attempt',
+  'count',
+] as const;
+
+export type AuditMetadataKey = (typeof ALLOWED_METADATA_KEYS)[number];
+
+const ALLOWED_METADATA_KEY_SET: ReadonlySet<string> = new Set(ALLOWED_METADATA_KEYS);
+
+/** Longest value accepted for a metadata string, to bound row growth. */
+const MAX_METADATA_STRING_LENGTH = 64;
+
+export function sanitizeAuditMetadata(
+  metadata: EventMetadata | undefined,
+): EventMetadata | undefined {
+  if (metadata === undefined) return undefined;
+
+  const result: EventMetadata = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    if (!ALLOWED_METADATA_KEY_SET.has(key)) continue;
+    if (typeof value === 'string') {
+      if (value.length > MAX_METADATA_STRING_LENGTH) continue;
+      result[key] = value;
+    } else if (typeof value === 'number' || typeof value === 'boolean') {
+      result[key] = value;
+    }
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+export interface AuditEventInput {
+  applicationId: string;
+  eventType: string;
+  actorType: ActorType;
+  /** Manager identity for admin actions; never an applicant's personal data. */
+  actorId?: string | null;
+  metadata?: Partial<Record<AuditMetadataKey, string | number | boolean>>;
+}
+
+export interface AuditLog {
+  record(input: AuditEventInput): Promise<void>;
+  /** Appends `eventType` only if the application has no such event yet. */
+  recordOnce(input: AuditEventInput): Promise<boolean>;
+}
+
+export function createAuditLog(db: Repository): AuditLog {
+  return {
+    async record(input) {
+      const metadata = sanitizeAuditMetadata(input.metadata);
+      await db.events.append({
+        applicationId: input.applicationId,
+        eventType: input.eventType,
+        actorType: input.actorType,
+        actorId: input.actorId ?? null,
+        ...(metadata ? { metadata } : {}),
+      });
+    },
+
+    async recordOnce(input) {
+      // Not atomic on its own; callers that must be exactly-once pair this with
+      // a compare-and-set on the row the event describes.
+      if (await db.events.existsForApplication(input.applicationId, input.eventType)) {
+        return false;
+      }
+      await this.record(input);
+      return true;
+    },
+  };
+}

--- a/src/worker/services/index.ts
+++ b/src/worker/services/index.ts
@@ -1,0 +1,3 @@
+export * from './audit';
+export * from './numbering';
+export * from './state-machine';

--- a/src/worker/services/numbering.ts
+++ b/src/worker/services/numbering.ts
@@ -1,0 +1,178 @@
+import { UniqueConstraintError } from '../db';
+import type { Repository } from '../db';
+import { bangkokBuddhistYear } from '../lib/time';
+
+/**
+ * Application and receipt numbering (Issue #1 sections 24, 29, 70).
+ *
+ * Numbers look like `VRA-2569-000001` and `VRA-RC-2569-000091`: a configurable
+ * prefix, the Buddhist-era year derived from Bangkok local time, and a running
+ * sequence that restarts each year.
+ *
+ * Uniqueness is a database guarantee, not an application one. The sequence is
+ * proposed by reading the highest number already issued for the year, and the
+ * `UNIQUE` constraint decides whether the proposal wins. A loser retries with
+ * the next value. Reading a maximum and adding one without that guard is the
+ * classic way to hand two applicants the same receipt number.
+ */
+
+export interface NumberFormat {
+  /** Uppercase letters, digits and hyphens only. */
+  prefix: string;
+  /** Zero-padded width of the running sequence. */
+  sequenceLength: number;
+}
+
+export const DEFAULT_APPLICATION_FORMAT: NumberFormat = { prefix: 'VRA', sequenceLength: 6 };
+export const DEFAULT_RECEIPT_FORMAT: NumberFormat = { prefix: 'VRA-RC', sequenceLength: 6 };
+
+/** Attempts before giving up, so a pathological race cannot spin forever. */
+const MAX_ATTEMPTS = 10;
+
+const PREFIX_PATTERN = /^[A-Z][A-Z0-9-]*$/;
+
+export class NumberingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'NumberingError';
+  }
+}
+
+function assertValidFormat(format: NumberFormat): void {
+  // The prefix reaches SQL as part of a bound `like` pattern, so `%` and `_`
+  // must be impossible. Restricting the character set is the guard.
+  if (!PREFIX_PATTERN.test(format.prefix)) {
+    throw new NumberingError('Number prefix must contain only A-Z, 0-9 and hyphens');
+  }
+  if (!Number.isInteger(format.sequenceLength) || format.sequenceLength < 1) {
+    throw new NumberingError('Number sequence length must be a positive integer');
+  }
+}
+
+export function formatNumber(format: NumberFormat, year: number, sequence: number): string {
+  return `${format.prefix}-${year}-${String(sequence).padStart(format.sequenceLength, '0')}`;
+}
+
+/** `VRA-2569-%`, used to find the highest number issued for a year. */
+function yearPattern(format: NumberFormat, year: number): string {
+  return `${format.prefix}-${year}-%`;
+}
+
+/**
+ * Reads the sequence out of a number. Returns 0 when the value does not match
+ * the current format, so a stored number from an older format cannot make the
+ * next sequence go backwards or produce `NaN`.
+ */
+export function parseSequence(format: NumberFormat, value: string | null, year: number): number {
+  if (value === null) return 0;
+  const expectedStart = `${format.prefix}-${year}-`;
+  if (!value.startsWith(expectedStart)) return 0;
+  const sequence = Number(value.slice(expectedStart.length));
+  return Number.isInteger(sequence) && sequence > 0 ? sequence : 0;
+}
+
+export interface NumberingOptions {
+  applicationFormat?: NumberFormat;
+  receiptFormat?: NumberFormat;
+  now?: () => Date;
+}
+
+export interface NumberingService {
+  /**
+   * Assigns the application number and returns it. Returns the existing number
+   * unchanged when the application already has one, so a retried request cannot
+   * issue a second number for the same application.
+   */
+  assignApplicationNumber(applicationId: string): Promise<string>;
+  /**
+   * Runs `insert` with successive candidate receipt numbers until it succeeds.
+   * `insert` must be a single atomic write, because a candidate that loses the
+   * race must leave nothing behind.
+   */
+  issueReceiptNumber<T>(insert: (receiptNo: string) => Promise<T>): Promise<T>;
+}
+
+export function createNumberingService(
+  db: Repository,
+  options: NumberingOptions = {},
+): NumberingService {
+  const applicationFormat = options.applicationFormat ?? DEFAULT_APPLICATION_FORMAT;
+  const receiptFormat = options.receiptFormat ?? DEFAULT_RECEIPT_FORMAT;
+  const now = options.now ?? (() => new Date());
+
+  assertValidFormat(applicationFormat);
+  assertValidFormat(receiptFormat);
+
+  return {
+    async assignApplicationNumber(applicationId) {
+      const existing = await db.applications.findById(applicationId);
+      if (!existing) {
+        throw new NumberingError('Application does not exist');
+      }
+      if (existing.referenceNo !== null) {
+        return existing.referenceNo;
+      }
+
+      const year = bangkokBuddhistYear(now());
+
+      for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+        // Always the highest issued number plus one, re-read on every attempt.
+        // Offsetting by the attempt counter instead would avoid a second
+        // collision but leave gaps in the sequence, and a missing number in a
+        // run of receipts is the kind of thing an auditor asks about.
+        const highest = await db.applications.findMaxReferenceNo(
+          yearPattern(applicationFormat, year),
+        );
+        const candidate = formatNumber(
+          applicationFormat,
+          year,
+          parseSequence(applicationFormat, highest, year) + 1,
+        );
+
+        try {
+          await db.applications.setReferenceNo(applicationId, candidate);
+          return candidate;
+        } catch (error) {
+          if (!(error instanceof UniqueConstraintError)) throw error;
+
+          // Either the candidate was taken by a concurrent request, or this
+          // application was given a number in the meantime. Re-read to tell the
+          // two apart: issuing a second number to one application would put two
+          // different references on documents the applicant has already seen.
+          const current = await db.applications.findById(applicationId);
+          if (current?.referenceNo) {
+            return current.referenceNo;
+          }
+        }
+      }
+
+      throw new NumberingError('Could not allocate an application number');
+    },
+
+    async issueReceiptNumber(insert) {
+      const year = bangkokBuddhistYear(now());
+
+      for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+        // See `assignApplicationNumber`: always highest + 1, so the receipt
+        // sequence has no gaps.
+        const highest = await db.receipts.findMaxReceiptNo(yearPattern(receiptFormat, year));
+        const candidate = formatNumber(
+          receiptFormat,
+          year,
+          parseSequence(receiptFormat, highest, year) + 1,
+        );
+
+        try {
+          return await insert(candidate);
+        } catch (error) {
+          if (!(error instanceof UniqueConstraintError)) throw error;
+          // A constraint other than the receipt number means retrying with a
+          // new number will fail the same way, so stop instead of looping.
+          if (!error.constraintName.includes('receipt_no')) throw error;
+        }
+      }
+
+      throw new NumberingError('Could not allocate a receipt number');
+    },
+  };
+}

--- a/src/worker/services/state-machine.ts
+++ b/src/worker/services/state-machine.ts
@@ -1,0 +1,179 @@
+import type { ApplicationStatus, Repository } from '../db';
+import type { AuditLog } from './audit';
+
+/**
+ * Application state machine (Issue #1 section 41).
+ *
+ * Three properties matter here and each is enforced rather than assumed:
+ *
+ * 1. **Validated** - a transition that is not in the table below is refused, so
+ *    no code path can move an application from, say, `DRAFT` straight to
+ *    `COMPLETED`.
+ * 2. **Idempotent** - asking for a status the application already has is a
+ *    no-op that records nothing. Resend can deliver the same webhook ten times
+ *    and the manager can double-click a button; neither may produce a second
+ *    audit event or a second email.
+ * 3. **Concurrency-safe** - the write is a compare-and-set against the current
+ *    status, so of two simultaneous requests exactly one applies the change.
+ *    D1 has no interactive transaction to lean on.
+ */
+
+/**
+ * Allowed target statuses for each status.
+ *
+ * The happy path follows Issue #1 section 41. Exception statuses are reachable
+ * from the points where the corresponding real-world problem can be discovered:
+ * a payment can only need a refund once money has been taken, and an
+ * application can only be cancelled before that.
+ */
+const ALLOWED_TRANSITIONS: Readonly<Record<ApplicationStatus, readonly ApplicationStatus[]>> = {
+  DRAFT: ['AWAITING_PAYMENT', 'CANCELLED'],
+  AWAITING_PAYMENT: ['PAYMENT_VERIFIED', 'CANCELLED', 'REJECTED'],
+  PAYMENT_VERIFIED: ['SUBMITTED', 'REJECTED', 'REFUND_REQUIRED'],
+  SUBMITTED: ['MANAGER_NOTIFIED', 'REJECTED', 'REFUND_REQUIRED'],
+  MANAGER_NOTIFIED: ['NBTC_PROCESSING', 'REJECTED', 'REFUND_REQUIRED'],
+  NBTC_PROCESSING: ['NBTC_RECORDED', 'REJECTED', 'REFUND_REQUIRED'],
+  NBTC_RECORDED: ['COMPLETED'],
+  COMPLETED: [],
+  REJECTED: ['REFUND_REQUIRED'],
+  CANCELLED: [],
+  REFUND_REQUIRED: ['REFUNDED'],
+  REFUNDED: [],
+};
+
+/** Statuses from which no further transition is possible. */
+export const TERMINAL_STATUSES: readonly ApplicationStatus[] = Object.entries(ALLOWED_TRANSITIONS)
+  .filter(([, targets]) => targets.length === 0)
+  .map(([status]) => status as ApplicationStatus);
+
+export function allowedTargets(from: ApplicationStatus): readonly ApplicationStatus[] {
+  return ALLOWED_TRANSITIONS[from];
+}
+
+export function isTransitionAllowed(from: ApplicationStatus, to: ApplicationStatus): boolean {
+  return ALLOWED_TRANSITIONS[from].includes(to);
+}
+
+/** Statuses that may legally precede `to`. */
+export function predecessorsOf(to: ApplicationStatus): readonly ApplicationStatus[] {
+  return (Object.keys(ALLOWED_TRANSITIONS) as ApplicationStatus[]).filter((from) =>
+    ALLOWED_TRANSITIONS[from].includes(to),
+  );
+}
+
+export const STATUS_CHANGED_EVENT = 'STATUS_CHANGED';
+
+export type TransitionOutcome =
+  | { kind: 'APPLIED'; from: ApplicationStatus; to: ApplicationStatus }
+  /** The application already had the target status; nothing was written. */
+  | { kind: 'ALREADY_IN_TARGET_STATE'; status: ApplicationStatus }
+  | { kind: 'NOT_ALLOWED'; from: ApplicationStatus; to: ApplicationStatus }
+  /**
+   * Another request kept moving the row to a status from which the requested
+   * transition is still legal, for more attempts than this service will make.
+   * The caller may retry; nothing was written.
+   */
+  | { kind: 'CONCURRENTLY_MODIFIED'; status: ApplicationStatus; to: ApplicationStatus }
+  | { kind: 'NOT_FOUND' };
+
+/** Attempts before giving up and reporting `CONCURRENTLY_MODIFIED`. */
+const MAX_ATTEMPTS = 3;
+
+export interface TransitionOptions {
+  /** Who caused the change. Defaults to the system. */
+  actorType?: 'APPLICANT' | 'MANAGER' | 'SYSTEM' | 'PROVIDER';
+  /** Manager identity for admin actions. */
+  actorId?: string | null;
+  /** Timestamps that belong to this transition. */
+  timestamps?: {
+    submittedAt?: string;
+    managerAcknowledgedAt?: string;
+    nbtcRecordedAt?: string;
+    nbtcRecordedBy?: string;
+  };
+  /**
+   * Domain event recorded alongside `STATUS_CHANGED`, e.g. `PAYMENT_VERIFIED`.
+   * Recorded only when the transition actually applies.
+   */
+  domainEvent?: string;
+}
+
+export interface StateMachine {
+  transition(
+    applicationId: string,
+    to: ApplicationStatus,
+    options?: TransitionOptions,
+  ): Promise<TransitionOutcome>;
+}
+
+export function createStateMachine(db: Repository, audit: AuditLog): StateMachine {
+  return {
+    async transition(applicationId, to, options = {}) {
+      for (let attempt = 1; ; attempt += 1) {
+        const application = await db.applications.findById(applicationId);
+        if (!application) {
+          return { kind: 'NOT_FOUND' };
+        }
+
+        const from = application.status;
+
+        if (from === to) {
+          return { kind: 'ALREADY_IN_TARGET_STATE', status: to };
+        }
+
+        if (!isTransitionAllowed(from, to)) {
+          return { kind: 'NOT_ALLOWED', from, to };
+        }
+
+        // Compare-and-set against the exact status that was read, not against
+        // every legal predecessor. Guarding on the wider set would let the write
+        // succeed after a concurrent request had already moved the row, and the
+        // audit event would then record a `from` that was never true.
+        const applied = await db.applications.updateStatusIf(
+          applicationId,
+          [from],
+          to,
+          options.timestamps ?? {},
+        );
+
+        if (!applied) {
+          // Another request won the race. Decide from fresh state rather than
+          // guessing, and retry while the requested transition is still legal.
+          if (attempt < MAX_ATTEMPTS) continue;
+
+          const current = await db.applications.findById(applicationId);
+          if (!current) return { kind: 'NOT_FOUND' };
+          if (current.status === to) {
+            return { kind: 'ALREADY_IN_TARGET_STATE', status: to };
+          }
+          if (isTransitionAllowed(current.status, to)) {
+            return { kind: 'CONCURRENTLY_MODIFIED', status: current.status, to };
+          }
+          return { kind: 'NOT_ALLOWED', from: current.status, to };
+        }
+
+        const actorType = options.actorType ?? 'SYSTEM';
+        const actorId = options.actorId ?? null;
+
+        if (options.domainEvent) {
+          await audit.record({
+            applicationId,
+            eventType: options.domainEvent,
+            actorType,
+            actorId,
+          });
+        }
+
+        await audit.record({
+          applicationId,
+          eventType: STATUS_CHANGED_EVENT,
+          actorType,
+          actorId,
+          metadata: { from, to },
+        });
+
+        return { kind: 'APPLIED', from, to };
+      }
+    },
+  };
+}

--- a/src/worker/services/state-machine.ts
+++ b/src/worker/services/state-machine.ts
@@ -1,5 +1,5 @@
 import type { ApplicationStatus, Repository } from '../db';
-import type { AuditLog } from './audit';
+import { toEventInput } from './audit';
 
 /**
  * Application state machine (Issue #1 section 41).
@@ -106,7 +106,7 @@ export interface StateMachine {
   ): Promise<TransitionOutcome>;
 }
 
-export function createStateMachine(db: Repository, audit: AuditLog): StateMachine {
+export function createStateMachine(db: Repository): StateMachine {
   return {
     async transition(applicationId, to, options = {}) {
       for (let attempt = 1; ; attempt += 1) {
@@ -125,16 +125,38 @@ export function createStateMachine(db: Repository, audit: AuditLog): StateMachin
           return { kind: 'NOT_ALLOWED', from, to };
         }
 
+        const actorType = options.actorType ?? 'SYSTEM';
+        const actorId = options.actorId ?? null;
+
+        // The domain event comes first so the trail reads in causal order:
+        // PAYMENT_VERIFIED, then STATUS_CHANGED.
+        const events = [
+          ...(options.domainEvent
+            ? [toEventInput({ applicationId, eventType: options.domainEvent, actorType, actorId })]
+            : []),
+          toEventInput({
+            applicationId,
+            eventType: STATUS_CHANGED_EVENT,
+            actorType,
+            actorId,
+            metadata: { from, to },
+          }),
+        ];
+
         // Compare-and-set against the exact status that was read, not against
         // every legal predecessor. Guarding on the wider set would let the write
         // succeed after a concurrent request had already moved the row, and the
         // audit event would then record a `from` that was never true.
-        const applied = await db.applications.updateStatusIf(
-          applicationId,
-          [from],
+        //
+        // Status and events go in one transaction, so a transition can never
+        // exist without its trail.
+        const applied = await db.applications.transitionStatus({
+          id: applicationId,
+          from,
           to,
-          options.timestamps ?? {},
-        );
+          timestamps: options.timestamps ?? {},
+          events,
+        });
 
         if (!applied) {
           // Another request won the race. Decide from fresh state rather than
@@ -151,26 +173,6 @@ export function createStateMachine(db: Repository, audit: AuditLog): StateMachin
           }
           return { kind: 'NOT_ALLOWED', from: current.status, to };
         }
-
-        const actorType = options.actorType ?? 'SYSTEM';
-        const actorId = options.actorId ?? null;
-
-        if (options.domainEvent) {
-          await audit.record({
-            applicationId,
-            eventType: options.domainEvent,
-            actorType,
-            actorId,
-          });
-        }
-
-        await audit.record({
-          applicationId,
-          eventType: STATUS_CHANGED_EVENT,
-          actorType,
-          actorId,
-          metadata: { from, to },
-        });
 
         return { kind: 'APPLIED', from, to };
       }

--- a/tests/unit/audit-metadata.test.ts
+++ b/tests/unit/audit-metadata.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeAuditMetadata } from '../../src/worker/services/audit';
+
+/**
+ * The audit trail must not become a second store of personal data
+ * (Issue #1 section 49). The allowlist below is the enforcement point, so these
+ * cases assert on the fields that would actually be tempting to attach.
+ */
+describe('sanitizeAuditMetadata', () => {
+  it('keeps allowlisted keys', () => {
+    expect(
+      sanitizeAuditMetadata({
+        from: 'SUBMITTED',
+        to: 'NBTC_PROCESSING',
+        amountSatang: 50_000,
+        receiptNo: 'VRA-RC-2569-000001',
+      }),
+    ).toEqual({
+      from: 'SUBMITTED',
+      to: 'NBTC_PROCESSING',
+      amountSatang: 50_000,
+      receiptNo: 'VRA-RC-2569-000001',
+    });
+  });
+
+  it('drops personal data even when the value is a primitive', () => {
+    const sanitized = sanitizeAuditMetadata({
+      to: 'SUBMITTED',
+      ...({
+        citizenId: '1234567890121',
+        firstName: 'redacted',
+        lastName: 'redacted',
+        address: 'redacted',
+        email: 'member@example.test',
+        phone: '0800000000',
+        callsign: 'HS0TEST',
+        photoKey: 'member-photos/abc.jpg',
+      } as Record<string, string>),
+    });
+
+    expect(sanitized).toEqual({ to: 'SUBMITTED' });
+  });
+
+  it('drops values that are not primitives', () => {
+    const sanitized = sanitizeAuditMetadata({
+      from: 'DRAFT',
+      ...({ reason: { providerResponse: 'anything' } } as unknown as { reason: string }),
+    });
+
+    expect(sanitized).toEqual({ from: 'DRAFT' });
+  });
+
+  it('drops an allowlisted string that is long enough to be a payload', () => {
+    const sanitized = sanitizeAuditMetadata({ reason: 'x'.repeat(65), to: 'REJECTED' });
+
+    expect(sanitized).toEqual({ to: 'REJECTED' });
+  });
+
+  it('keeps an allowlisted string at the length limit', () => {
+    const sanitized = sanitizeAuditMetadata({ reason: 'x'.repeat(64) });
+
+    expect(sanitized).toEqual({ reason: 'x'.repeat(64) });
+  });
+
+  it('returns undefined rather than an empty object when nothing survives', () => {
+    expect(
+      sanitizeAuditMetadata({ ...({ citizenId: '1234567890121' } as Record<string, string>) }),
+    ).toBeUndefined();
+  });
+
+  it('passes undefined through', () => {
+    expect(sanitizeAuditMetadata(undefined)).toBeUndefined();
+  });
+});

--- a/tests/unit/time.test.ts
+++ b/tests/unit/time.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import {
+  bangkokBuddhistYear,
+  bangkokIsoDate,
+  formatThaiDate,
+  formatThaiDateTime,
+  toBangkokParts,
+} from '../../src/worker/lib/time';
+
+/** Bangkok is UTC+7 with no daylight saving, which every case below relies on. */
+
+describe('toBangkokParts', () => {
+  it('shifts an instant into Bangkok local time', () => {
+    expect(toBangkokParts(new Date('2026-08-20T03:04:05.000Z'))).toEqual({
+      year: 2026,
+      month: 8,
+      day: 20,
+      hour: 10,
+      minute: 4,
+      second: 5,
+    });
+  });
+
+  it('renders Bangkok midnight as hour 0, not hour 24', () => {
+    expect(toBangkokParts(new Date('2026-08-19T17:00:00.000Z'))).toMatchObject({
+      day: 20,
+      hour: 0,
+    });
+  });
+
+  it('rolls the day over for a late-evening UTC instant', () => {
+    expect(toBangkokParts(new Date('2026-08-20T23:30:00.000Z'))).toMatchObject({
+      month: 8,
+      day: 21,
+      hour: 6,
+    });
+  });
+});
+
+describe('bangkokIsoDate', () => {
+  it('uses the Bangkok calendar day, not the UTC one', () => {
+    expect(bangkokIsoDate(new Date('2026-08-20T23:30:00.000Z'))).toBe('2026-08-21');
+    expect(bangkokIsoDate(new Date('2026-08-20T10:00:00.000Z'))).toBe('2026-08-20');
+  });
+});
+
+describe('bangkokBuddhistYear', () => {
+  it('adds 543 to the Gregorian year', () => {
+    expect(bangkokBuddhistYear(new Date('2026-08-20T03:00:00.000Z'))).toBe(2569);
+  });
+
+  it('is still the old year one second before Bangkok new year', () => {
+    // 2026-12-31T16:59:59Z is 2026-12-31T23:59:59 in Bangkok.
+    expect(bangkokBuddhistYear(new Date('2026-12-31T16:59:59.000Z'))).toBe(2569);
+  });
+
+  it('rolls over at Bangkok midnight, not at UTC midnight', () => {
+    // 2026-12-31T17:00:00Z is 2027-01-01T00:00:00 in Bangkok. A number issued at
+    // this instant belongs to 2570, even though the UTC year is still 2026.
+    expect(bangkokBuddhistYear(new Date('2026-12-31T17:00:00.000Z'))).toBe(2570);
+  });
+
+  it('has not rolled over yet at UTC midnight on 1 January', () => {
+    // Already 07:00 in Bangkok on 1 January, so the same year as the line above.
+    expect(bangkokBuddhistYear(new Date('2027-01-01T00:00:00.000Z'))).toBe(2570);
+  });
+
+  it('is never hard-coded to a single year', () => {
+    expect(bangkokBuddhistYear(new Date('2030-06-01T00:00:00.000Z'))).toBe(2573);
+    expect(bangkokBuddhistYear(new Date('2019-06-01T00:00:00.000Z'))).toBe(2562);
+  });
+});
+
+describe('Thai display formatting', () => {
+  it('renders the date in the Buddhist calendar', () => {
+    const formatted = formatThaiDate(new Date('2026-08-20T03:00:00.000Z'));
+
+    expect(formatted).toContain('2569');
+    expect(formatted).not.toContain('2026');
+  });
+
+  it('renders date and time together in the Buddhist calendar', () => {
+    const formatted = formatThaiDateTime(new Date('2026-08-20T03:04:00.000Z'));
+
+    expect(formatted).toContain('2569');
+    // 03:04 UTC is 10:04 in Bangkok.
+    expect(formatted).toContain('10:04');
+  });
+});

--- a/tests/worker/numbering.test.ts
+++ b/tests/worker/numbering.test.ts
@@ -1,0 +1,367 @@
+import { describe, expect, it } from 'vitest';
+import { UniqueConstraintError } from '../../src/worker/db';
+import type { PaymentInput, Repository } from '../../src/worker/db';
+import {
+  createNumberingService,
+  DEFAULT_APPLICATION_FORMAT,
+  DEFAULT_RECEIPT_FORMAT,
+  formatNumber,
+  NumberingError,
+  parseSequence,
+} from '../../src/worker/services/numbering';
+import {
+  ANNUAL_SATANG,
+  OTHER_TEST_CITIZEN_ID,
+  repository,
+  seedApplication,
+  TEST_CITIZEN_ID,
+} from '../support/fixtures';
+
+/** 2026-08-20 in Bangkok, which is Buddhist year 2569. */
+const IN_2569 = new Date('2026-08-20T03:00:00.000Z');
+/** 2027-01-01T00:00 Bangkok, one second into Buddhist year 2570. */
+const IN_2570 = new Date('2026-12-31T17:00:00.000Z');
+
+function numbering(repo: Repository, now: () => Date = () => IN_2569) {
+  return createNumberingService(repo, { now });
+}
+
+function paymentInput(applicationId: string): PaymentInput {
+  return {
+    applicationId,
+    provider: 'slipok',
+    transactionRef: `REF-${crypto.randomUUID()}`,
+    amountSatang: ANNUAL_SATANG,
+    sendingBank: null,
+    receivingBank: null,
+    receiverAccountTail: null,
+    transactionAt: null,
+    receiverMatched: true,
+    amountMatched: true,
+    verificationStatus: 'VERIFIED',
+    verifiedAt: null,
+  };
+}
+
+describe('formatNumber', () => {
+  it('produces the documented application format', () => {
+    expect(formatNumber(DEFAULT_APPLICATION_FORMAT, 2569, 1)).toBe('VRA-2569-000001');
+  });
+
+  it('produces the documented receipt format', () => {
+    expect(formatNumber(DEFAULT_RECEIPT_FORMAT, 2569, 91)).toBe('VRA-RC-2569-000091');
+  });
+
+  it('pads to the configured width', () => {
+    expect(formatNumber({ prefix: 'VRA', sequenceLength: 4 }, 2569, 7)).toBe('VRA-2569-0007');
+  });
+
+  it('does not truncate a sequence longer than the padding', () => {
+    expect(formatNumber(DEFAULT_APPLICATION_FORMAT, 2569, 1_234_567)).toBe('VRA-2569-1234567');
+  });
+});
+
+describe('parseSequence', () => {
+  it('reads the sequence back', () => {
+    expect(parseSequence(DEFAULT_APPLICATION_FORMAT, 'VRA-2569-000042', 2569)).toBe(42);
+  });
+
+  it('returns 0 for a number from a different year', () => {
+    expect(parseSequence(DEFAULT_APPLICATION_FORMAT, 'VRA-2568-000042', 2569)).toBe(0);
+  });
+
+  it('returns 0 for a number from a different prefix', () => {
+    expect(parseSequence(DEFAULT_APPLICATION_FORMAT, 'VRA-RC-2569-000042', 2569)).toBe(0);
+  });
+
+  it('returns 0 rather than NaN for a malformed value', () => {
+    expect(parseSequence(DEFAULT_APPLICATION_FORMAT, 'VRA-2569-abcdef', 2569)).toBe(0);
+    expect(parseSequence(DEFAULT_APPLICATION_FORMAT, null, 2569)).toBe(0);
+  });
+});
+
+describe('format validation', () => {
+  it('rejects a prefix containing a like wildcard', () => {
+    const repo = repository();
+
+    // A `%` would make the year pattern match every number ever issued.
+    expect(() =>
+      createNumberingService(repo, { applicationFormat: { prefix: 'VRA%', sequenceLength: 6 } }),
+    ).toThrow(NumberingError);
+    expect(() =>
+      createNumberingService(repo, { applicationFormat: { prefix: 'VRA_', sequenceLength: 6 } }),
+    ).toThrow(NumberingError);
+  });
+
+  it('rejects a lowercase or empty prefix', () => {
+    const repo = repository();
+
+    expect(() =>
+      createNumberingService(repo, { applicationFormat: { prefix: 'vra', sequenceLength: 6 } }),
+    ).toThrow(NumberingError);
+    expect(() =>
+      createNumberingService(repo, { applicationFormat: { prefix: '', sequenceLength: 6 } }),
+    ).toThrow(NumberingError);
+  });
+
+  it('rejects a non-positive sequence length', () => {
+    const repo = repository();
+
+    expect(() =>
+      createNumberingService(repo, { receiptFormat: { prefix: 'VRA-RC', sequenceLength: 0 } }),
+    ).toThrow(NumberingError);
+  });
+});
+
+describe('application numbers', () => {
+  it('issues the first number of the year', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+
+    await expect(numbering(repo).assignApplicationNumber(id)).resolves.toBe('VRA-2569-000001');
+  });
+
+  it('increments for each application', async () => {
+    const repo = repository();
+    const service = numbering(repo);
+    const first = await seedApplication(repo, TEST_CITIZEN_ID);
+    const second = await seedApplication(repo, OTHER_TEST_CITIZEN_ID);
+
+    await expect(service.assignApplicationNumber(first)).resolves.toBe('VRA-2569-000001');
+    await expect(service.assignApplicationNumber(second)).resolves.toBe('VRA-2569-000002');
+  });
+
+  it('returns the existing number instead of issuing a second one', async () => {
+    const repo = repository();
+    const service = numbering(repo);
+    const id = await seedApplication(repo);
+
+    const first = await service.assignApplicationNumber(id);
+    const second = await service.assignApplicationNumber(id);
+
+    expect(second).toBe(first);
+  });
+
+  it('restarts the sequence in a new Buddhist year', async () => {
+    const repo = repository();
+    let now = IN_2569;
+    const service = numbering(repo, () => now);
+
+    const inOldYear = await seedApplication(repo, TEST_CITIZEN_ID);
+    await expect(service.assignApplicationNumber(inOldYear)).resolves.toBe('VRA-2569-000001');
+
+    now = IN_2570;
+    const inNewYear = await seedApplication(repo, OTHER_TEST_CITIZEN_ID);
+    await expect(service.assignApplicationNumber(inNewYear)).resolves.toBe('VRA-2570-000001');
+  });
+
+  it('keeps counting within the year after a rollover', async () => {
+    const repo = repository();
+    let now = IN_2570;
+    const service = numbering(repo, () => now);
+
+    const first = await seedApplication(repo, TEST_CITIZEN_ID);
+    await service.assignApplicationNumber(first);
+
+    now = new Date('2027-06-01T03:00:00.000Z');
+    const second = await seedApplication(repo, OTHER_TEST_CITIZEN_ID);
+    await expect(service.assignApplicationNumber(second)).resolves.toBe('VRA-2570-000002');
+  });
+
+  it('gives concurrent applications distinct numbers', async () => {
+    const repo = repository();
+    const service = numbering(repo);
+    const ids = await Promise.all([
+      seedApplication(repo, TEST_CITIZEN_ID),
+      seedApplication(repo, OTHER_TEST_CITIZEN_ID),
+      seedApplication(repo, '1234567890147'),
+      seedApplication(repo, '1234567890154'),
+      seedApplication(repo, '1234567890162'),
+    ]);
+
+    const numbers = await Promise.all(ids.map((id) => service.assignApplicationNumber(id)));
+
+    expect(new Set(numbers).size).toBe(ids.length);
+    expect([...numbers].sort()).toEqual([
+      'VRA-2569-000001',
+      'VRA-2569-000002',
+      'VRA-2569-000003',
+      'VRA-2569-000004',
+      'VRA-2569-000005',
+    ]);
+  });
+
+  it('gives one number to an application asked for concurrently', async () => {
+    const repo = repository();
+    const service = numbering(repo);
+    const id = await seedApplication(repo);
+
+    const numbers = await Promise.all(
+      Array.from({ length: 5 }, () => service.assignApplicationNumber(id)),
+    );
+
+    expect(new Set(numbers).size).toBe(1);
+  });
+
+  it('fails clearly for an application that does not exist', async () => {
+    const repo = repository();
+
+    await expect(numbering(repo).assignApplicationNumber(crypto.randomUUID())).rejects.toThrow(
+      NumberingError,
+    );
+  });
+
+  it('ignores numbers stored in an older format when picking the next one', async () => {
+    const repo = repository();
+    const service = numbering(repo);
+    const legacy = await seedApplication(repo, TEST_CITIZEN_ID);
+    await repo.applications.setReferenceNo(legacy, 'VRA-2569-OLD');
+
+    const next = await seedApplication(repo, OTHER_TEST_CITIZEN_ID);
+
+    await expect(service.assignApplicationNumber(next)).resolves.toBe('VRA-2569-000001');
+  });
+});
+
+describe('receipt numbers', () => {
+  async function seedPayment(repo: Repository, citizenId = TEST_CITIZEN_ID) {
+    const applicationId = await seedApplication(repo, citizenId);
+    const payment = await repo.payments.create(paymentInput(applicationId));
+    return { applicationId, paymentId: payment.id };
+  }
+
+  it('issues the first receipt number of the year', async () => {
+    const repo = repository();
+    const service = numbering(repo);
+    const { applicationId, paymentId } = await seedPayment(repo);
+
+    const receipt = await service.issueReceiptNumber((receiptNo) =>
+      repo.receipts.create({
+        applicationId,
+        paymentId,
+        receiptNo,
+        amountSatang: ANNUAL_SATANG,
+        issuedAt: IN_2569.toISOString(),
+      }),
+    );
+
+    expect(receipt.receiptNo).toBe('VRA-RC-2569-000001');
+  });
+
+  it('increments for each receipt', async () => {
+    const repo = repository();
+    const service = numbering(repo);
+
+    const numbers: string[] = [];
+    for (const citizenId of [TEST_CITIZEN_ID, OTHER_TEST_CITIZEN_ID]) {
+      const { applicationId, paymentId } = await seedPayment(repo, citizenId);
+      const receipt = await service.issueReceiptNumber((receiptNo) =>
+        repo.receipts.create({
+          applicationId,
+          paymentId,
+          receiptNo,
+          amountSatang: ANNUAL_SATANG,
+          issuedAt: IN_2569.toISOString(),
+        }),
+      );
+      numbers.push(receipt.receiptNo);
+    }
+
+    expect(numbers).toEqual(['VRA-RC-2569-000001', 'VRA-RC-2569-000002']);
+  });
+
+  it('gives concurrent receipts distinct numbers', async () => {
+    const repo = repository();
+    const service = numbering(repo);
+    const seeds = [];
+    for (const citizenId of [
+      TEST_CITIZEN_ID,
+      OTHER_TEST_CITIZEN_ID,
+      '1234567890147',
+      '1234567890154',
+    ]) {
+      seeds.push(await seedPayment(repo, citizenId));
+    }
+
+    const receipts = await Promise.all(
+      seeds.map(({ applicationId, paymentId }) =>
+        service.issueReceiptNumber((receiptNo) =>
+          repo.receipts.create({
+            applicationId,
+            paymentId,
+            receiptNo,
+            amountSatang: ANNUAL_SATANG,
+            issuedAt: IN_2569.toISOString(),
+          }),
+        ),
+      ),
+    );
+
+    const numbers = receipts.map((receipt) => receipt.receiptNo);
+    expect(new Set(numbers).size).toBe(numbers.length);
+  });
+
+  it('restarts the receipt sequence in a new Buddhist year', async () => {
+    const repo = repository();
+    let now = IN_2569;
+    const service = numbering(repo, () => now);
+
+    const first = await seedPayment(repo, TEST_CITIZEN_ID);
+    await service.issueReceiptNumber((receiptNo) =>
+      repo.receipts.create({
+        applicationId: first.applicationId,
+        paymentId: first.paymentId,
+        receiptNo,
+        amountSatang: ANNUAL_SATANG,
+        issuedAt: IN_2569.toISOString(),
+      }),
+    );
+
+    now = IN_2570;
+    const second = await seedPayment(repo, OTHER_TEST_CITIZEN_ID);
+    const receipt = await service.issueReceiptNumber((receiptNo) =>
+      repo.receipts.create({
+        applicationId: second.applicationId,
+        paymentId: second.paymentId,
+        receiptNo,
+        amountSatang: ANNUAL_SATANG,
+        issuedAt: IN_2570.toISOString(),
+      }),
+    );
+
+    expect(receipt.receiptNo).toBe('VRA-RC-2570-000001');
+  });
+
+  it('stops instead of looping when a different constraint fails', async () => {
+    const repo = repository();
+    const service = numbering(repo);
+    const { applicationId, paymentId } = await seedPayment(repo);
+
+    const insert = (receiptNo: string) =>
+      repo.receipts.create({
+        applicationId,
+        paymentId,
+        receiptNo,
+        amountSatang: ANNUAL_SATANG,
+        issuedAt: IN_2569.toISOString(),
+      });
+
+    await service.issueReceiptNumber(insert);
+
+    // The second receipt violates the one-receipt-per-application and
+    // one-receipt-per-payment constraints, not receipt_no, so retrying with a
+    // fresh number would fail identically forever.
+    const error = await service.issueReceiptNumber(insert).catch((reason: unknown) => reason);
+    expect(error).toBeInstanceOf(UniqueConstraintError);
+    expect((error as UniqueConstraintError).constraintName).not.toContain('receipt_no');
+  });
+
+  it('propagates an error that is not a constraint violation', async () => {
+    const repo = repository();
+    const service = numbering(repo);
+
+    await expect(
+      service.issueReceiptNumber(() => Promise.reject(new Error('provider exploded'))),
+    ).rejects.toThrow('provider exploded');
+  });
+});

--- a/tests/worker/state-machine.test.ts
+++ b/tests/worker/state-machine.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { APPLICATION_STATUSES } from '../../src/worker/db';
 import type { ApplicationStatus, Repository } from '../../src/worker/db';
-import { createAuditLog } from '../../src/worker/services/audit';
 import {
   allowedTargets,
   createStateMachine,
@@ -12,7 +11,7 @@ import {
 import { repository, seedApplication } from '../support/fixtures';
 
 function machine(repo: Repository) {
-  return createStateMachine(repo, createAuditLog(repo));
+  return createStateMachine(repo);
 }
 
 /** Walks an application to `target` through the legal happy path. */
@@ -306,6 +305,63 @@ describe('audit trail', () => {
     await machine(repo).transition(id, 'COMPLETED');
 
     await expect(repo.events.listByApplicationId(id)).resolves.toEqual([]);
+  });
+
+  it('writes the status and its events in one transaction', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+
+    // Every statement in the batch is guarded on the pre-transition status, so
+    // a compare-and-set that does not apply leaves no event behind. Calling the
+    // repository with a stale `from` simulates losing the race.
+    const applied = await repo.applications.transitionStatus({
+      id,
+      from: 'SUBMITTED',
+      to: 'MANAGER_NOTIFIED',
+      events: [
+        {
+          applicationId: id,
+          eventType: 'STATUS_CHANGED',
+          actorType: 'SYSTEM',
+          metadata: { from: 'SUBMITTED', to: 'MANAGER_NOTIFIED' },
+        },
+      ],
+    });
+
+    expect(applied).toBe(false);
+    await expect(repo.applications.findById(id)).resolves.toMatchObject({ status: 'DRAFT' });
+    await expect(repo.events.listByApplicationId(id)).resolves.toEqual([]);
+  });
+
+  it('refuses a same-status transition at the repository level', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+
+    // A same-status call would satisfy the event guard without changing
+    // anything, which would record a transition that never happened.
+    await expect(
+      repo.applications.transitionStatus({
+        id,
+        from: 'DRAFT',
+        to: 'DRAFT',
+        events: [],
+      }),
+    ).rejects.toThrow(/must change the status/);
+  });
+
+  it('never leaves a status change without its audit event', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+    const stateMachine = machine(repo);
+
+    for (const status of HAPPY_PATH) {
+      await stateMachine.transition(id, status);
+    }
+
+    const changes = (await repo.events.listByApplicationId(id)).filter(
+      (event) => event.eventType === 'STATUS_CHANGED',
+    );
+    expect(changes).toHaveLength(HAPPY_PATH.length);
   });
 });
 

--- a/tests/worker/state-machine.test.ts
+++ b/tests/worker/state-machine.test.ts
@@ -1,0 +1,347 @@
+import { describe, expect, it } from 'vitest';
+import { APPLICATION_STATUSES } from '../../src/worker/db';
+import type { ApplicationStatus, Repository } from '../../src/worker/db';
+import { createAuditLog } from '../../src/worker/services/audit';
+import {
+  allowedTargets,
+  createStateMachine,
+  isTransitionAllowed,
+  predecessorsOf,
+  TERMINAL_STATUSES,
+} from '../../src/worker/services/state-machine';
+import { repository, seedApplication } from '../support/fixtures';
+
+function machine(repo: Repository) {
+  return createStateMachine(repo, createAuditLog(repo));
+}
+
+/** Walks an application to `target` through the legal happy path. */
+const HAPPY_PATH: readonly ApplicationStatus[] = [
+  'AWAITING_PAYMENT',
+  'PAYMENT_VERIFIED',
+  'SUBMITTED',
+  'MANAGER_NOTIFIED',
+  'NBTC_PROCESSING',
+  'NBTC_RECORDED',
+  'COMPLETED',
+];
+
+async function walkTo(
+  repo: Repository,
+  applicationId: string,
+  target: ApplicationStatus,
+): Promise<void> {
+  const stateMachine = machine(repo);
+  for (const status of HAPPY_PATH) {
+    const outcome = await stateMachine.transition(applicationId, status);
+    expect(outcome.kind).toBe('APPLIED');
+    if (status === target) return;
+  }
+  if (target !== 'COMPLETED') {
+    throw new Error(`${target} is not on the happy path`);
+  }
+}
+
+describe('transition table', () => {
+  it('covers every status', () => {
+    for (const status of APPLICATION_STATUSES) {
+      expect(allowedTargets(status)).toBeDefined();
+    }
+  });
+
+  it('matches the flow in Issue #1 section 41', () => {
+    expect(allowedTargets('DRAFT')).toContain('AWAITING_PAYMENT');
+    expect(allowedTargets('AWAITING_PAYMENT')).toContain('PAYMENT_VERIFIED');
+    expect(allowedTargets('PAYMENT_VERIFIED')).toContain('SUBMITTED');
+    expect(allowedTargets('SUBMITTED')).toContain('MANAGER_NOTIFIED');
+    expect(allowedTargets('MANAGER_NOTIFIED')).toContain('NBTC_PROCESSING');
+    expect(allowedTargets('NBTC_PROCESSING')).toContain('NBTC_RECORDED');
+    expect(allowedTargets('NBTC_RECORDED')).toContain('COMPLETED');
+  });
+
+  it('never allows a status to transition to itself', () => {
+    for (const status of APPLICATION_STATUSES) {
+      expect(isTransitionAllowed(status, status)).toBe(false);
+    }
+  });
+
+  it('never allows a step backwards along the happy path', () => {
+    const path: ApplicationStatus[] = ['DRAFT', ...HAPPY_PATH];
+    for (let index = 1; index < path.length; index += 1) {
+      expect(isTransitionAllowed(path[index]!, path[index - 1]!)).toBe(false);
+    }
+  });
+
+  it('never allows skipping a step on the happy path', () => {
+    const path: ApplicationStatus[] = ['DRAFT', ...HAPPY_PATH];
+    for (let index = 0; index + 2 < path.length; index += 1) {
+      expect(isTransitionAllowed(path[index]!, path[index + 2]!)).toBe(false);
+    }
+  });
+
+  it('treats COMPLETED, CANCELLED and REFUNDED as terminal', () => {
+    expect([...TERMINAL_STATUSES].sort()).toEqual(['CANCELLED', 'COMPLETED', 'REFUNDED']);
+  });
+
+  it('only allows a refund once money has been taken', () => {
+    expect(isTransitionAllowed('DRAFT', 'REFUND_REQUIRED')).toBe(false);
+    expect(isTransitionAllowed('AWAITING_PAYMENT', 'REFUND_REQUIRED')).toBe(false);
+    expect(isTransitionAllowed('PAYMENT_VERIFIED', 'REFUND_REQUIRED')).toBe(true);
+  });
+
+  it('only allows cancelling before money has been taken', () => {
+    expect(isTransitionAllowed('DRAFT', 'CANCELLED')).toBe(true);
+    expect(isTransitionAllowed('AWAITING_PAYMENT', 'CANCELLED')).toBe(true);
+    expect(isTransitionAllowed('PAYMENT_VERIFIED', 'CANCELLED')).toBe(false);
+  });
+
+  it('reports predecessors consistently with the forward table', () => {
+    for (const to of APPLICATION_STATUSES) {
+      for (const from of predecessorsOf(to)) {
+        expect(isTransitionAllowed(from, to)).toBe(true);
+      }
+    }
+  });
+});
+
+describe('applying transitions', () => {
+  it('walks the whole happy path', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+    const stateMachine = machine(repo);
+
+    for (const status of HAPPY_PATH) {
+      await expect(stateMachine.transition(id, status)).resolves.toMatchObject({
+        kind: 'APPLIED',
+        to: status,
+      });
+    }
+
+    await expect(repo.applications.findById(id)).resolves.toMatchObject({ status: 'COMPLETED' });
+  });
+
+  it('refuses a transition that is not in the table', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+
+    await expect(machine(repo).transition(id, 'COMPLETED')).resolves.toEqual({
+      kind: 'NOT_ALLOWED',
+      from: 'DRAFT',
+      to: 'COMPLETED',
+    });
+    await expect(repo.applications.findById(id)).resolves.toMatchObject({ status: 'DRAFT' });
+  });
+
+  it('reports NOT_FOUND for an unknown application', async () => {
+    const repo = repository();
+
+    await expect(
+      machine(repo).transition(crypto.randomUUID(), 'AWAITING_PAYMENT'),
+    ).resolves.toEqual({ kind: 'NOT_FOUND' });
+  });
+
+  it('records the timestamps that belong to the transition', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+    await walkTo(repo, id, 'PAYMENT_VERIFIED');
+
+    await machine(repo).transition(id, 'SUBMITTED', {
+      timestamps: { submittedAt: '2026-03-04T05:06:07.000Z' },
+    });
+
+    await expect(repo.applications.findById(id)).resolves.toMatchObject({
+      status: 'SUBMITTED',
+      submittedAt: '2026-03-04T05:06:07.000Z',
+    });
+  });
+
+  it('records who performed a manager action', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+    await walkTo(repo, id, 'NBTC_PROCESSING');
+
+    await machine(repo).transition(id, 'NBTC_RECORDED', {
+      actorType: 'MANAGER',
+      actorId: 'manager@example.test',
+      timestamps: {
+        nbtcRecordedAt: '2026-04-05T06:07:08.000Z',
+        nbtcRecordedBy: 'manager@example.test',
+      },
+    });
+
+    await expect(repo.applications.findById(id)).resolves.toMatchObject({
+      status: 'NBTC_RECORDED',
+      nbtcRecordedBy: 'manager@example.test',
+    });
+  });
+});
+
+describe('idempotency', () => {
+  it('treats a repeated transition as a no-op', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+    const stateMachine = machine(repo);
+
+    await stateMachine.transition(id, 'AWAITING_PAYMENT');
+
+    await expect(stateMachine.transition(id, 'AWAITING_PAYMENT')).resolves.toEqual({
+      kind: 'ALREADY_IN_TARGET_STATE',
+      status: 'AWAITING_PAYMENT',
+    });
+  });
+
+  it('does not record a second audit event for a repeated transition', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+    const stateMachine = machine(repo);
+
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      await stateMachine.transition(id, 'AWAITING_PAYMENT');
+    }
+
+    const events = await repo.events.listByApplicationId(id);
+    expect(events.filter((event) => event.eventType === 'STATUS_CHANGED')).toHaveLength(1);
+  });
+
+  it('lets exactly one of many concurrent identical transitions apply', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+    const stateMachine = machine(repo);
+
+    const outcomes = await Promise.all(
+      Array.from({ length: 10 }, () => stateMachine.transition(id, 'AWAITING_PAYMENT')),
+    );
+
+    expect(outcomes.filter((outcome) => outcome.kind === 'APPLIED')).toHaveLength(1);
+    expect(outcomes.filter((outcome) => outcome.kind === 'ALREADY_IN_TARGET_STATE')).toHaveLength(
+      9,
+    );
+
+    const events = await repo.events.listByApplicationId(id);
+    expect(events.filter((event) => event.eventType === 'STATUS_CHANGED')).toHaveLength(1);
+  });
+
+  it('does not record the domain event twice', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+    const stateMachine = machine(repo);
+    await stateMachine.transition(id, 'AWAITING_PAYMENT');
+
+    await Promise.all(
+      Array.from({ length: 5 }, () =>
+        stateMachine.transition(id, 'PAYMENT_VERIFIED', { domainEvent: 'PAYMENT_VERIFIED' }),
+      ),
+    );
+
+    const events = await repo.events.listByApplicationId(id);
+    expect(events.filter((event) => event.eventType === 'PAYMENT_VERIFIED')).toHaveLength(1);
+  });
+});
+
+describe('audit trail', () => {
+  it('records STATUS_CHANGED with the statuses only', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+
+    await machine(repo).transition(id, 'AWAITING_PAYMENT');
+
+    const [event] = await repo.events.listByApplicationId(id);
+    expect(event).toMatchObject({
+      eventType: 'STATUS_CHANGED',
+      actorType: 'SYSTEM',
+      metadata: { from: 'DRAFT', to: 'AWAITING_PAYMENT' },
+    });
+  });
+
+  it('records the domain event before the status change', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+    const stateMachine = machine(repo);
+    await stateMachine.transition(id, 'AWAITING_PAYMENT');
+
+    await stateMachine.transition(id, 'PAYMENT_VERIFIED', { domainEvent: 'PAYMENT_VERIFIED' });
+
+    const events = await repo.events.listByApplicationId(id);
+    const types = events.map((event) => event.eventType);
+    expect(types.indexOf('PAYMENT_VERIFIED')).toBeLessThan(types.lastIndexOf('STATUS_CHANGED'));
+  });
+
+  it('records the true previous status, never a stale one', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+    const stateMachine = machine(repo);
+
+    await stateMachine.transition(id, 'AWAITING_PAYMENT');
+    await stateMachine.transition(id, 'PAYMENT_VERIFIED');
+    await stateMachine.transition(id, 'SUBMITTED');
+
+    const changes = (await repo.events.listByApplicationId(id))
+      .filter((event) => event.eventType === 'STATUS_CHANGED')
+      .map((event) => `${String(event.metadata?.['from'])}->${String(event.metadata?.['to'])}`);
+
+    expect(changes).toEqual([
+      'DRAFT->AWAITING_PAYMENT',
+      'AWAITING_PAYMENT->PAYMENT_VERIFIED',
+      'PAYMENT_VERIFIED->SUBMITTED',
+    ]);
+  });
+
+  it('never writes applicant data into the audit metadata', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+    await walkTo(repo, id, 'COMPLETED');
+
+    const events = await repo.events.listByApplicationId(id);
+    const serialised = JSON.stringify(events);
+
+    for (const forbidden of ['1234567890121', 'ทดสอบ', 'ระบบสมัคร', 'example.test']) {
+      expect(serialised).not.toContain(forbidden);
+    }
+  });
+
+  it('records no audit event when the transition is refused', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+
+    await machine(repo).transition(id, 'COMPLETED');
+
+    await expect(repo.events.listByApplicationId(id)).resolves.toEqual([]);
+  });
+});
+
+describe('exception paths', () => {
+  it('allows cancelling a draft', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+
+    await expect(machine(repo).transition(id, 'CANCELLED')).resolves.toMatchObject({
+      kind: 'APPLIED',
+    });
+  });
+
+  it('allows a refund to be requested and settled after payment', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+    const stateMachine = machine(repo);
+    await walkTo(repo, id, 'PAYMENT_VERIFIED');
+
+    await expect(stateMachine.transition(id, 'REFUND_REQUIRED')).resolves.toMatchObject({
+      kind: 'APPLIED',
+    });
+    await expect(stateMachine.transition(id, 'REFUNDED')).resolves.toMatchObject({
+      kind: 'APPLIED',
+    });
+  });
+
+  it('refuses any transition out of a terminal status', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+    const stateMachine = machine(repo);
+    await walkTo(repo, id, 'COMPLETED');
+
+    for (const status of APPLICATION_STATUSES) {
+      const outcome = await stateMachine.transition(id, status);
+      expect(outcome.kind).toBe(status === 'COMPLETED' ? 'ALREADY_IN_TARGET_STATE' : 'NOT_ALLOWED');
+    }
+  });
+});

--- a/tests/worker/state-machine.test.ts
+++ b/tests/worker/state-machine.test.ts
@@ -260,9 +260,38 @@ describe('audit trail', () => {
 
     await stateMachine.transition(id, 'PAYMENT_VERIFIED', { domainEvent: 'PAYMENT_VERIFIED' });
 
+    // Asserted as an exact sequence rather than with index arithmetic: both
+    // events of one transition share a millisecond, so this is precisely the
+    // case where a non-deterministic tiebreak would show up.
     const events = await repo.events.listByApplicationId(id);
-    const types = events.map((event) => event.eventType);
-    expect(types.indexOf('PAYMENT_VERIFIED')).toBeLessThan(types.lastIndexOf('STATUS_CHANGED'));
+    expect(events.map((event) => event.eventType)).toEqual([
+      'STATUS_CHANGED',
+      'PAYMENT_VERIFIED',
+      'STATUS_CHANGED',
+    ]);
+  });
+
+  it('keeps the timeline in causal order when a batch shares a millisecond', async () => {
+    // The clock is frozen, so every event carries the same created_at and the
+    // ordering can only come from insert order.
+    const frozen = new Date('2026-08-20T03:00:00.000Z');
+    const repo = repository({ now: () => frozen });
+    const id = await seedApplication(repo);
+    const stateMachine = createStateMachine(repo);
+
+    await stateMachine.transition(id, 'AWAITING_PAYMENT');
+    await stateMachine.transition(id, 'PAYMENT_VERIFIED', { domainEvent: 'PAYMENT_VERIFIED' });
+    await stateMachine.transition(id, 'SUBMITTED', { domainEvent: 'APPLICATION_SUBMITTED' });
+
+    const events = await repo.events.listByApplicationId(id);
+    expect(new Set(events.map((event) => event.createdAt)).size).toBe(1);
+    expect(events.map((event) => event.eventType)).toEqual([
+      'STATUS_CHANGED',
+      'PAYMENT_VERIFIED',
+      'STATUS_CHANGED',
+      'APPLICATION_SUBMITTED',
+      'STATUS_CHANGED',
+    ]);
   });
 
   it('records the true previous status, never a stale one', async () => {


### PR DESCRIPTION
## Linked Issue

Closes #7

## Outcome

การเปลี่ยนสถานะใบสมัครทุกครั้งผ่าน state machine ที่ validate, idempotent และปลอดภัยใต้ concurrency และเลขใบสมัคร/เลขใบสำคัญรับเงินไม่ซ้ำและไม่มีเลขขาดหายแม้มี request พร้อมกัน

## Scope

- Changed:
  - `src/worker/services/state-machine.ts` (ใหม่) — ตาราง transition ตาม Issue #1 หัวข้อ 41, compare-and-set, idempotency
  - `src/worker/services/numbering.ts` (ใหม่) — เลขใบสมัครและเลขใบสำคัญรับเงิน format configurable ปี พ.ศ. จากเวลา Asia/Bangkok
  - `src/worker/services/audit.ts` (ใหม่) — audit trail พร้อม allowlist ของ metadata key
  - `src/worker/lib/time.ts` (ใหม่) — แปลงเวลาเป็น Asia/Bangkok, ปี พ.ศ., รูปแบบแสดงผลภาษาไทย
  - `src/worker/db/repository.ts` — เพิ่ม `applications.findMaxReferenceNo` และ `receipts.findMaxReceiptNo`
  - `tests/worker/state-machine.test.ts`, `tests/worker/numbering.test.ts`, `tests/unit/time.test.ts`, `tests/unit/audit-metadata.test.ts` (ใหม่ทั้งหมด)
  - `docs/architecture.md` — แผนภาพ state machine และกฎของ numbering

- Explicitly not changed:
  - ยังไม่มี endpoint, provider จริง, email หรือ UI ที่เรียก service เหล่านี้ (non-goals ของ #7)
  - ไม่แตะ schema, migration, workflow ของ CI/CD

## Decisions worth reviewing

**1. Compare-and-set ใช้สถานะที่อ่านมาจริง ไม่ใช่ชุด predecessor ทั้งหมด**

ตอนแรกเขียนให้ CAS ใช้ `predecessorsOf(to)` เป็นเงื่อนไข `where status in (...)` ด้วยเหตุผลว่าจะลด spurious failure แต่พบตอนทบทวนว่ามันผิด: `REFUND_REQUIRED` มี predecessor ห้าตัว ถ้าใบสมัครอยู่ `SUBMITTED` แล้วอีก request ย้ายไป `MANAGER_NOTIFIED` พร้อมกัน CAS แบบกว้างจะยังสำเร็จ และ audit event จะบันทึก `from: SUBMITTED` ซึ่งไม่เคยเป็นจริงในขณะที่เขียน — audit trail ที่โกหกแย่กว่าการ retry

จึงเปลี่ยนเป็น CAS บน `[from]` ตัวเดียว แล้วมี retry ภายในสูงสุด 3 ครั้ง ถ้ายังแพ้และ transition ยัง legal อยู่ จะคืน `CONCURRENTLY_MODIFIED` ให้ผู้เรียกตัดสินใจ แทนที่จะรายงาน `NOT_ALLOWED` ที่ไม่ตรงความจริง

**2. Numbering ใช้ highest + 1 ทุกครั้ง ไม่ใช่ highest + attempt**

เขียนครั้งแรกเป็น `highest + attempt` เพื่อลดการชนซ้ำ test concurrency จับได้ว่าได้เลข `000001, 000003, 000006, 000010, 000015` — ไม่ซ้ำแต่มีเลขขาดหาย สำหรับใบสำคัญรับเงินเลขขาดหายเป็นเรื่องที่ผู้ตรวจสอบบัญชีจะถามหา จึงเปลี่ยนเป็นอ่านค่าสูงสุดใหม่ทุกครั้งแล้ว +1 ผลคือ 5 request พร้อมกันได้ `000001` ถึง `000005` ครบไม่ขาด

**3. `assignApplicationNumber` ที่เรียกซ้ำคืนเลขเดิม**

ถ้า `setReferenceNo` ชน unique constraint ระบบจะอ่านใบสมัครใหม่เพื่อแยกสองกรณี: เลขที่เสนอถูกคนอื่นใช้ไปแล้ว (ลองเลขถัดไป) กับใบสมัครนี้ได้เลขไปแล้วโดย request อื่น (คืนเลขนั้น) การออกเลขที่สองให้ใบสมัครเดียวหมายถึงมีสองเลขอ้างอิงอยู่บนเอกสารที่ผู้สมัครเห็นแล้ว ซึ่งแก้ย้อนหลังไม่ได้

**4. Prefix ถูกจำกัดชุดตัวอักษร เพราะมันไปเป็นส่วนของ `like` pattern**

`findMaxReferenceNo` รับ pattern อย่าง `VRA-2569-%` ถ้า prefix มี `%` หรือ `_` ได้ pattern จะ match เลขของทุกปีหรือ match ผิด จึง validate ด้วย `^[A-Z][A-Z0-9-]*$` ตอนสร้าง service ค่ายังถูก bind เป็น parameter อยู่แล้วจึงไม่มีปัญหา injection แต่ความถูกต้องของ pattern สำคัญกว่า

**5. Audit metadata ใช้ allowlist ไม่ใช่แค่ type ที่เป็น primitive**

`EventMetadata` จำกัด type ตอน compile แล้ว แต่ primitive ก็ยังใส่ชื่อหรือ email ได้ จึงใช้ allowlist ของ key แบบเดียวกับ logger พร้อมจำกัดความยาว string ที่ 64 ตัวอักษร มี test ที่พยายามใส่ `citizenId`, `firstName`, `address`, `email`, `phone`, `callsign`, `photoKey` แล้วยืนยันว่าถูกตัดทิ้งทั้งหมด

**6. `parseSequence` คืน 0 เมื่ออ่านไม่ออก**

ถ้าฐานข้อมูลมีเลขจาก format เก่า เช่น `VRA-2569-OLD` การ `Number()` จะได้ `NaN` แล้วเลขถัดไปจะกลายเป็น `NaN` การคืน 0 ทำให้ระบบเริ่มนับใหม่จาก 1 และ unique constraint ยังกันการซ้ำอยู่ มี test ครอบกรณีนี้

## Verification

| Command / check | Result |
| --- | --- |
| `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\scripts\validate-repository.ps1` | pass — 77 tracked files |
| `npm run lint` | pass |
| `npm run format:check` | pass |
| `npm run typecheck` | pass |
| `npm test` | pass — 12 files / 188 tests (เพิ่มจาก 118) |
| `npm run build` | pass |
| `npm run check:worker:production` | pass |

Test ที่ครอบ acceptance criteria โดยตรง

- ตาราง transition: เดินเส้นทาง happy path ครบ, ปฏิเสธการถอยหลังทุกคู่, ปฏิเสธการข้ามขั้นทุกคู่, ปฏิเสธ self-transition ทุกสถานะ, terminal status ครบสามตัว
- Idempotency: เรียกซ้ำ 5 ครั้งได้ audit event ครั้งเดียว, ยิงพร้อมกัน 10 ครั้งมี `APPLIED` ครั้งเดียวและ `ALREADY_IN_TARGET_STATE` เก้าครั้ง, domain event ไม่ซ้ำ
- Concurrency ของ numbering: 5 ใบสมัครพร้อมกันได้ `000001`-`000005` ครบไม่ขาด, ขอเลขใบเดิมพร้อมกัน 5 ครั้งได้เลขเดียว, receipt พร้อมกันสี่ใบได้เลขไม่ซ้ำ
- ปี พ.ศ.: `2026-12-31T16:59:59Z` -> 2569 และ `2026-12-31T17:00:00Z` -> 2570 (เที่ยงคืน Asia/Bangkok) พร้อม test ว่าไม่ได้ hardcode ปีเดียว
- Audit metadata: ไม่มีข้อมูลผู้สมัครใน audit trail หลังเดินครบ workflow ตรวจด้วยการ serialize ทั้ง trail แล้วหาเลขบัตร ชื่อ และ domain ของ email

## Security and privacy

- [x] No secrets, real PII, ID-card images, payment-slip images, or raw provider responses are included.
- [x] Logs contain only allowlisted technical metadata.
- [x] Tests use synthetic data and mocked providers.
- [x] Authentication, authorization, payment, webhook, retention, migration, and deployment impact is described below.

Impact and mitigations:

- **Authorization** — service เหล่านี้ไม่ตัดสินว่าใครมีสิทธิ์ทำอะไร แต่รับ `actorType`/`actorId` มาบันทึก การบังคับสิทธิ์เป็นของ #8 (middleware) และ #16 (Cloudflare Access) `actorId` ถูกออกแบบให้เก็บตัวตนผู้จัดการเท่านั้น ไม่ใช่ข้อมูลผู้สมัคร
- **Audit trail** — allowlist ของ metadata key คือจุดบังคับ ไม่ใช่ข้อตกลง มี test ที่พยายามใส่ข้อมูลส่วนบุคคลทุกประเภทที่น่าจะเผลอใส่แล้วยืนยันว่าถูกตัดทิ้ง และ test ที่เดินครบ workflow แล้ว serialize audit trail ทั้งก้อนเพื่อยืนยันว่าไม่มีข้อมูลผู้สมัครหลุดเข้าไป
- **Idempotency กับ side effect** — คุณสมบัติ no-op เมื่อสถานะเป็นเป้าหมายอยู่แล้ว เป็นรากฐานของข้อกำหนดใน Issue #1 หัวข้อ 34 และ 56 ที่ว่าสมาชิกต้องได้ processing email เพียงครั้งเดียว #14 จะต่อยอดจากจุดนี้
- **ไม่มีการ log ใน service** — service ไม่ log อะไรเลย ผู้เรียกเป็นฝ่าย log ผลลัพธ์กับ internal id ตามสัญญาของ logger
- **Payment path** — ยังไม่แตะการตรวจสลิปหรือยอดเงิน แต่ transition `PAYMENT_VERIFIED` และ `REFUND_REQUIRED` ถูกจำกัดให้เข้าได้จากสถานะที่สมเหตุสมผลเท่านั้น
- **Medium risk** — งานนี้กำหนดว่าสถานะเปลี่ยนได้อย่างไรและ audit trail เก็บอะไร ขอ human review ตาม `AGENTS.md`

## Deployment / migration / rollback

Not applicable — ไม่มี migration และไม่มีการเปลี่ยน schema เพิ่มเฉพาะ query ใหม่สองตัวที่อ่านจาก column ที่มีอยู่แล้ว rollback ของ code ทำได้โดยไม่ต้องแตะ database

## UI evidence

Not applicable — PR นี้ไม่มีส่วน UI

## Human / AI handoff

- **Completed:** state machine พร้อมตาราง transition ครบ, numbering ที่ไม่ซ้ำและไม่มีเลขขาด, audit trail พร้อม allowlist, helper เวลา Asia/Bangkok และปี พ.ศ., repository query สองตัวที่ numbering ต้องใช้, test 70 เคสใหม่ (รวมทั้ง suite 188), เอกสาร state machine และ numbering
- **Remaining:** #8 security middleware (Turnstile, rate limiting, MIME/size validation, CSRF) แล้วต่อด้วย provider integration #9 และ #11
- **Changed paths:** ตามหัวข้อ Scope
- **Risks / assumptions:**
  - สมมติว่าเส้นทาง exception ตามที่ออกแบบไว้ถูกต้องกับกระบวนการจริงของสมาคม: ยกเลิกได้ก่อนชำระเงินเท่านั้น, ขอคืนเงินได้หลังชำระเงินแล้วเท่านั้น, `REJECTED` เข้าถึงได้จาก `AWAITING_PAYMENT` เป็นต้นไปและนำไปสู่ `REFUND_REQUIRED` ได้ ถ้าสมาคมมีกรณีที่ต่างจากนี้ควรแก้ตารางใน PR นี้เพราะแก้ทีหลังจะมีข้อมูลจริงติดอยู่ในสถานะเดิมแล้ว
  - สมมติว่า `MANAGER_NOTIFIED` เป็นสถานะที่ระบบตั้งเองหลังส่ง email สำเร็จ ไม่ใช่สถานะที่ผู้จัดการกด #15 จะเป็นผู้เรียก transition นี้
  - `CONCURRENTLY_MODIFIED` ยังไม่มีผู้เรียกจัดการ ผู้เรียกใน #14/#15/#16 ต้องตัดสินใจว่าจะ retry หรือรายงานความขัดแย้งต่อผู้ใช้
  - เลขที่มี sequence เกินความกว้าง padding จะยาวขึ้นแทนที่จะถูกตัด ที่ปริมาณ 1-2 ใบสมัครต่อวัน 6 หลักพอสำหรับ 2,700 ปี จึงไม่ตั้งเพดาน
- **Next safe action:** merge PR นี้แล้วเริ่ม #8 บน branch `feat/issue-8-security-middleware`
