### PR TITLE
chore: provision Cloudflare resources and commit the real D1 database ids

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -16,20 +16,15 @@ Pipeline ประกอบด้วยสาม workflow
 
 ขั้นตอนเหล่านี้ต้องทำโดยผู้ดูแลที่มีสิทธิ์ในบัญชี Cloudflare และ repository ไม่สามารถทำจาก CI ได้
 
-1. สร้าง D1 database สองชุด
+1. ~~สร้าง D1 database สองชุด~~ **เสร็จแล้ว** `vra-membership-dev` และ `vra-membership-prod` ถูกสร้างและ `database_id` อยู่ใน `wrangler.jsonc` แล้ว
+
+2. ~~สร้าง R2 bucket แบบ private สองชุด~~ **เสร็จแล้ว** `vra-member-private-dev` และ `vra-member-private` ถูกสร้างแล้ว ตรวจยืนยันว่า public access ผ่าน `r2.dev` ปิดอยู่และไม่มี custom domain ผูกไว้
+
+   ตรวจซ้ำได้ด้วย
 
    ```bash
-   npx wrangler d1 create vra-membership-dev
-   npx wrangler d1 create vra-membership-prod
-   ```
-
-   นำ `database_id` ที่ได้ไปแทน placeholder `00000000-0000-0000-0000-000000000000` ใน `wrangler.jsonc` (ค่านี้ไม่ใช่ความลับ)
-
-2. สร้าง R2 bucket แบบ private สองชุด และตรวจว่าไม่มี public access หรือ custom domain
-
-   ```bash
-   npx wrangler r2 bucket create vra-member-private-dev
-   npx wrangler r2 bucket create vra-member-private
+   npx wrangler r2 bucket dev-url get vra-member-private
+   npx wrangler r2 bucket domain list vra-member-private
    ```
 
 3. ผูก custom domain `member.vra.or.th` เข้ากับ Worker `vra-membership`

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -6,8 +6,9 @@
  *   keys, bank account details, or any personal data.
  * - Secrets live in Cloudflare Secrets (`wrangler secret put <NAME>`) and, for
  *   local development, in the git-ignored `.dev.vars` file. See `.env.example`.
- * - Resource identifiers below are placeholders until the Cloudflare account
- *   owner provisions the real D1 database and R2 buckets. See docs/deployment.md.
+ * - The D1 `database_id` values below are real but are not secrets: they only
+ *   identify a database, and access still requires an authenticated token.
+ *   Committing them is what makes a clean checkout deployable.
  */
 {
   "$schema": "./node_modules/wrangler/config-schema.json",
@@ -35,7 +36,7 @@
     {
       "binding": "DB",
       "database_name": "vra-membership-dev",
-      "database_id": "00000000-0000-0000-0000-000000000000",
+      "database_id": "73c5ef46-3923-4216-b2cd-874655d008c8",
       "migrations_dir": "migrations"
     }
   ],
@@ -63,7 +64,7 @@
         {
           "binding": "DB",
           "database_name": "vra-membership-prod",
-          "database_id": "00000000-0000-0000-0000-000000000000",
+          "database_id": "cc6ace9f-77af-41a0-833b-55ec8595e2a7",
           "migrations_dir": "migrations"
         }
       ],


### PR DESCRIPTION
## Linked Issue

Refs #3

Not `Closes` yet: the remaining items on #3 are environment secrets and the `CLOUDFLARE_DEPLOY_ENABLED` variable, which need values only the account owner can supply.

## Outcome

The Cloudflare resources exist, so `wrangler.jsonc` carries real identifiers instead of placeholders and a clean checkout is deployable without hand-editing the config.

## What was provisioned

| Resource | Name | Identifier / note |
| --- | --- | --- |
| D1 | `vra-membership-dev` | `73c5ef46-3923-4216-b2cd-874655d008c8` |
| D1 | `vra-membership-prod` | `cc6ace9f-77af-41a0-833b-55ec8595e2a7` |
| R2 | `vra-member-private-dev` | private, APAC |
| R2 | `vra-member-private` | private, APAC |

## Scope

- Changed:
  - `wrangler.jsonc` — real `database_id` for both environments, and the header comment now explains why these values are committed rather than calling them placeholders
  - `docs/deployment.md` — steps 1 and 2 marked done, with the commands to re-verify that the buckets are not publicly reachable

- Explicitly not changed:
  - No secrets were set. `IAPP_API_KEY`, `SLIPOK_API_KEY`, `RESEND_API_KEY`, `RESEND_WEBHOOK_SECRET`, `PII_ENCRYPTION_KEY`, `TURNSTILE_SECRET_KEY`, `MANAGER_EMAIL`, `EMAIL_FROM` and the bank details remain unset, as do `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`
  - No custom domain was attached to the Worker
  - Production migrations were not applied; that stays the deployment workflow's job
  - `src/worker/providers/iapp/` is in progress for #9 and is deliberately not part of this PR

## Why the database ids are committed

A `database_id` identifies a database; it authorises nothing. Reading or writing still requires an authenticated Cloudflare token. Keeping the ids in the repository is what makes `wrangler deploy` reproducible from a clean checkout, which is one of the acceptance criteria on #3. The file comment previously described them as placeholders to be replaced locally, which would have meant every deploy depended on an uncommitted edit.

## Verification

| Command / check | Result |
| --- | --- |
| `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\scripts\validate-repository.ps1` | pass — 97 tracked files |
| `npm run cf-typegen` | pass — no change to the generated bindings |
| `npm run lint` | pass |
| `npm run format:check` | pass |
| `npm run typecheck` | pass |
| `npm test` | pass — 15 files / 257 tests |
| `npm run build` | pass |
| `npm run check:worker:production` | pass — resolves `env.DB (vra-membership-prod)` and `env.MEMBER_PHOTOS (vra-member-private)` |
| `npx wrangler d1 migrations list DB --env="" --remote` | pass — both migrations listed as pending against the real database |
| `npx wrangler d1 migrations apply DB --env="" --remote` | pass — 3 commands, both migrations applied |
| `npx wrangler r2 bucket dev-url get vra-member-private` | `Public access via the r2.dev URL is disabled.` |
| `npx wrangler r2 bucket domain list vra-member-private` | `There are no custom domains connected to this bucket.` |

Applying the migrations to the remote development database is worth more than the local run: it exercises the SQL against real D1 rather than against Miniflare's SQLite, so a construct that Miniflare accepts but D1 rejects would have shown up here. Both migrations applied unchanged.

## Security and privacy

- [x] No secrets, real PII, ID-card images, payment-slip images, or raw provider responses are included.
- [x] Logs contain only allowlisted technical metadata.
- [x] Tests use synthetic data and mocked providers.
- [x] Authentication, authorization, payment, webhook, retention, migration, and deployment impact is described below.

Impact and mitigations:

- **Committed identifiers** — `database_id` is not a credential. It cannot be used without a token, and the account is not identified by it. No account id, token or secret appears in the diff.
- **R2 exposure** — a member photo behind a public URL would defeat the whole point of private storage, so both buckets were checked rather than assumed: `r2.dev` public access is disabled and no custom domain is attached. The re-verification commands are now in the deployment doc so this can be re-checked before go-live and after any dashboard change.
- **OAuth scope** — the CLI session used to provision these was granted `account:read`, `user:read`, `d1:write`, `workers:write`, `workers_scripts:write` and `challenge-widgets.write`. It is a personal CLI session, not the deployment token; `CLOUDFLARE_API_TOKEN` for CI is still to be created separately and should be scoped narrower.
- **Remote development database** — now has the schema but no rows. It contains no personal data and never should: development uses synthetic data only.
- **High risk** — touches deployment configuration, so human review is requested per `AGENTS.md`.

## Deployment / migration / rollback

**Migration:** none added. `0001` and `0002` were applied to the development database only.

**Rollback:** reverting this commit restores the placeholder ids, which breaks `wrangler deploy` but nothing else — no data is involved. The resources themselves are unaffected by a code rollback.

**Still required before production delivery works:**

- [ ] `wrangler secret put <NAME> --env production` for `IAPP_API_KEY`, `SLIPOK_API_KEY`, `RESEND_API_KEY`, `RESEND_WEBHOOK_SECRET`, `PII_ENCRYPTION_KEY`, `TURNSTILE_SECRET_KEY`, `MANAGER_EMAIL`, `EMAIL_FROM`, `VRA_BANK_NAME`, `VRA_BANK_ACCOUNT`, `VRA_BANK_ACCOUNT_NAME`
- [ ] Attach the `member.vra.or.th` custom domain to the Worker
- [ ] Create the Cloudflare Access application covering `/admin*` and `/api/admin/*`
- [ ] Create the Turnstile site and a Cloudflare rate-limiting rule at the edge
- [ ] Add `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` as environment secrets on the `production` GitHub environment
- [ ] Set the repository variable `CLOUDFLARE_DEPLOY_ENABLED=true`

## UI evidence

Not applicable — configuration only.

## Human / AI handoff

- **Completed:** both D1 databases, both private R2 buckets, real ids in `wrangler.jsonc`, privacy of the buckets verified, migrations validated against real D1, deployment doc updated
- **Remaining:** the secret and token items listed above, which require values the account owner holds
- **Changed paths:** `wrangler.jsonc`, `docs/deployment.md`
- **Risks / assumptions:**
  - Both resources were created in the APAC location, which is right for a Thai membership base but was chosen by Cloudflare rather than pinned. If a specific jurisdiction is required for data residency, that has to be decided before any real data is stored, because it cannot be changed in place.
  - The development database is remote and shares the account with production. Nothing points development at the production database, but a mistyped `--env` on a manual command could. `wrangler.jsonc` keeps them in separate environments to make that unlikely.
- **Next safe action:** merge, then continue with #9
