### PR TITLE
feat: add the security controls that guard every public endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@ IAPP_API_KEY=
 SLIPOK_API_KEY=
 RESEND_API_KEY=
 RESEND_WEBHOOK_SECRET=
+# Turnstile secret key. The matching site key is public and ships in the client.
+TURNSTILE_SECRET_KEY=
 # Random value of at least 32 bytes, e.g. `openssl rand -base64 48`.
 # Used verbatim as HKDF input, so it must never change once data exists.
 PII_ENCRYPTION_KEY=

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,6 +28,12 @@ src/worker/            Cloudflare Worker (Hono)
     mappers.ts         row to model conversion
     repository.ts      parameterised queries grouped per aggregate
     errors.ts          constraint-violation translation
+  security/            controls applied before business rules run
+    turnstile.ts       bot protection, verified before any provider call
+    rate-limit.ts      fixed-window counters in D1, hashed identifiers
+    csrf.ts            origin check plus double-submit token for admin POSTs
+    validation.ts      strict zod parsing that never echoes a submitted value
+    context.ts         per-request assembly of the above
   services/            business rules; no SQL, no HTTP
     state-machine.ts   validated, idempotent, concurrency-safe transitions
     numbering.ts       application and receipt numbers
@@ -37,6 +43,7 @@ src/worker/            Cloudflare Worker (Hono)
   lib/http.ts          API error codes and applicant-safe messages
   lib/crypto.ts        citizen ID encryption and duplicate-lookup hashing
   lib/citizen-id.ts    citizen ID normalisation and check-digit validation
+  lib/files.ts         magic-byte sniffing and size-limited body reads
   providers/types.ts   OcrProvider, SlipVerificationProvider, EmailProvider
   providers/mock/      deterministic adapters used by development and tests
 src/web/               React client, built to dist/client
@@ -110,6 +117,30 @@ COMPLETED, CANCELLED and REFUNDED are terminal
 `VRA-{พ.ศ.}-{running}` และ `VRA-RC-{พ.ศ.}-{running}` โดย prefix และความยาว sequence เป็น config ปี พ.ศ. คำนวณจากเวลา Asia/Bangkok ไม่ใช่จากวัน UTC ใบสมัครที่ส่งเวลา 23:30 UTC ของวันที่ 31 ธันวาคม จึงได้เลขของปีถัดไป
 
 ความไม่ซ้ำเป็นการรับประกันจาก `UNIQUE` constraint ไม่ใช่จาก application layer ระบบเสนอเลขจากค่าสูงสุดที่ออกไปแล้วบวกหนึ่ง แล้วให้ constraint ตัดสิน ผู้แพ้อ่านค่าสูงสุดใหม่และลองอีกครั้ง จึงได้ลำดับที่ไม่ซ้ำและไม่มีเลขขาดหาย
+
+## Public endpoint controls
+
+ทุก endpoint สาธารณะที่มีค่าใช้จ่ายต้องผ่านลำดับนี้ก่อนถึง business logic
+
+```text
+request
+  -> Turnstile        ตรวจก่อนเรียก provider ใด ๆ เพราะการตรวจทีหลังยังทำให้เกิดค่าใช้จ่าย
+  -> rate limit       fixed window ใน D1 ต่อ scope และต่อ client
+  -> file validation  sniff magic bytes และจำกัดขนาดระหว่างอ่าน stream
+  -> zod validation   strict object ปฏิเสธ field ที่ไม่รู้จัก
+  -> business logic
+```
+
+Admin endpoint ที่เปลี่ยนสถานะเพิ่มอีกสองชั้น: ตรวจ `Origin` และ double-submit CSRF token ที่เทียบแบบ constant time เพราะ Cloudflare Access ใช้ cookie ซึ่งถูกส่งไปกับ cross-site request ด้วย
+
+หลักที่ใช้ตัดสินใจ
+
+- **Content-Type ที่ client ส่งมาเป็นเพียงคำใบ้** ชนิดไฟล์ตัดสินจาก magic bytes ไฟล์ PDF หรือ script ที่เปลี่ยนนามสกุลเป็น `.jpg` ต้องไม่ถึง provider หรือ bucket
+- **ขนาดไฟล์ถูกบังคับระหว่างอ่าน ไม่ใช่หลังอ่านจบ** การ buffer ไฟล์ทั้งก้อนแล้วค่อยวัดคือวิธีที่ Worker ถูกฆ่าด้วย request เดียว
+- **Field ที่ไม่รู้จักถูกปฏิเสธ ไม่ใช่ถูกตัดออกเงียบ ๆ** client ที่ส่ง `amount` มาพร้อม `membershipType` เข้าใจ contract ผิด และการตัดออกเงียบ ๆ ปิดบังเรื่องนั้น
+- **ข้อความ error ไม่มีค่าที่ผู้ใช้ส่งมา** ค่าเหล่านั้นคือเลขบัตร ที่อยู่ และ email ตอบกลับเฉพาะ path ของ field กับข้อความภาษาไทยตามชนิดของข้อผิดพลาด
+- **Rate limit counter อยู่ใน D1 ไม่ใช่ในหน่วยความจำของ isolate** Worker หนึ่งตัวรันหลาย isolate พร้อมกัน counter ในหน่วยความจำจึงไม่จำกัดอะไรเลย และ bucket ที่เก็บเป็น keyed hash ของ `<scope>:<identifier>` ไม่ใช่ IP ตรง ๆ
+- **rate limit ใน application layer ไม่แทน rule ที่ edge** rule ของ Cloudflare หยุด traffic ก่อนถึง Worker จึงกันทั้งค่า invocation และค่า D1 write ที่ counter ใช้ ต้องตั้งทั้งสองชั้น
 
 ## Decision records
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -42,6 +42,7 @@ Pipeline ประกอบด้วยสาม workflow
    | `SLIPOK_API_KEY`        | SlipOK slip verification          |
    | `RESEND_API_KEY`        | Resend transactional email        |
    | `RESEND_WEBHOOK_SECRET` | ตรวจ signature ของ Resend webhook |
+   | `TURNSTILE_SECRET_KEY`  | ตรวจ Turnstile token ฝั่ง server  |
    | `PII_ENCRYPTION_KEY`    | เข้ารหัสเลขบัตรประชาชนใน D1       |
    | `MANAGER_EMAIL`         | ผู้รับ email แจ้งใบสมัครใหม่      |
    | `EMAIL_FROM`            | sender ของ transactional email    |
@@ -61,7 +62,9 @@ Pipeline ประกอบด้วยสาม workflow
 
 5. สร้าง Cloudflare Access application ครอบ `/admin*` และ `/api/admin/*` แล้วกำหนดผู้ใช้ที่เข้าได้
 
-6. สร้าง Turnstile site และเก็บ secret key เป็น Cloudflare Secret เมื่อ issue ที่ใช้งาน Turnstile ถูก implement
+6. สร้าง Turnstile site แล้วเก็บ secret key เป็น Cloudflare Secret ชื่อ `TURNSTILE_SECRET_KEY` ส่วน site key เป็นค่าสาธารณะที่อยู่ใน client bundle
+
+   เพิ่ม Cloudflare rate limiting rule ที่ระดับ edge สำหรับ `/api/ocr`, `/api/payment/verify` และ `/api/member-photo` ด้วย ระบบมี rate limiting ใน application layer อยู่แล้ว แต่ rule ที่ edge หยุด traffic ก่อนถึง Worker จึงกันทั้งค่า Worker invocation และค่า D1 write ที่ counter ใช้
 
 7. สร้าง GitHub environment ชื่อ `production` (Settings -> Environments) โดยเปิด required reviewers และจำกัด deployment branch เป็น `main` แล้วเพิ่ม environment secrets
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -77,7 +77,7 @@ export default tseslint.config(
   },
   {
     // Mock adapters satisfy async provider interfaces without awaiting.
-    files: ['src/worker/providers/mock/**/*.ts'],
+    files: ['src/worker/providers/mock/**/*.ts', 'src/worker/security/turnstile.ts'],
     rules: { '@typescript-eslint/require-await': 'off' },
   },
   {

--- a/migrations/0002_create_rate_limits.sql
+++ b/migrations/0002_create_rate_limits.sql
@@ -1,0 +1,25 @@
+-- Fixed-window rate limiting for the public endpoints that cost money
+-- (Issue #1 section 57).
+--
+-- Privacy: `bucket` holds a keyed hash of the identifier, never the identifier
+-- itself. A client IP address is personal data and has no business sitting in
+-- the database in clear text, and a hash is all a counter needs.
+--
+-- Rows are disposable. Old windows are deleted opportunistically on write, so
+-- the table stays small without a scheduled job.
+
+CREATE TABLE rate_limits (
+  -- Keyed hash of "<scope>:<identifier>".
+  bucket TEXT NOT NULL,
+  -- Unix seconds at the start of the window.
+  window_start INTEGER NOT NULL,
+  count INTEGER NOT NULL DEFAULT 0,
+
+  PRIMARY KEY (bucket, window_start),
+
+  CHECK (count >= 0),
+  CHECK (window_start >= 0)
+);
+
+-- Supports the opportunistic cleanup of expired windows.
+CREATE INDEX idx_rate_limits_window_start ON rate_limits (window_start);

--- a/src/worker/context.ts
+++ b/src/worker/context.ts
@@ -2,6 +2,7 @@ import type { Repository } from './db';
 import type { Logger } from './lib/logger';
 import type { WorkerConfig, WorkerEnv } from './env';
 import type { Providers } from './providers';
+import type { SecurityServices } from './security';
 
 /** Hono generics for every route in the application. */
 export interface AppContext {
@@ -12,5 +13,6 @@ export interface AppContext {
     logger: Logger;
     providers: Providers;
     db: Repository;
+    security: SecurityServices;
   };
 }

--- a/src/worker/db/repository.ts
+++ b/src/worker/db/repository.ts
@@ -176,6 +176,23 @@ export interface EventRepository {
   existsForApplication(applicationId: string, eventType: string): Promise<boolean>;
 }
 
+export interface RateLimitRepository {
+  /**
+   * Counts one request in a window and returns the new total.
+   *
+   * The insert-or-increment is a single statement, so two concurrent requests
+   * cannot both read the same count and write back the same value. Expired
+   * windows are removed in the same batch, which keeps the table small without
+   * a scheduled job.
+   */
+  increment(input: {
+    bucket: string;
+    windowStart: number;
+    /** Windows starting before this instant are deleted. */
+    expireBefore: number;
+  }): Promise<number>;
+}
+
 export interface Repository {
   applications: ApplicationRepository;
   addresses: AddressRepository;
@@ -183,6 +200,7 @@ export interface Repository {
   receipts: ReceiptRepository;
   emails: EmailRepository;
   events: EventRepository;
+  rateLimits: RateLimitRepository;
 }
 
 export function createRepository(db: D1Database, options: RepositoryOptions = {}): Repository {
@@ -832,5 +850,29 @@ export function createRepository(db: D1Database, options: RepositoryOptions = {}
     },
   };
 
-  return { applications, addresses, payments, receipts, emails, events };
+  const rateLimits: RateLimitRepository = {
+    async increment({ bucket, windowStart, expireBefore }) {
+      const [incremented] = await withTranslatedErrors(async () =>
+        db.batch<{ count: number }>([
+          db
+            .prepare(
+              `insert into rate_limits (bucket, window_start, count)
+               values (?, ?, 1)
+               on conflict (bucket, window_start) do update set count = count + 1
+               returning count`,
+            )
+            .bind(bucket, windowStart),
+          db.prepare('delete from rate_limits where window_start < ?').bind(expireBefore),
+        ]),
+      );
+
+      const count = incremented?.results[0]?.count;
+      if (typeof count !== 'number') {
+        throw new Error('Rate limit counter did not return a count');
+      }
+      return count;
+    },
+  };
+
+  return { applications, addresses, payments, receipts, emails, events, rateLimits };
 }

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -6,6 +6,7 @@ import { ConfigurationError, readConfig } from './env';
 import { ApiError, errorBody, statusForErrorCode } from './lib/http';
 import { createLogger } from './lib/logger';
 import { ProviderNotConfiguredError, createProviders } from './providers';
+import { ValidationError, createSecurityServices, validationErrorBody } from './security';
 import { healthRoutes } from './routes/health';
 
 const GENERIC_ERROR_MESSAGE = 'เกิดข้อผิดพลาดภายในระบบ กรุณาลองใหม่อีกครั้ง';
@@ -42,7 +43,9 @@ app.use('*', async (c, next) => {
     }),
   );
   c.set('providers', createProviders(c.env));
-  c.set('db', createRepository(c.env.DB));
+  const db = createRepository(c.env.DB);
+  c.set('db', db);
+  c.set('security', await createSecurityServices(c.env, db));
 
   const startedAt = Date.now();
   await next();
@@ -68,6 +71,13 @@ app.notFound((c) => {
 app.onError((error, c) => {
   const requestId = c.var.requestId as string | undefined;
   const logger = c.var.logger ?? createLogger();
+
+  if (error instanceof ValidationError) {
+    // Field paths are safe to return; the submitted values are not, and
+    // `validationErrorBody` carries only the paths.
+    logger.warn({ event: 'request.failed', errorCode: error.code, count: error.fields.length });
+    return c.json(validationErrorBody(error, requestId), 422);
+  }
 
   if (error instanceof ApiError) {
     logger.warn({ event: 'request.failed', errorCode: error.code });

--- a/src/worker/lib/crypto.ts
+++ b/src/worker/lib/crypto.ts
@@ -98,14 +98,56 @@ async function deriveBits(master: CryptoKey, info: string): Promise<ArrayBuffer>
   );
 }
 
+async function importMaster(keyMaterial: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey('raw', decodeKeyMaterial(keyMaterial), 'HKDF', false, [
+    'deriveBits',
+  ]);
+}
+
+/**
+ * A keyed hash over an arbitrary label, derived from the same master secret but
+ * a different HKDF `info`, so it shares no key material with anything else.
+ *
+ * Used where an identifier must be stored or compared without storing the
+ * identifier itself - a client IP address in a rate-limit bucket, for instance,
+ * is personal data that has no business sitting in the database in clear.
+ */
+export interface KeyedHasher {
+  hash(value: string): Promise<string>;
+}
+
+export async function createKeyedHasher(keyMaterial: string, info: string): Promise<KeyedHasher> {
+  const bits = await deriveBits(await importMaster(keyMaterial), info);
+  const key = await crypto.subtle.importKey('raw', bits, { name: 'HMAC', hash: 'SHA-256' }, false, [
+    'sign',
+  ]);
+
+  return {
+    async hash(value: string): Promise<string> {
+      const signature = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(value));
+      return toBase64Url(new Uint8Array(signature));
+    },
+  };
+}
+
+/**
+ * Constant-time comparison for secrets and tokens.
+ *
+ * `a === b` on strings short-circuits at the first differing byte, which leaks
+ * how much of a guess was correct. Length is compared first because it is not
+ * secret, and the loop then always runs over the full length.
+ */
+export function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let difference = 0;
+  for (let index = 0; index < a.length; index += 1) {
+    difference |= a.charCodeAt(index) ^ b.charCodeAt(index);
+  }
+  return difference === 0;
+}
+
 export async function createCitizenIdProtection(keyMaterial: string): Promise<CitizenIdProtection> {
-  const master = await crypto.subtle.importKey(
-    'raw',
-    decodeKeyMaterial(keyMaterial),
-    'HKDF',
-    false,
-    ['deriveBits'],
-  );
+  const master = await importMaster(keyMaterial);
 
   const [aesBits, hmacBits] = await Promise.all([
     deriveBits(master, AES_INFO),

--- a/src/worker/lib/files.ts
+++ b/src/worker/lib/files.ts
@@ -1,0 +1,178 @@
+import { ApiError } from './http';
+
+/**
+ * Upload validation for the three images the workflow touches: the ID card
+ * (never stored), the member photo (stored) and the payment slip (never
+ * stored) - Issue #1 section 59.
+ *
+ * Two rules drive the design:
+ *
+ * 1. **The declared content type is a hint, not evidence.** `Content-Type` and
+ *    a file's name come from the client, so the type is decided by sniffing the
+ *    leading bytes. A PDF or a script renamed to `.jpg` must not reach a
+ *    provider or the bucket.
+ * 2. **The size limit is enforced while reading, not after.** Buffering an
+ *    arbitrary upload and then measuring it is how a Worker gets killed by a
+ *    single request. The stream is read with a running total and abandoned the
+ *    moment it goes over.
+ */
+
+export const SUPPORTED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp'] as const;
+export type SupportedImageType = (typeof SUPPORTED_IMAGE_TYPES)[number];
+
+/** Applicant-safe Thai messages; these reach the browser. */
+const MESSAGES = {
+  tooLarge: 'ไฟล์มีขนาดใหญ่เกินกำหนด กรุณาถ่ายภาพใหม่หรือย่อขนาดไฟล์',
+  unsupported: 'รองรับเฉพาะไฟล์ภาพ JPEG, PNG หรือ WebP เท่านั้น',
+  empty: 'ไม่พบไฟล์ภาพ กรุณาเลือกไฟล์อีกครั้ง',
+} as const;
+
+interface Signature {
+  type: SupportedImageType;
+  /** Byte values to match, with `null` for a position that may be anything. */
+  bytes: readonly (number | null)[];
+  offset: number;
+}
+
+/**
+ * Magic-byte signatures. WebP needs two checks because `RIFF` alone is a
+ * container that also holds AVI and WAV.
+ */
+const SIGNATURES: readonly Signature[] = [
+  { type: 'image/jpeg', offset: 0, bytes: [0xff, 0xd8, 0xff] },
+  {
+    type: 'image/png',
+    offset: 0,
+    bytes: [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a],
+  },
+  // "RIFF" .... "WEBP"
+  { type: 'image/webp', offset: 0, bytes: [0x52, 0x49, 0x46, 0x46] },
+];
+
+const WEBP_FORM_TYPE = [0x57, 0x45, 0x42, 0x50]; // "WEBP" at offset 8
+
+function matches(bytes: Uint8Array, signature: Signature): boolean {
+  if (bytes.byteLength < signature.offset + signature.bytes.length) return false;
+  return signature.bytes.every((expected, index) => {
+    if (expected === null) return true;
+    return bytes[signature.offset + index] === expected;
+  });
+}
+
+/** Returns the sniffed type, or null when the bytes are not a supported image. */
+export function sniffImageType(bytes: Uint8Array): SupportedImageType | null {
+  for (const signature of SIGNATURES) {
+    if (!matches(bytes, signature)) continue;
+    if (signature.type !== 'image/webp') return signature.type;
+
+    const isWebp = WEBP_FORM_TYPE.every((expected, index) => bytes[8 + index] === expected);
+    if (isWebp) return 'image/webp';
+  }
+  return null;
+}
+
+export interface ImageValidationOptions {
+  maxBytes: number;
+  /** Defaults to every supported type. */
+  allowedTypes?: readonly SupportedImageType[];
+}
+
+export interface ValidatedImage {
+  bytes: Uint8Array;
+  /** The sniffed type, never the declared one. */
+  contentType: SupportedImageType;
+}
+
+/**
+ * Reads at most `maxBytes + 1` bytes from `stream`.
+ *
+ * Reading one byte past the limit is what makes "too large" detectable without
+ * ever holding more than the limit plus a byte in memory.
+ */
+async function readWithLimit(
+  stream: ReadableStream<Uint8Array>,
+  maxBytes: number,
+): Promise<{ bytes: Uint8Array; exceeded: boolean }> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+
+      total += value.byteLength;
+      chunks.push(value);
+
+      if (total > maxBytes) {
+        return { bytes: new Uint8Array(0), exceeded: true };
+      }
+    }
+  } finally {
+    // Release the lock even when abandoning early, so the request can be
+    // discarded without leaving the body half-read.
+    reader.releaseLock();
+  }
+
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return { bytes, exceeded: false };
+}
+
+/**
+ * Validates an image already held in memory, e.g. one field of a parsed form.
+ * Throws `ApiError` with an applicant-safe message.
+ */
+export function validateImageBytes(
+  bytes: Uint8Array,
+  options: ImageValidationOptions,
+): ValidatedImage {
+  if (bytes.byteLength === 0) {
+    throw new ApiError('BAD_REQUEST', MESSAGES.empty);
+  }
+  if (bytes.byteLength > options.maxBytes) {
+    throw new ApiError('PAYLOAD_TOO_LARGE', MESSAGES.tooLarge);
+  }
+
+  const contentType = sniffImageType(bytes);
+  const allowed = options.allowedTypes ?? SUPPORTED_IMAGE_TYPES;
+  if (contentType === null || !allowed.includes(contentType)) {
+    throw new ApiError('UNSUPPORTED_MEDIA_TYPE', MESSAGES.unsupported);
+  }
+
+  return { bytes, contentType };
+}
+
+/**
+ * Reads and validates an image from a request body stream.
+ *
+ * The `Content-Length` header is checked first purely to fail fast; it is
+ * client-supplied, so the byte count from the stream is the one that decides.
+ */
+export async function readValidatedImage(
+  request: Request,
+  options: ImageValidationOptions,
+): Promise<ValidatedImage> {
+  const declaredLength = Number(request.headers.get('content-length') ?? '');
+  if (Number.isFinite(declaredLength) && declaredLength > options.maxBytes) {
+    throw new ApiError('PAYLOAD_TOO_LARGE', MESSAGES.tooLarge);
+  }
+
+  const body: ReadableStream<Uint8Array> | null = request.body;
+  if (!body) {
+    throw new ApiError('BAD_REQUEST', MESSAGES.empty);
+  }
+
+  const { bytes, exceeded } = await readWithLimit(body, options.maxBytes);
+  if (exceeded) {
+    throw new ApiError('PAYLOAD_TOO_LARGE', MESSAGES.tooLarge);
+  }
+
+  return validateImageBytes(bytes, options);
+}

--- a/src/worker/security/context.ts
+++ b/src/worker/security/context.ts
@@ -1,0 +1,92 @@
+import type { Repository } from '../db';
+import { requireSecret } from '../env';
+import type { WorkerEnv } from '../env';
+import { createKeyedHasher } from '../lib/crypto';
+import type { KeyedHasher } from '../lib/crypto';
+import { createRateLimiter } from './rate-limit';
+import type { RateLimiter } from './rate-limit';
+import { createMockTurnstileVerifier, createTurnstileVerifier } from './turnstile';
+import type { TurnstileVerifier } from './turnstile';
+
+/**
+ * Assembles the per-request security services.
+ *
+ * Turnstile follows the same rule as the business providers: `mock` mode gets a
+ * deterministic stand-in so no test reaches Cloudflare, and `live` mode requires
+ * the secret rather than falling back to a mock.
+ */
+
+const RATE_LIMIT_HASH_INFO = 'vra:rate-limit:v1';
+
+/**
+ * Derived HMAC keys are cached per isolate, keyed by the secret they came from.
+ *
+ * HKDF on every request would be wasteful, and the key material is already in
+ * this isolate's memory as an environment variable, so keeping the derived key
+ * beside it exposes nothing new.
+ */
+let cachedHasher: { keyMaterial: string; hasher: KeyedHasher } | null = null;
+
+async function rateLimitHasher(env: WorkerEnv): Promise<KeyedHasher> {
+  const keyMaterial = resolveHashKey(env);
+  if (cachedHasher?.keyMaterial === keyMaterial) {
+    return cachedHasher.hasher;
+  }
+
+  const hasher = await createKeyedHasher(keyMaterial, RATE_LIMIT_HASH_INFO);
+  cachedHasher = { keyMaterial, hasher };
+  return hasher;
+}
+
+/** Random key material for development, generated once per isolate. */
+let developmentHashKey: string | null = null;
+
+/**
+ * Key material for hashing rate-limit identifiers.
+ *
+ * Production reuses `PII_ENCRYPTION_KEY` through a distinct HKDF label. In
+ * development the secret is usually absent, and rather than fall back to an
+ * unkeyed hash - which would let anyone holding the database brute-force the
+ * IPv4 space back to plaintext addresses - a random per-isolate key is used.
+ * Counters then reset when the isolate does, which is acceptable locally and
+ * cannot happen in production because the secret is required there.
+ */
+function resolveHashKey(env: WorkerEnv): string {
+  if (env.PROVIDER_MODE === 'live') {
+    return requireSecret(env, 'PII_ENCRYPTION_KEY');
+  }
+
+  const configured = env['PII_ENCRYPTION_KEY'];
+  if (typeof configured === 'string' && configured.length >= 32) {
+    return configured;
+  }
+
+  developmentHashKey ??= `development-only-${crypto.randomUUID()}${crypto.randomUUID()}`;
+  return developmentHashKey;
+}
+
+export interface SecurityServices {
+  turnstile: TurnstileVerifier;
+  rateLimiter: RateLimiter;
+}
+
+export async function createSecurityServices(
+  env: WorkerEnv,
+  db: Repository,
+): Promise<SecurityServices> {
+  const turnstile =
+    env.PROVIDER_MODE === 'mock'
+      ? createMockTurnstileVerifier()
+      : createTurnstileVerifier(requireSecret(env, 'TURNSTILE_SECRET_KEY'));
+
+  return {
+    turnstile,
+    rateLimiter: createRateLimiter(db, await rateLimitHasher(env)),
+  };
+}
+
+/** Test seam: drops the cached derived key so a new secret takes effect. */
+export function resetSecurityCaches(): void {
+  cachedHasher = null;
+  developmentHashKey = null;
+}

--- a/src/worker/security/csrf.ts
+++ b/src/worker/security/csrf.ts
@@ -1,0 +1,127 @@
+import { timingSafeEqual } from '../lib/crypto';
+import { ApiError } from '../lib/http';
+
+/**
+ * CSRF protection for admin actions (Issue #1 section 57).
+ *
+ * Cloudflare Access authenticates the manager with a cookie, and a cookie is
+ * sent on cross-site requests too. Without this, any page the manager visits
+ * while signed in could POST to `/api/admin/applications/:id/nbtc-complete` and
+ * the request would carry a valid Access cookie.
+ *
+ * Two independent checks, because each covers a case the other misses:
+ *
+ * 1. **Origin check.** Browsers set `Origin` on state-changing requests and a
+ *    page cannot forge it. This alone stops the classic form-post attack.
+ * 2. **Double-submit token.** A random value is issued in a cookie and must be
+ *    echoed in a header. A cross-site page can cause the cookie to be sent but
+ *    cannot read it, so it cannot produce the header. This covers the case
+ *    where `Origin` is missing - some clients and older browsers - without
+ *    having to decide whether a missing header means "safe" or "attack".
+ *
+ * The comparison is constant time so a token cannot be guessed byte by byte.
+ */
+
+export const CSRF_COOKIE_NAME = 'vra_csrf';
+export const CSRF_HEADER_NAME = 'x-vra-csrf';
+
+const TOKEN_BYTE_LENGTH = 32;
+
+const MESSAGES = {
+  origin: 'คำขอนี้ถูกปฏิเสธเพราะไม่ได้มาจากหน้าเว็บของระบบ',
+  token: 'คำขอนี้หมดอายุหรือไม่ถูกต้อง กรุณาโหลดหน้าใหม่แล้วลองอีกครั้ง',
+} as const;
+
+/** Methods that can change state and therefore need protection. */
+const PROTECTED_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+export function isProtectedMethod(method: string): boolean {
+  return PROTECTED_METHODS.has(method.toUpperCase());
+}
+
+export function generateCsrfToken(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(TOKEN_BYTE_LENGTH));
+  return [...bytes].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * `Set-Cookie` value for the token.
+ *
+ * Deliberately readable by scripts: the browser has to echo it into a header,
+ * which is the whole mechanism. It is not a credential - it authorises nothing
+ * on its own - so `HttpOnly` would break the pattern without adding safety.
+ * `SameSite=Strict` means it is not even sent on a cross-site request.
+ */
+export function csrfCookie(token: string, options: { secure: boolean }): string {
+  const parts = [
+    `${CSRF_COOKIE_NAME}=${token}`,
+    'Path=/',
+    'SameSite=Strict',
+    `Max-Age=${60 * 60 * 8}`,
+  ];
+  if (options.secure) parts.push('Secure');
+  return parts.join('; ');
+}
+
+export function readCookie(request: Request, name: string): string | null {
+  const header = request.headers.get('cookie');
+  if (!header) return null;
+
+  for (const part of header.split(';')) {
+    const separator = part.indexOf('=');
+    if (separator === -1) continue;
+    if (part.slice(0, separator).trim() !== name) continue;
+    return part.slice(separator + 1).trim();
+  }
+  return null;
+}
+
+/**
+ * Rejects a state-changing request that did not come from the application.
+ *
+ * A missing `Origin` is treated as a failure rather than waved through: an
+ * admin action is always triggered from the app's own pages, so there is no
+ * legitimate caller without one.
+ */
+export function assertSameOrigin(request: Request, appBaseUrl: string): void {
+  if (!isProtectedMethod(request.method)) return;
+
+  const origin = request.headers.get('origin');
+  if (!origin) {
+    throw new ApiError('FORBIDDEN', MESSAGES.origin);
+  }
+
+  let expected: string;
+  let actual: string;
+  try {
+    expected = new URL(appBaseUrl).origin;
+    actual = new URL(origin).origin;
+  } catch {
+    throw new ApiError('FORBIDDEN', MESSAGES.origin);
+  }
+
+  if (expected !== actual) {
+    throw new ApiError('FORBIDDEN', MESSAGES.origin);
+  }
+}
+
+/** Rejects a state-changing request whose header and cookie tokens disagree. */
+export function assertCsrfToken(request: Request): void {
+  if (!isProtectedMethod(request.method)) return;
+
+  const cookieToken = readCookie(request, CSRF_COOKIE_NAME);
+  const headerToken = request.headers.get(CSRF_HEADER_NAME);
+
+  if (!cookieToken || !headerToken) {
+    throw new ApiError('FORBIDDEN', MESSAGES.token);
+  }
+  if (!timingSafeEqual(cookieToken, headerToken)) {
+    throw new ApiError('FORBIDDEN', MESSAGES.token);
+  }
+}
+
+/** Both checks, in the order that fails fastest. */
+export function assertCsrfProtected(request: Request, appBaseUrl: string): void {
+  assertSameOrigin(request, appBaseUrl);
+  assertCsrfToken(request);
+}

--- a/src/worker/security/index.ts
+++ b/src/worker/security/index.ts
@@ -1,0 +1,5 @@
+export * from './context';
+export * from './csrf';
+export * from './rate-limit';
+export * from './turnstile';
+export * from './validation';

--- a/src/worker/security/rate-limit.ts
+++ b/src/worker/security/rate-limit.ts
@@ -1,0 +1,117 @@
+import type { KeyedHasher } from '../lib/crypto';
+import { ApiError } from '../lib/http';
+import type { Repository } from '../db';
+
+/**
+ * Fixed-window rate limiting for the public endpoints that cost money
+ * (Issue #1 section 57).
+ *
+ * Counters live in D1 rather than in an isolate: a Worker runs in many isolates
+ * at once, so an in-memory counter limits nothing. At one or two applications a
+ * day the write volume is negligible.
+ *
+ * The stored bucket is a keyed hash of `<scope>:<identifier>`, so a client IP
+ * address never lands in the database in clear text.
+ *
+ * This is the application-level limit. It does not replace a Cloudflare
+ * rate-limiting rule at the edge, which is what stops traffic before it reaches
+ * the Worker at all - see docs/deployment.md.
+ */
+
+const MESSAGE = 'มีคำขอมากเกินไปในช่วงเวลาสั้น ๆ กรุณารอสักครู่แล้วลองอีกครั้ง';
+
+/** Windows kept beyond the current one before cleanup removes them. */
+const RETAINED_WINDOWS = 2;
+
+export interface RateLimitPolicy {
+  /** Names the counter, e.g. `ocr`. Part of the hashed bucket. */
+  scope: string;
+  /** Requests allowed per window. */
+  limit: number;
+  /** Window length in seconds. */
+  periodSeconds: number;
+}
+
+/** Sensible defaults for a service handling one or two applications a day. */
+export const OCR_POLICY: RateLimitPolicy = { scope: 'ocr', limit: 10, periodSeconds: 600 };
+export const PAYMENT_POLICY: RateLimitPolicy = { scope: 'payment', limit: 10, periodSeconds: 600 };
+export const PHOTO_POLICY: RateLimitPolicy = { scope: 'photo', limit: 20, periodSeconds: 600 };
+
+export interface RateLimitDecision {
+  allowed: boolean;
+  /** Requests used in the current window, including this one. */
+  used: number;
+  limit: number;
+  /** Unix seconds when the current window ends. */
+  resetAt: number;
+}
+
+export interface RateLimiter {
+  /** Counts one request against `policy` for `identifier`. */
+  consume(policy: RateLimitPolicy, identifier: string): Promise<RateLimitDecision>;
+}
+
+export interface RateLimiterOptions {
+  now?: () => Date;
+}
+
+export function createRateLimiter(
+  db: Repository,
+  hasher: KeyedHasher,
+  options: RateLimiterOptions = {},
+): RateLimiter {
+  const now = options.now ?? (() => new Date());
+
+  return {
+    async consume(policy, identifier) {
+      const seconds = Math.floor(now().getTime() / 1000);
+      const windowStart = Math.floor(seconds / policy.periodSeconds) * policy.periodSeconds;
+      const bucket = await hasher.hash(`${policy.scope}:${identifier}`);
+
+      const used = await db.rateLimits.increment({
+        bucket,
+        windowStart,
+        // Anything older than this cannot be consulted again, so it can go.
+        expireBefore: windowStart - policy.periodSeconds * RETAINED_WINDOWS,
+      });
+
+      return {
+        allowed: used <= policy.limit,
+        used,
+        limit: policy.limit,
+        resetAt: windowStart + policy.periodSeconds,
+      };
+    },
+  };
+}
+
+/**
+ * Identifies the caller for rate-limiting purposes.
+ *
+ * `CF-Connecting-IP` is set by Cloudflare and cannot be spoofed by the client
+ * on a request that actually arrived through the edge. When it is absent - only
+ * in local development - every caller shares one bucket, which is stricter
+ * rather than looser.
+ */
+export function clientIdentifier(request: Request): string {
+  return request.headers.get('cf-connecting-ip') ?? 'unknown-client';
+}
+
+/**
+ * Consumes one request and throws `ApiError` when the limit is exceeded.
+ *
+ * `Retry-After` is not included in the thrown error because the response body
+ * is built by the central handler; routes that want the header can read
+ * `resetAt` from `consume` directly.
+ */
+export async function assertWithinRateLimit(
+  limiter: RateLimiter,
+  policy: RateLimitPolicy,
+  identifier: string,
+): Promise<RateLimitDecision> {
+  const decision = await limiter.consume(policy, identifier);
+  if (!decision.allowed) {
+    throw new ApiError('RATE_LIMITED', MESSAGE);
+  }
+  return decision;
+}

--- a/src/worker/security/turnstile.ts
+++ b/src/worker/security/turnstile.ts
@@ -1,0 +1,134 @@
+import { ApiError } from '../lib/http';
+
+/**
+ * Cloudflare Turnstile verification (Issue #1 section 57).
+ *
+ * Every endpoint that costs money - OCR, slip verification, photo upload - is
+ * gated on a token that only a real browser session can produce, and the token
+ * is verified **before** the provider is called. Verifying afterwards would
+ * still let an attacker run up the bill.
+ *
+ * The site key is public and lives in the client bundle. The secret key never
+ * leaves the Worker.
+ *
+ * Verification is behind an interface for the same reason the providers are:
+ * automated tests must not call Cloudflare, and a test needs to be able to
+ * simulate a rejected token.
+ */
+
+const SITEVERIFY_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
+const VERIFY_TIMEOUT_MS = 5_000;
+
+const MESSAGES = {
+  missing: 'ไม่พบการยืนยันว่าคุณไม่ใช่บอท กรุณาลองใหม่อีกครั้ง',
+  failed: 'การยืนยันว่าคุณไม่ใช่บอทไม่สำเร็จ กรุณาลองใหม่อีกครั้ง',
+  unavailable: 'ไม่สามารถยืนยันคำขอได้ในขณะนี้ กรุณาลองใหม่อีกครั้ง',
+} as const;
+
+export type TurnstileOutcome =
+  | { ok: true }
+  /** The token was absent, malformed, expired, replayed or for another site. */
+  | { ok: false; reason: 'REJECTED' }
+  /** Cloudflare could not be reached or replied unusably. */
+  | { ok: false; reason: 'UNAVAILABLE' };
+
+export interface TurnstileVerifier {
+  readonly name: string;
+  verify(input: { token: string; remoteIp?: string | null }): Promise<TurnstileOutcome>;
+}
+
+/** Header the client uses to carry the token on non-form requests. */
+export const TURNSTILE_TOKEN_HEADER = 'cf-turnstile-response';
+
+export function createTurnstileVerifier(secretKey: string): TurnstileVerifier {
+  return {
+    name: 'turnstile',
+    async verify({ token, remoteIp }) {
+      if (token.length === 0) {
+        return { ok: false, reason: 'REJECTED' };
+      }
+
+      const body = new FormData();
+      body.append('secret', secretKey);
+      body.append('response', token);
+      if (remoteIp) body.append('remoteip', remoteIp);
+      // Cloudflare deduplicates by idempotency key, which is what makes a
+      // replayed token detectable on their side.
+      body.append('idempotency_key', crypto.randomUUID());
+
+      let response: Response;
+      try {
+        response = await fetch(SITEVERIFY_URL, {
+          method: 'POST',
+          body,
+          signal: AbortSignal.timeout(VERIFY_TIMEOUT_MS),
+        });
+      } catch {
+        return { ok: false, reason: 'UNAVAILABLE' };
+      }
+
+      if (!response.ok) {
+        return { ok: false, reason: 'UNAVAILABLE' };
+      }
+
+      let payload: unknown;
+      try {
+        payload = await response.json();
+      } catch {
+        return { ok: false, reason: 'UNAVAILABLE' };
+      }
+
+      // Only the boolean is read. Cloudflare's error codes and the hostname it
+      // echoes back are provider detail that must not reach a log or a client.
+      const success =
+        typeof payload === 'object' &&
+        payload !== null &&
+        (payload as { success?: unknown }).success;
+
+      return success === true ? { ok: true } : { ok: false, reason: 'REJECTED' };
+    },
+  };
+}
+
+export interface MockTurnstileOptions {
+  outcome?: TurnstileOutcome;
+}
+
+/** Accepts any non-empty token unless configured otherwise. */
+export function createMockTurnstileVerifier(options: MockTurnstileOptions = {}): TurnstileVerifier {
+  return {
+    name: 'mock-turnstile',
+    async verify({ token }) {
+      if (options.outcome) return options.outcome;
+      return token.length > 0 ? { ok: true } : { ok: false, reason: 'REJECTED' };
+    },
+  };
+}
+
+/**
+ * Verifies the token on a request, throwing `ApiError` when it does not pass.
+ *
+ * An unreachable Cloudflare is reported as `PROVIDER_UNAVAILABLE`, not as a
+ * rejection: failing closed is correct, but telling the applicant they look
+ * like a bot when the real problem is on our side is not.
+ */
+export async function assertHumanRequest(
+  verifier: TurnstileVerifier,
+  request: Request,
+): Promise<void> {
+  const token = request.headers.get(TURNSTILE_TOKEN_HEADER) ?? '';
+  if (token.length === 0) {
+    throw new ApiError('FORBIDDEN', MESSAGES.missing);
+  }
+
+  const outcome = await verifier.verify({
+    token,
+    remoteIp: request.headers.get('cf-connecting-ip'),
+  });
+
+  if (outcome.ok) return;
+  if (outcome.reason === 'UNAVAILABLE') {
+    throw new ApiError('PROVIDER_UNAVAILABLE', MESSAGES.unavailable);
+  }
+  throw new ApiError('FORBIDDEN', MESSAGES.failed);
+}

--- a/src/worker/security/validation.ts
+++ b/src/worker/security/validation.ts
@@ -1,0 +1,124 @@
+import type { z } from 'zod';
+import { ApiError } from '../lib/http';
+
+/**
+ * Request-body validation.
+ *
+ * Two properties matter beyond "is this the right shape":
+ *
+ * 1. **Unknown fields are rejected, not stripped.** A client that sends
+ *    `amount` alongside `membershipType` has misunderstood the contract, and
+ *    silently dropping the field hides that. Rejecting also means a future
+ *    field cannot be smuggled past a schema that has not been updated.
+ * 2. **No submitted value ever appears in the response.** Zod's default
+ *    messages quote what was received, and what was received here is a citizen
+ *    ID, an address or an email. Only the field path and a generic Thai message
+ *    per failure kind travel back to the client.
+ */
+
+/** Applicant-safe messages, keyed by the kind of failure. */
+const MESSAGE_BY_CODE: Record<string, string> = {
+  invalid_type: 'รูปแบบข้อมูลไม่ถูกต้อง',
+  too_small: 'ข้อมูลสั้นเกินกำหนด',
+  too_big: 'ข้อมูลยาวเกินกำหนด',
+  invalid_format: 'รูปแบบข้อมูลไม่ถูกต้อง',
+  invalid_value: 'ค่าที่เลือกไม่ถูกต้อง',
+  unrecognized_keys: 'มีข้อมูลที่ระบบไม่รู้จัก',
+  invalid_union: 'รูปแบบข้อมูลไม่ถูกต้อง',
+  custom: 'ข้อมูลไม่ถูกต้อง',
+};
+
+const FALLBACK_MESSAGE = 'ข้อมูลไม่ถูกต้อง';
+const BODY_MESSAGE = 'ข้อมูลที่ส่งมาไม่ถูกต้อง กรุณาตรวจสอบและลองอีกครั้ง';
+const JSON_MESSAGE = 'ไม่สามารถอ่านข้อมูลที่ส่งมาได้';
+
+export interface FieldError {
+  /** Dotted path of the offending field, e.g. `mailAddress.postcode`. */
+  field: string;
+  message: string;
+}
+
+/** Thrown when a body fails validation. Carries paths and messages only. */
+export class ValidationError extends ApiError {
+  readonly fields: readonly FieldError[];
+
+  constructor(fields: readonly FieldError[]) {
+    super('VALIDATION_FAILED', BODY_MESSAGE);
+    this.name = 'ValidationError';
+    this.fields = fields;
+  }
+}
+
+/** Maps zod issues to field errors, discarding every received value. */
+export function toFieldErrors(error: z.ZodError): FieldError[] {
+  const seen = new Set<string>();
+  const fields: FieldError[] = [];
+
+  for (const issue of error.issues) {
+    const field = issue.path.map(String).join('.') || '(body)';
+    if (seen.has(field)) continue;
+    seen.add(field);
+    fields.push({ field, message: MESSAGE_BY_CODE[issue.code] ?? FALLBACK_MESSAGE });
+  }
+
+  return fields;
+}
+
+/**
+ * Parses `value` against `schema`.
+ *
+ * The schema is expected to be strict about unknown keys; `parseBody` below
+ * enforces that for object schemas so a caller cannot forget.
+ */
+export function parseWithSchema<T>(schema: z.ZodType<T>, value: unknown): T {
+  const result = schema.safeParse(value);
+  if (!result.success) {
+    throw new ValidationError(toFieldErrors(result.error));
+  }
+  return result.data;
+}
+
+/**
+ * Reads a JSON body and validates it.
+ *
+ * A body that is not JSON at all fails with `BAD_REQUEST` rather than a
+ * validation error, because there is no field to point at.
+ */
+export async function parseJsonBody<T>(request: Request, schema: z.ZodType<T>): Promise<T> {
+  const contentType = request.headers.get('content-type') ?? '';
+  if (!contentType.toLowerCase().includes('application/json')) {
+    throw new ApiError('UNSUPPORTED_MEDIA_TYPE', JSON_MESSAGE);
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    // The parser error can quote the payload, so it is discarded.
+    throw new ApiError('BAD_REQUEST', JSON_MESSAGE);
+  }
+
+  return parseWithSchema(schema, body);
+}
+
+/** Response body for a validation failure. Contains field paths, never values. */
+export function validationErrorBody(
+  error: ValidationError,
+  requestId?: string,
+): {
+  error: {
+    code: 'VALIDATION_FAILED';
+    message: string;
+    fields: readonly FieldError[];
+    requestId?: string;
+  };
+} {
+  return {
+    error: {
+      code: 'VALIDATION_FAILED',
+      message: error.publicMessage,
+      fields: error.fields,
+      ...(requestId ? { requestId } : {}),
+    },
+  };
+}

--- a/tests/setup/storage.ts
+++ b/tests/setup/storage.ts
@@ -22,6 +22,7 @@ const testEnv = env as unknown as { TEST_MIGRATIONS: D1Migration[] };
 
 /** Child tables first: `delete` respects foreign keys when they are enforced. */
 const TABLES_IN_DELETION_ORDER = [
+  'rate_limits',
   'application_events',
   'emails',
   'receipts',

--- a/tests/unit/files.test.ts
+++ b/tests/unit/files.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+import { ApiError } from '../../src/worker/lib/http';
+import { readValidatedImage, sniffImageType, validateImageBytes } from '../../src/worker/lib/files';
+
+const JPEG = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46]);
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00]);
+
+function webp(): Uint8Array {
+  const bytes = new Uint8Array(16);
+  bytes.set([0x52, 0x49, 0x46, 0x46], 0); // "RIFF"
+  bytes.set([0x10, 0x00, 0x00, 0x00], 4); // size
+  bytes.set([0x57, 0x45, 0x42, 0x50], 8); // "WEBP"
+  return bytes;
+}
+
+/** A RIFF container that is not WebP: this is what a naive check would accept. */
+function riffWave(): Uint8Array {
+  const bytes = new Uint8Array(16);
+  bytes.set([0x52, 0x49, 0x46, 0x46], 0); // "RIFF"
+  bytes.set([0x57, 0x41, 0x56, 0x45], 8); // "WAVE"
+  return bytes;
+}
+
+const PDF = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34]);
+const SCRIPT = new TextEncoder().encode('#!/bin/sh\nrm -rf /\n');
+
+function streamRequest(chunks: Uint8Array[], headers: Record<string, string> = {}): Request {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      controller.close();
+    },
+  });
+  return new Request('http://localhost/api/ocr', {
+    method: 'POST',
+    body: stream,
+    headers,
+    // Required by the Fetch spec when the body is a stream.
+    duplex: 'half',
+  } as RequestInit);
+}
+
+describe('sniffImageType', () => {
+  it('recognises JPEG, PNG and WebP', () => {
+    expect(sniffImageType(JPEG)).toBe('image/jpeg');
+    expect(sniffImageType(PNG)).toBe('image/png');
+    expect(sniffImageType(webp())).toBe('image/webp');
+  });
+
+  it('rejects a RIFF container that is not WebP', () => {
+    expect(sniffImageType(riffWave())).toBeNull();
+  });
+
+  it('rejects a PDF and a shell script', () => {
+    expect(sniffImageType(PDF)).toBeNull();
+    expect(sniffImageType(SCRIPT)).toBeNull();
+  });
+
+  it('rejects an empty or truncated header', () => {
+    expect(sniffImageType(new Uint8Array())).toBeNull();
+    expect(sniffImageType(new Uint8Array([0xff, 0xd8]))).toBeNull();
+  });
+});
+
+describe('validateImageBytes', () => {
+  it('returns the sniffed type, not a declared one', () => {
+    expect(validateImageBytes(PNG, { maxBytes: 1000 })).toEqual({
+      bytes: PNG,
+      contentType: 'image/png',
+    });
+  });
+
+  it('rejects a file whose real type is not an allowed image', () => {
+    // A PDF renamed to .jpg is exactly the case the declared type would miss.
+    try {
+      validateImageBytes(PDF, { maxBytes: 1000 });
+      expect.unreachable('validateImageBytes should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ApiError);
+      expect((error as ApiError).code).toBe('UNSUPPORTED_MEDIA_TYPE');
+    }
+  });
+
+  it('rejects a supported image that the caller did not allow', () => {
+    try {
+      validateImageBytes(PNG, { maxBytes: 1000, allowedTypes: ['image/jpeg'] });
+      expect.unreachable('validateImageBytes should have thrown');
+    } catch (error) {
+      expect((error as ApiError).code).toBe('UNSUPPORTED_MEDIA_TYPE');
+    }
+  });
+
+  it('rejects a file over the limit', () => {
+    const large = new Uint8Array(200);
+    large.set(JPEG, 0);
+
+    try {
+      validateImageBytes(large, { maxBytes: 100 });
+      expect.unreachable('validateImageBytes should have thrown');
+    } catch (error) {
+      expect((error as ApiError).code).toBe('PAYLOAD_TOO_LARGE');
+    }
+  });
+
+  it('rejects an empty file', () => {
+    try {
+      validateImageBytes(new Uint8Array(), { maxBytes: 100 });
+      expect.unreachable('validateImageBytes should have thrown');
+    } catch (error) {
+      expect((error as ApiError).code).toBe('BAD_REQUEST');
+    }
+  });
+
+  it('never echoes file content in the message shown to the applicant', () => {
+    try {
+      validateImageBytes(SCRIPT, { maxBytes: 1000 });
+      expect.unreachable('validateImageBytes should have thrown');
+    } catch (error) {
+      expect((error as ApiError).publicMessage).not.toContain('rm -rf');
+    }
+  });
+});
+
+describe('readValidatedImage', () => {
+  it('reads a valid image from the body stream', async () => {
+    const request = streamRequest([JPEG]);
+
+    await expect(readValidatedImage(request, { maxBytes: 1000 })).resolves.toMatchObject({
+      contentType: 'image/jpeg',
+    });
+  });
+
+  it('reassembles a body that arrives in several chunks', async () => {
+    const request = streamRequest([JPEG.slice(0, 2), JPEG.slice(2)]);
+
+    const image = await readValidatedImage(request, { maxBytes: 1000 });
+    expect(image.contentType).toBe('image/jpeg');
+    expect(image.bytes).toEqual(JPEG);
+  });
+
+  it('rejects a body that exceeds the limit while streaming', async () => {
+    // Ten chunks of 100 bytes against a 500-byte limit: the read must stop
+    // rather than buffer the whole thing and measure afterwards.
+    const chunks = Array.from({ length: 10 }, () => new Uint8Array(100));
+    chunks[0]!.set(JPEG, 0);
+
+    await expect(readValidatedImage(streamRequest(chunks), { maxBytes: 500 })).rejects.toThrow(
+      ApiError,
+    );
+  });
+
+  it('rejects an oversized Content-Length before validating the bytes', async () => {
+    // The declared length is the cheap pre-check. It cannot be asserted by
+    // observing that the stream was never pulled, because the runtime consumes
+    // the body when the Request is constructed - so this asserts the outcome
+    // instead: a valid JPEG is still rejected, and rejected as too large rather
+    // than for its content.
+    const request = streamRequest([JPEG], { 'content-length': '999999999' });
+
+    const error = await readValidatedImage(request, { maxBytes: 500 }).catch(
+      (reason: unknown) => reason,
+    );
+    expect(error).toBeInstanceOf(ApiError);
+    expect((error as ApiError).code).toBe('PAYLOAD_TOO_LARGE');
+  });
+
+  it('does not trust a Content-Length that understates the real size', async () => {
+    const chunks = Array.from({ length: 10 }, () => new Uint8Array(100));
+    chunks[0]!.set(JPEG, 0);
+
+    // The header claims the body is small; the stream says otherwise, and the
+    // stream is what decides.
+    await expect(
+      readValidatedImage(streamRequest(chunks, { 'content-length': '10' }), { maxBytes: 500 }),
+    ).rejects.toThrow(ApiError);
+  });
+});

--- a/tests/unit/security.test.ts
+++ b/tests/unit/security.test.ts
@@ -1,0 +1,422 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { ApiError } from '../../src/worker/lib/http';
+import { timingSafeEqual } from '../../src/worker/lib/crypto';
+import {
+  assertCsrfProtected,
+  assertCsrfToken,
+  assertSameOrigin,
+  CSRF_COOKIE_NAME,
+  CSRF_HEADER_NAME,
+  csrfCookie,
+  generateCsrfToken,
+  readCookie,
+} from '../../src/worker/security/csrf';
+import {
+  assertHumanRequest,
+  createMockTurnstileVerifier,
+  TURNSTILE_TOKEN_HEADER,
+} from '../../src/worker/security/turnstile';
+import {
+  parseJsonBody,
+  parseWithSchema,
+  ValidationError,
+  validationErrorBody,
+} from '../../src/worker/security/validation';
+
+const APP_ORIGIN = 'https://member.vra.or.th';
+
+function post(headers: Record<string, string> = {}, body?: unknown): Request {
+  return new Request(`${APP_ORIGIN}/api/admin/applications/x/nbtc-complete`, {
+    method: 'POST',
+    headers: { origin: APP_ORIGIN, ...headers },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+}
+
+/* ------------------------------------------------------------- Turnstile --- */
+
+describe('assertHumanRequest', () => {
+  it('passes a request with a valid token', async () => {
+    const request = post({ [TURNSTILE_TOKEN_HEADER]: 'a-token' });
+
+    await expect(
+      assertHumanRequest(createMockTurnstileVerifier(), request),
+    ).resolves.toBeUndefined();
+  });
+
+  it('rejects a request with no token', async () => {
+    const error = await assertHumanRequest(createMockTurnstileVerifier(), post()).catch(
+      (reason: unknown) => reason,
+    );
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect((error as ApiError).code).toBe('FORBIDDEN');
+  });
+
+  it('rejects a token the verifier refuses', async () => {
+    const verifier = createMockTurnstileVerifier({
+      outcome: { ok: false, reason: 'REJECTED' },
+    });
+
+    const error = await assertHumanRequest(
+      verifier,
+      post({ [TURNSTILE_TOKEN_HEADER]: 'stale-token' }),
+    ).catch((reason: unknown) => reason);
+
+    expect((error as ApiError).code).toBe('FORBIDDEN');
+  });
+
+  it('distinguishes an unreachable verifier from a rejected token', async () => {
+    // Failing closed is right, but telling the applicant they look like a bot
+    // when Cloudflare is down would send them chasing the wrong problem.
+    const verifier = createMockTurnstileVerifier({
+      outcome: { ok: false, reason: 'UNAVAILABLE' },
+    });
+
+    const error = await assertHumanRequest(
+      verifier,
+      post({ [TURNSTILE_TOKEN_HEADER]: 'a-token' }),
+    ).catch((reason: unknown) => reason);
+
+    expect((error as ApiError).code).toBe('PROVIDER_UNAVAILABLE');
+  });
+
+  it('never reveals the token or provider detail in the message', async () => {
+    const verifier = createMockTurnstileVerifier({
+      outcome: { ok: false, reason: 'REJECTED' },
+    });
+    const token = 'secret-looking-token-value';
+
+    const error = await assertHumanRequest(
+      verifier,
+      post({ [TURNSTILE_TOKEN_HEADER]: token }),
+    ).catch((reason: unknown) => reason);
+
+    expect((error as ApiError).publicMessage).not.toContain(token);
+  });
+});
+
+/* ------------------------------------------------------------------ CSRF --- */
+
+describe('constant-time comparison', () => {
+  it('accepts equal values and rejects differing ones', () => {
+    expect(timingSafeEqual('abc', 'abc')).toBe(true);
+    expect(timingSafeEqual('abc', 'abd')).toBe(false);
+  });
+
+  it('rejects values of different lengths', () => {
+    expect(timingSafeEqual('abc', 'abcd')).toBe(false);
+  });
+
+  it('rejects a value that only shares a prefix', () => {
+    // The property that matters is that a partially correct guess is not
+    // treated as closer to correct.
+    expect(timingSafeEqual('token-aaaa', 'token-bbbb')).toBe(false);
+  });
+});
+
+describe('generateCsrfToken', () => {
+  it('produces a long random hex token', () => {
+    const token = generateCsrfToken();
+
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+    expect(generateCsrfToken()).not.toBe(token);
+  });
+});
+
+describe('csrfCookie', () => {
+  it('is scoped to the site and not sent cross-site', () => {
+    const cookie = csrfCookie('token-value', { secure: true });
+
+    expect(cookie).toContain(`${CSRF_COOKIE_NAME}=token-value`);
+    expect(cookie).toContain('SameSite=Strict');
+    expect(cookie).toContain('Secure');
+    // Readable by scripts on purpose: the browser has to echo it into a header,
+    // and the token authorises nothing by itself.
+    expect(cookie).not.toContain('HttpOnly');
+  });
+
+  it('omits Secure for local development over http', () => {
+    expect(csrfCookie('token-value', { secure: false })).not.toContain('Secure');
+  });
+});
+
+describe('readCookie', () => {
+  it('reads a cookie from a multi-value header', () => {
+    const request = new Request(APP_ORIGIN, {
+      headers: { cookie: `other=1; ${CSRF_COOKIE_NAME}=wanted; another=2` },
+    });
+
+    expect(readCookie(request, CSRF_COOKIE_NAME)).toBe('wanted');
+  });
+
+  it('does not match a cookie whose name merely ends with the target', () => {
+    const request = new Request(APP_ORIGIN, {
+      headers: { cookie: `not_${CSRF_COOKIE_NAME}=wrong` },
+    });
+
+    expect(readCookie(request, CSRF_COOKIE_NAME)).toBeNull();
+  });
+
+  it('returns null when there is no cookie header', () => {
+    expect(readCookie(new Request(APP_ORIGIN), CSRF_COOKIE_NAME)).toBeNull();
+  });
+});
+
+describe('assertSameOrigin', () => {
+  it('allows a request from the application origin', () => {
+    expect(() => assertSameOrigin(post(), APP_ORIGIN)).not.toThrow();
+  });
+
+  it('rejects a request from another origin', () => {
+    const request = new Request(`${APP_ORIGIN}/api/admin/x`, {
+      method: 'POST',
+      headers: { origin: 'https://evil.example' },
+    });
+
+    expect(() => assertSameOrigin(request, APP_ORIGIN)).toThrow(ApiError);
+  });
+
+  it('rejects a state-changing request with no Origin at all', () => {
+    // An admin action always comes from the app's own pages, so a missing
+    // Origin has no legitimate caller and is treated as a failure.
+    const request = new Request(`${APP_ORIGIN}/api/admin/x`, { method: 'POST' });
+
+    expect(() => assertSameOrigin(request, APP_ORIGIN)).toThrow(ApiError);
+  });
+
+  it('ignores safe methods', () => {
+    const request = new Request(`${APP_ORIGIN}/api/admin/x`, { method: 'GET' });
+
+    expect(() => assertSameOrigin(request, APP_ORIGIN)).not.toThrow();
+  });
+
+  it('compares origins, not full URLs', () => {
+    const request = new Request(`${APP_ORIGIN}/api/admin/x`, {
+      method: 'POST',
+      headers: { origin: `${APP_ORIGIN}` },
+    });
+
+    expect(() => assertSameOrigin(request, `${APP_ORIGIN}/apply`)).not.toThrow();
+  });
+});
+
+describe('assertCsrfToken', () => {
+  const token = 'a'.repeat(64);
+
+  it('accepts a matching cookie and header', () => {
+    const request = post({
+      cookie: `${CSRF_COOKIE_NAME}=${token}`,
+      [CSRF_HEADER_NAME]: token,
+    });
+
+    expect(() => assertCsrfToken(request)).not.toThrow();
+  });
+
+  it('rejects a request with the cookie but no header', () => {
+    // This is the cross-site case: the browser sends the cookie, but the
+    // attacking page cannot read it to produce the header.
+    const request = post({ cookie: `${CSRF_COOKIE_NAME}=${token}` });
+
+    expect(() => assertCsrfToken(request)).toThrow(ApiError);
+  });
+
+  it('rejects a request with the header but no cookie', () => {
+    const request = post({ [CSRF_HEADER_NAME]: token });
+
+    expect(() => assertCsrfToken(request)).toThrow(ApiError);
+  });
+
+  it('rejects mismatched values', () => {
+    const request = post({
+      cookie: `${CSRF_COOKIE_NAME}=${token}`,
+      [CSRF_HEADER_NAME]: 'b'.repeat(64),
+    });
+
+    expect(() => assertCsrfToken(request)).toThrow(ApiError);
+  });
+
+  it('ignores safe methods', () => {
+    const request = new Request(`${APP_ORIGIN}/api/admin/x`, { method: 'GET' });
+
+    expect(() => assertCsrfToken(request)).not.toThrow();
+  });
+});
+
+describe('assertCsrfProtected', () => {
+  const token = 'c'.repeat(64);
+
+  it('needs both the origin and the token to pass', () => {
+    const good = post({ cookie: `${CSRF_COOKIE_NAME}=${token}`, [CSRF_HEADER_NAME]: token });
+    expect(() => assertCsrfProtected(good, APP_ORIGIN)).not.toThrow();
+
+    const noToken = post();
+    expect(() => assertCsrfProtected(noToken, APP_ORIGIN)).toThrow(ApiError);
+
+    const badOrigin = new Request(`${APP_ORIGIN}/api/admin/x`, {
+      method: 'POST',
+      headers: {
+        origin: 'https://evil.example',
+        cookie: `${CSRF_COOKIE_NAME}=${token}`,
+        [CSRF_HEADER_NAME]: token,
+      },
+    });
+    expect(() => assertCsrfProtected(badOrigin, APP_ORIGIN)).toThrow(ApiError);
+  });
+});
+
+/* ------------------------------------------------------------ validation --- */
+
+const applicantSchema = z
+  .object({
+    membershipType: z.enum(['ANNUAL', 'LIFETIME']),
+    email: z.string().email(),
+    postcode: z.string().regex(/^\d{5}$/),
+  })
+  .strict();
+
+describe('parseWithSchema', () => {
+  it('returns the parsed value', () => {
+    expect(
+      parseWithSchema(applicantSchema, {
+        membershipType: 'ANNUAL',
+        email: 'member@example.test',
+        postcode: '10200',
+      }),
+    ).toEqual({
+      membershipType: 'ANNUAL',
+      email: 'member@example.test',
+      postcode: '10200',
+    });
+  });
+
+  it('rejects an unknown field rather than stripping it', () => {
+    // `amount` must never be accepted from a client, and silently dropping it
+    // would hide that the caller misunderstood the contract.
+    const error = (() => {
+      try {
+        parseWithSchema(applicantSchema, {
+          membershipType: 'ANNUAL',
+          email: 'member@example.test',
+          postcode: '10200',
+          amount: 1,
+        });
+        return null;
+      } catch (reason) {
+        return reason;
+      }
+    })();
+
+    expect(error).toBeInstanceOf(ValidationError);
+  });
+
+  it('reports the field path of each failure', () => {
+    const error = (() => {
+      try {
+        parseWithSchema(applicantSchema, {
+          membershipType: 'MONTHLY',
+          email: 'not-an-email',
+          postcode: 'abcde',
+        });
+        return null;
+      } catch (reason) {
+        return reason as ValidationError;
+      }
+    })()!;
+
+    expect(error.fields.map((field) => field.field).sort()).toEqual([
+      'email',
+      'membershipType',
+      'postcode',
+    ]);
+  });
+
+  it('never echoes a submitted value, which would leak personal data', () => {
+    const citizenId = '1234567890121';
+    const email = 'member@example.test';
+
+    const error = (() => {
+      try {
+        parseWithSchema(applicantSchema, {
+          membershipType: citizenId,
+          email,
+          postcode: citizenId,
+        });
+        return null;
+      } catch (reason) {
+        return reason as ValidationError;
+      }
+    })()!;
+
+    const serialised = JSON.stringify(validationErrorBody(error, 'req-1'));
+    expect(serialised).not.toContain(citizenId);
+    expect(serialised).not.toContain(email);
+  });
+
+  it('reports one error per field, not one per rule', () => {
+    const error = (() => {
+      try {
+        parseWithSchema(applicantSchema, { membershipType: 'ANNUAL', email: 1, postcode: 1 });
+        return null;
+      } catch (reason) {
+        return reason as ValidationError;
+      }
+    })()!;
+
+    expect(new Set(error.fields.map((field) => field.field)).size).toBe(error.fields.length);
+  });
+});
+
+describe('parseJsonBody', () => {
+  function jsonRequest(body: string, contentType = 'application/json'): Request {
+    return new Request(`${APP_ORIGIN}/api/applications`, {
+      method: 'POST',
+      headers: { 'content-type': contentType, origin: APP_ORIGIN },
+      body,
+    });
+  }
+
+  it('parses a valid body', async () => {
+    const request = jsonRequest(
+      JSON.stringify({
+        membershipType: 'LIFETIME',
+        email: 'member@example.test',
+        postcode: '10200',
+      }),
+    );
+
+    await expect(parseJsonBody(request, applicantSchema)).resolves.toMatchObject({
+      membershipType: 'LIFETIME',
+    });
+  });
+
+  it('rejects a non-JSON content type', async () => {
+    const request = jsonRequest('membershipType=ANNUAL', 'application/x-www-form-urlencoded');
+
+    const error = await parseJsonBody(request, applicantSchema).catch((reason: unknown) => reason);
+    expect((error as ApiError).code).toBe('UNSUPPORTED_MEDIA_TYPE');
+  });
+
+  it('rejects a malformed body without quoting it', async () => {
+    const malformed = '{"email": "member@example.test", broken';
+    const request = jsonRequest(malformed);
+
+    const error = await parseJsonBody(request, applicantSchema).catch((reason: unknown) => reason);
+    expect((error as ApiError).code).toBe('BAD_REQUEST');
+    expect((error as ApiError).publicMessage).not.toContain('member@example.test');
+  });
+
+  it('accepts a content type with a charset parameter', async () => {
+    const request = jsonRequest(
+      JSON.stringify({
+        membershipType: 'ANNUAL',
+        email: 'member@example.test',
+        postcode: '10200',
+      }),
+      'application/json; charset=utf-8',
+    );
+
+    await expect(parseJsonBody(request, applicantSchema)).resolves.toBeDefined();
+  });
+});

--- a/tests/worker/rate-limit.test.ts
+++ b/tests/worker/rate-limit.test.ts
@@ -1,0 +1,226 @@
+import { env } from 'cloudflare:workers';
+import { describe, expect, it } from 'vitest';
+import { createKeyedHasher } from '../../src/worker/lib/crypto';
+import { ApiError } from '../../src/worker/lib/http';
+import {
+  assertWithinRateLimit,
+  clientIdentifier,
+  createRateLimiter,
+} from '../../src/worker/security/rate-limit';
+import type { RateLimitPolicy } from '../../src/worker/security/rate-limit';
+import { repository, TEST_KEY } from '../support/fixtures';
+
+const POLICY: RateLimitPolicy = { scope: 'ocr', limit: 3, periodSeconds: 60 };
+
+async function limiter(now: () => Date = () => new Date('2026-08-20T10:00:00.000Z')) {
+  const hasher = await createKeyedHasher(TEST_KEY, 'vra:rate-limit:test');
+  return createRateLimiter(repository(), hasher, { now });
+}
+
+describe('createRateLimiter', () => {
+  it('allows requests up to the limit and refuses the next one', async () => {
+    const rateLimiter = await limiter();
+
+    for (let attempt = 1; attempt <= POLICY.limit; attempt += 1) {
+      const decision = await rateLimiter.consume(POLICY, '203.0.113.1');
+      expect(decision.allowed).toBe(true);
+      expect(decision.used).toBe(attempt);
+    }
+
+    const refused = await rateLimiter.consume(POLICY, '203.0.113.1');
+    expect(refused.allowed).toBe(false);
+    expect(refused.used).toBe(POLICY.limit + 1);
+  });
+
+  it('counts each identifier separately', async () => {
+    const rateLimiter = await limiter();
+
+    for (let attempt = 0; attempt < POLICY.limit; attempt += 1) {
+      await rateLimiter.consume(POLICY, '203.0.113.1');
+    }
+
+    await expect(rateLimiter.consume(POLICY, '203.0.113.2')).resolves.toMatchObject({
+      allowed: true,
+      used: 1,
+    });
+  });
+
+  it('counts each scope separately', async () => {
+    const rateLimiter = await limiter();
+
+    for (let attempt = 0; attempt < POLICY.limit; attempt += 1) {
+      await rateLimiter.consume(POLICY, '203.0.113.1');
+    }
+
+    await expect(
+      rateLimiter.consume({ ...POLICY, scope: 'payment' }, '203.0.113.1'),
+    ).resolves.toMatchObject({ allowed: true, used: 1 });
+  });
+
+  it('starts a fresh window when the period rolls over', async () => {
+    let now = new Date('2026-08-20T10:00:00.000Z');
+    const rateLimiter = await limiter(() => now);
+
+    for (let attempt = 0; attempt < POLICY.limit; attempt += 1) {
+      await rateLimiter.consume(POLICY, '203.0.113.1');
+    }
+    await expect(rateLimiter.consume(POLICY, '203.0.113.1')).resolves.toMatchObject({
+      allowed: false,
+    });
+
+    now = new Date('2026-08-20T10:01:00.000Z');
+    await expect(rateLimiter.consume(POLICY, '203.0.113.1')).resolves.toMatchObject({
+      allowed: true,
+      used: 1,
+    });
+  });
+
+  it('keeps counting within the same window regardless of position in it', async () => {
+    let now = new Date('2026-08-20T10:00:05.000Z');
+    const rateLimiter = await limiter(() => now);
+
+    await rateLimiter.consume(POLICY, '203.0.113.1');
+    now = new Date('2026-08-20T10:00:59.000Z');
+
+    await expect(rateLimiter.consume(POLICY, '203.0.113.1')).resolves.toMatchObject({ used: 2 });
+  });
+
+  it('reports when the window resets', async () => {
+    const rateLimiter = await limiter(() => new Date('2026-08-20T10:00:30.000Z'));
+
+    const decision = await rateLimiter.consume(POLICY, '203.0.113.1');
+    expect(decision.resetAt).toBe(
+      Math.floor(new Date('2026-08-20T10:01:00.000Z').getTime() / 1000),
+    );
+  });
+
+  it('counts concurrent requests without losing any', async () => {
+    // A read-then-write counter would let several requests read the same value
+    // and write back the same total, so the limit would never be reached.
+    const rateLimiter = await limiter();
+
+    const decisions = await Promise.all(
+      Array.from({ length: 10 }, () => rateLimiter.consume(POLICY, '203.0.113.9')),
+    );
+
+    expect(decisions.map((decision) => decision.used).sort((a, b) => a - b)).toEqual([
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+    ]);
+    expect(decisions.filter((decision) => decision.allowed)).toHaveLength(POLICY.limit);
+  });
+
+  it('deletes windows that can no longer be consulted', async () => {
+    let now = new Date('2026-08-20T10:00:00.000Z');
+    const rateLimiter = await limiter(() => now);
+    await rateLimiter.consume(POLICY, '203.0.113.1');
+
+    // Three periods later, the first window is beyond the retained range.
+    now = new Date('2026-08-20T10:03:00.000Z');
+    await rateLimiter.consume(POLICY, '203.0.113.1');
+
+    const { results } = await env.DB.prepare('select count(*) as rows from rate_limits').all<{
+      rows: number;
+    }>();
+    expect(results[0]!.rows).toBe(1);
+  });
+});
+
+describe('privacy of the stored bucket', () => {
+  it('never stores the identifier in clear text', async () => {
+    const address = '203.0.113.44';
+    const rateLimiter = await limiter();
+
+    await rateLimiter.consume(POLICY, address);
+
+    const { results } = await env.DB.prepare('select bucket from rate_limits').all<{
+      bucket: string;
+    }>();
+    expect(results).toHaveLength(1);
+    // A client IP is personal data; a counter only ever needs a hash of it.
+    expect(results[0]!.bucket).not.toContain(address);
+    expect(results[0]!.bucket).not.toContain('ocr');
+  });
+
+  it('produces a different bucket under a different key', async () => {
+    const first = createRateLimiter(
+      repository(),
+      await createKeyedHasher(TEST_KEY, 'vra:rate-limit:test'),
+      {},
+    );
+    const second = createRateLimiter(
+      repository(),
+      await createKeyedHasher(`${TEST_KEY}-other`, 'vra:rate-limit:test'),
+      {},
+    );
+
+    await first.consume(POLICY, '203.0.113.1');
+    await second.consume(POLICY, '203.0.113.1');
+
+    const { results } = await env.DB.prepare(
+      'select count(distinct bucket) as buckets from rate_limits',
+    ).all<{ buckets: number }>();
+    expect(results[0]!.buckets).toBe(2);
+  });
+});
+
+describe('clientIdentifier', () => {
+  it('uses the Cloudflare-supplied client address', () => {
+    const request = new Request('http://localhost/api/ocr', {
+      headers: { 'cf-connecting-ip': '203.0.113.7' },
+    });
+
+    expect(clientIdentifier(request)).toBe('203.0.113.7');
+  });
+
+  it('falls back to a single shared bucket when the header is absent', () => {
+    // Sharing one bucket is stricter than letting an unidentified caller
+    // through, which is the right way to fail.
+    expect(clientIdentifier(new Request('http://localhost/api/ocr'))).toBe('unknown-client');
+  });
+
+  it('ignores a client-supplied X-Forwarded-For', () => {
+    // Only CF-Connecting-IP is set by the edge; trusting a header the client
+    // controls would make the limit trivially bypassable.
+    const request = new Request('http://localhost/api/ocr', {
+      headers: { 'x-forwarded-for': '203.0.113.99' },
+    });
+
+    expect(clientIdentifier(request)).toBe('unknown-client');
+  });
+});
+
+describe('assertWithinRateLimit', () => {
+  it('returns the decision while under the limit', async () => {
+    const rateLimiter = await limiter();
+
+    await expect(assertWithinRateLimit(rateLimiter, POLICY, '203.0.113.1')).resolves.toMatchObject({
+      allowed: true,
+    });
+  });
+
+  it('throws RATE_LIMITED once over the limit', async () => {
+    const rateLimiter = await limiter();
+    for (let attempt = 0; attempt < POLICY.limit; attempt += 1) {
+      await rateLimiter.consume(POLICY, '203.0.113.1');
+    }
+
+    const error = await assertWithinRateLimit(rateLimiter, POLICY, '203.0.113.1').catch(
+      (reason: unknown) => reason,
+    );
+    expect(error).toBeInstanceOf(ApiError);
+    expect((error as ApiError).code).toBe('RATE_LIMITED');
+  });
+
+  it('does not reveal the identifier in the message', async () => {
+    const address = '203.0.113.55';
+    const rateLimiter = await limiter();
+    for (let attempt = 0; attempt < POLICY.limit; attempt += 1) {
+      await rateLimiter.consume(POLICY, address);
+    }
+
+    const error = await assertWithinRateLimit(rateLimiter, POLICY, address).catch(
+      (reason: unknown) => reason,
+    );
+    expect((error as ApiError).publicMessage).not.toContain(address);
+  });
+});


### PR DESCRIPTION
## Linked Issue

Closes #8

## Outcome

Endpoint สาธารณะที่มีค่าใช้จ่ายทุกตัวมี control ชุดเดียวกันคุมอยู่ก่อนถึง business logic และ admin action ที่เปลี่ยนสถานะมี CSRF protection สร้างเป็น layer เดียวเพื่อไม่ให้แต่ละ endpoint ไป implement เองแล้วได้ control ที่ไม่สอดคล้องกัน

## Scope

- Changed:
  - `src/worker/security/turnstile.ts` (ใหม่) — interface + live adapter + mock + `assertHumanRequest`
  - `src/worker/security/rate-limit.ts` (ใหม่) — fixed-window counter, policy ต่อ scope, `clientIdentifier`, `assertWithinRateLimit`
  - `src/worker/security/csrf.ts` (ใหม่) — origin check, double-submit token, cookie helper, constant-time compare
  - `src/worker/security/validation.ts` (ใหม่) — strict zod parsing, field-path error mapping, `parseJsonBody`
  - `src/worker/security/context.ts` (ใหม่) — ประกอบ service ต่อ request และ cache derived key ต่อ isolate
  - `src/worker/lib/files.ts` (ใหม่) — magic-byte sniffing, size-limited stream read
  - `src/worker/lib/crypto.ts` — เพิ่ม `createKeyedHasher` และ `timingSafeEqual` แยก `importMaster` ออกมาใช้ร่วมกัน
  - `src/worker/db/repository.ts` — เพิ่ม `rateLimits.increment`
  - `src/worker/context.ts`, `src/worker/index.ts` — เพิ่ม `security` เข้า request context และ map `ValidationError` เป็น response ที่มี field path
  - `migrations/0002_create_rate_limits.sql` (ใหม่)
  - `tests/unit/security.test.ts`, `tests/unit/files.test.ts`, `tests/worker/rate-limit.test.ts` (ใหม่ทั้งหมด)
  - `tests/setup/storage.ts` — ล้าง `rate_limits` ก่อนทุก test
  - `eslint.config.mjs` — ยกเว้น `require-await` ให้ mock verifier
  - `.env.example`, `docs/deployment.md`, `docs/architecture.md` — `TURNSTILE_SECRET_KEY` และ edge rate limiting rule

- Explicitly not changed:
  - ยังไม่มี endpoint ที่ใช้ control เหล่านี้ (`/api/ocr`, `/api/payment/verify`, `/api/member-photo`, admin routes มาใน #9, #10, #11, #16)
  - endpoint แจก CSRF token เป็นของ #16 ที่สร้าง admin routes — PR นี้ให้ helper และ middleware พร้อม test ไว้
  - ไม่แตะ state machine, numbering หรือ provider ของธุรกิจ

## Decisions worth reviewing

**1. Rate limit counter อยู่ใน D1 ไม่ใช่ในหน่วยความจำ**

Worker หนึ่งตัวรันหลาย isolate พร้อมกัน counter ในหน่วยความจำจึงไม่จำกัดอะไรเลย ทางเลือกอื่นคือ Cloudflare Rate Limiting binding (mock ใน miniflare ได้ไม่ครบ ทำให้ test ไม่ครอบจริง) หรือ Durable Object (เพิ่ม infrastructure เกินความจำเป็นสำหรับ 1-2 ใบสมัครต่อวัน) จึงเลือก D1 ซึ่ง test ได้จริงใน workerd และไม่เพิ่ม infrastructure

`insert ... on conflict do update set count = count + 1 returning count` เป็น statement เดียว จึงไม่มีช่องให้หลาย request อ่านค่าเดิมแล้วเขียนค่าเดียวกันกลับ — ถ้าใช้ read-then-write เพดานจะไม่ถูกแตะเลย มี test ที่ยิงพร้อมกัน 10 ครั้งแล้วยืนยันว่าได้ค่า 1 ถึง 10 ครบ

ข้อจำกัดที่ระบุไว้ในเอกสาร: rate limit ชั้นนี้ไม่แทน Cloudflare rate limiting rule ที่ edge เพราะ rule ที่ edge หยุด traffic ก่อนถึง Worker จึงกันทั้งค่า invocation และค่า D1 write ที่ counter ใช้ `docs/deployment.md` เพิ่มขั้นตอนตั้ง rule ให้แล้ว

**2. Bucket เก็บเป็น keyed hash ไม่ใช่ IP**

IP ของ client เป็นข้อมูลส่วนบุคคล และ counter ต้องการแค่ hash HKDF แยก subkey จาก `PII_ENCRYPTION_KEY` ด้วย label `vra:rate-limit:v1` จึงไม่แชร์ key material กับการเข้ารหัสเลขบัตร มี test ที่อ่าน column `bucket` จาก database จริงแล้วยืนยันว่าไม่มีทั้ง IP และชื่อ scope อยู่ในนั้น

ใน development ที่ไม่มี secret ระบบใช้ key สุ่มต่อ isolate แทนการ hash แบบไม่มี key เพราะ hash ที่ไม่มี key ทำให้ใครที่มี database ไล่ IPv4 ทั้งหมดกลับเป็น IP ได้ ผลข้างเคียงคือ counter รีเซ็ตเมื่อ isolate รีสตาร์ท ซึ่งรับได้ในเครื่อง และเกิดใน production ไม่ได้เพราะ production บังคับให้มี secret

**3. ชนิดไฟล์ตัดสินจาก magic bytes เท่านั้น**

`Content-Type` และชื่อไฟล์มาจาก client ทั้งคู่ WebP ต้องตรวจสองจุดเพราะ `RIFF` เป็น container ที่ AVI และ WAV ก็ใช้ มี test ที่ส่ง RIFF/WAVE เข้าไปแล้วยืนยันว่าถูกปฏิเสธ ซึ่งเป็นเคสที่การตรวจ `RIFF` อย่างเดียวจะปล่อยผ่าน

**4. ขนาดไฟล์ถูกบังคับระหว่างอ่าน stream**

อ่านทีละ chunk พร้อมนับ และทิ้งทันทีที่เกิน จึงไม่เคยถือข้อมูลเกินเพดานไว้ในหน่วยความจำ `Content-Length` ใช้เป็นการปฏิเสธแบบเร็วเท่านั้น เพราะเป็นค่าที่ client ควบคุมได้ มี test ที่ส่ง `content-length: 10` มากับ body 1000 bytes แล้วยืนยันว่ายังถูกปฏิเสธ

**5. Field ที่ไม่รู้จักถูกปฏิเสธ ไม่ใช่ถูกตัดออก**

`amount` ที่ client ส่งมาต้องไม่ถูกยอมรับ และการตัดออกเงียบ ๆ ปิดบังว่า caller เข้าใจ contract ผิด การปฏิเสธยังทำให้ field ใหม่แอบผ่าน schema ที่ยังไม่อัปเดตไม่ได้

**6. Error ของ validation ตอบเฉพาะ path ของ field**

ข้อความของ zod อ้างค่าที่ได้รับ และค่าที่ได้รับที่นี่คือเลขบัตร ที่อยู่ email มี test ที่ส่งเลขบัตรและ email เข้าไปเป็นค่าที่ผิด แล้ว serialize response body ทั้งก้อนเพื่อยืนยันว่าไม่มีค่าเหล่านั้นอยู่

**7. CSRF ใช้สองชั้นที่ไม่พึ่งกัน**

Cloudflare Access ยืนยันตัวตนด้วย cookie และ cookie ถูกส่งไปกับ cross-site request ด้วย ถ้าไม่มี control นี้ หน้าเว็บใดก็ตามที่ผู้จัดการเปิดขณะ sign in อยู่ จะ POST ไป `/api/admin/applications/:id/nbtc-complete` ได้โดยมี Access cookie ติดไปด้วย

- Origin check กัน form post ข้าม site ได้ตรง ๆ และ browser ปลอม `Origin` ไม่ได้ กรณีไม่มี `Origin` เลยถือว่าไม่ผ่าน เพราะ admin action มาจากหน้าเว็บของระบบเสมอ
- Double-submit token ครอบกรณีที่ `Origin` ขาด หน้าเว็บข้าม site ทำให้ cookie ถูกส่งได้แต่อ่านค่าไม่ได้ จึงสร้าง header ไม่ได้

Cookie ไม่ตั้ง `HttpOnly` โดยเจตนา เพราะกลไกคือให้ browser echo ค่าลง header และ token นี้ไม่ได้ authorize อะไรด้วยตัวเอง ส่วน `SameSite=Strict` ทำให้ไม่ถูกส่งไปกับ cross-site request อยู่แล้ว การเทียบใช้ constant time เพื่อไม่ให้เดา token ทีละไบต์ได้

**8. Turnstile ตรวจก่อนเรียก provider**

ถ้าตรวจทีหลัง attacker ยังทำให้เกิดค่าใช้จ่ายกับ iApp/SlipOK ได้ และแยก `UNAVAILABLE` ออกจาก `REJECTED` เพราะการบอกผู้สมัครว่า "คุณดูเหมือนบอท" ตอนที่ Cloudflare ล่ม จะทำให้เขาไปแก้ปัญหาผิดจุด

## Verification

| Command / check | Result |
| --- | --- |
| `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\scripts\validate-repository.ps1` | pass — 86 tracked files |
| `npm run lint` | pass |
| `npm run format:check` | pass |
| `npm run typecheck` | pass |
| `npm test` | pass — 15 files / 257 tests (เพิ่มจาก 192) |
| `npm run build` | pass |
| `npm run check:worker:production` | pass |
| `npx wrangler d1 migrations apply DB --env="" --local` | pass — `0002_create_rate_limits.sql`, 3 commands |

หมายเหตุเรื่อง test ที่ต้องแก้: เขียน test ว่า "ปฏิเสธ `Content-Length` ที่ใหญ่เกินโดยไม่อ่าน body" ด้วยการตรวจว่า stream ไม่ถูก pull แต่ workerd อ่าน body ตอนสร้าง `Request` เอง ทำให้ assertion นั้นวัดพฤติกรรมของ runtime ไม่ใช่ของโค้ด จึงเปลี่ยนไป assert ผลลัพธ์ที่สังเกตได้จริงคือ JPEG ที่ถูกต้องยังถูกปฏิเสธด้วย `PAYLOAD_TOO_LARGE` และเขียน comment กำกับเหตุผลไว้

## Security and privacy

- [x] No secrets, real PII, ID-card images, payment-slip images, or raw provider responses are included.
- [x] Logs contain only allowlisted technical metadata.
- [x] Tests use synthetic data and mocked providers.
- [x] Authentication, authorization, payment, webhook, retention, migration, and deployment impact is described below.

Impact and mitigations:

- **Abuse and cost** — Turnstile + rate limit เป็น control ที่กันค่าใช้จ่ายของ iApp และ SlipOK ทั้งคู่ทำงานก่อน provider ถูกเรียก
- **IP address ไม่ถูกเก็บ** — bucket เป็น keyed hash มี test ยืนยันจาก database จริง ตาราง `rate_limits` ไม่มี column ใดเก็บ identifier ตรง ๆ และแถวเก่าถูกลบอัตโนมัติเมื่อพ้นช่วงที่ยังต้องใช้
- **Secrets** — `TURNSTILE_SECRET_KEY` อยู่ฝั่ง server เท่านั้น site key เป็นค่าสาธารณะที่อยู่ใน client bundle ตามการออกแบบของ Turnstile `PROVIDER_MODE=live` บังคับให้มี secret แทนที่จะ fallback ไป mock
- **Error surface** — ไม่มี error ใดจาก layer นี้ที่เปิดเผย token, ชื่อไฟล์ที่ผู้ใช้ตั้ง, เนื้อไฟล์, IP หรือค่าที่กรอกในฟอร์ม มี test คุมทุกข้อ
- **Logging** — `ValidationError` ถูก log เป็น error code กับ *จำนวน* field ที่ผิด ไม่ใช่ชื่อ field และไม่ใช่ค่า
- **CSRF** — ครอบเฉพาะ method ที่เปลี่ยนสถานะ `GET` ไม่ถูกบล็อก ซึ่งสอดคล้องกับข้อกำหนดใน Issue #1 หัวข้อ 37 ที่ว่า `GET` ต้องไม่เปลี่ยนสถานะอยู่แล้ว
- **Timing** — การเทียบ token ใช้ `timingSafeEqual` เทียบความยาวก่อน (ไม่ใช่ความลับ) แล้ววนครบความยาวเสมอ
- **High risk** — เป็น control หลักที่กัน abuse และค่าใช้จ่าย ขอ human review ตาม `AGENTS.md`

## Deployment / migration / rollback

**Migration:** `0002_create_rate_limits.sql` สร้างตารางใหม่หนึ่งตาราง ไม่แตะตารางเดิม จึง backward compatible กับ Worker รุ่นก่อนหน้าโดยสมบูรณ์ rollback ของ code ทำได้โดยไม่ต้องแตะ schema

**Forward-fix path:** ถ้าต้องเปลี่ยนโครงสร้าง counter ให้เพิ่ม migration ใหม่ ข้อมูลในตารางนี้เป็นของใช้แล้วทิ้ง (แถวเก่าถูกลบเองอยู่แล้ว) จึงลบและสร้างใหม่ได้โดยไม่กระทบข้อมูลสมาชิก

**ต้องทำก่อน production:** ตั้ง `TURNSTILE_SECRET_KEY` เป็น Cloudflare Secret และเพิ่ม Cloudflare rate limiting rule ที่ edge สำหรับ `/api/ocr`, `/api/payment/verify`, `/api/member-photo` — เพิ่มเข้าไปใน checklist ของ `docs/deployment.md` แล้ว

## UI evidence

Not applicable — PR นี้ไม่มีส่วน UI ฝั่ง client จะต้องแสดง Turnstile widget และส่ง token/CSRF header ซึ่งเป็นงานของ #17 และ #18

## Human / AI handoff

- **Completed:** Turnstile (interface + live + mock + assert), rate limiting (migration + repository + service + assert), CSRF (origin + double-submit + constant-time), strict body validation ที่ไม่ echo ค่า, file validation ด้วย magic bytes และ size limit ระหว่างอ่าน, การเชื่อมทั้งหมดเข้า request context, test 65 เคสใหม่ (รวมทั้ง suite 257), เอกสารลำดับ control และเหตุผล
- **Remaining:** #9 (iApp OCR + `POST /api/ocr`) เป็น endpoint แรกที่ใช้ layer นี้จริง ตามด้วย #10 และ #11
- **Changed paths:** ตามหัวข้อ Scope
- **Risks / assumptions:**
  - ค่าเริ่มต้นของ policy (OCR 10 ครั้ง/10 นาที, payment 10/10 นาที, photo 20/10 นาที) ตั้งจากสมมติฐานว่าผู้สมัครหนึ่งคนอาจถ่ายบัตรใหม่หลายครั้ง ถ้าใช้จริงแล้วพบว่าตึงหรือหลวมเกินไป ปรับได้ที่ค่าคงที่ใน `rate-limit.ts` โดยไม่ต้องแก้ schema
  - สมมติว่า `CF-Connecting-IP` มีอยู่จริงบน production ถ้าไม่มี ทุก caller จะแชร์ bucket เดียว ซึ่งเข้มกว่าปล่อยผ่าน แต่จะทำให้ผู้ใช้จริงกระทบกัน ควรตรวจข้อนี้ตอน smoke test ใน #19
  - Double-submit token ป้องกัน CSRF ได้ แต่ไม่ป้องกัน XSS ถ้ามี XSS ในหน้า admin ผู้โจมตีอ่าน cookie ได้ การป้องกัน XSS มาจาก CSP ซึ่งยังไม่มีใน PR นี้ — ควรเป็น issue แยกก่อน go-live
  - ยังไม่มี Content-Security-Policy header เลย จะบันทึกเป็น issue ใหม่
- **Next safe action:** merge PR นี้ แล้วเปิด issue เรื่อง CSP/security headers และเริ่ม #9
