### PR TITLE
chore: add a one-pass script for uploading the production secrets

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -29,7 +29,26 @@ Pipeline ประกอบด้วยสาม workflow
 
 3. ผูก custom domain `member.vra.or.th` เข้ากับ Worker `vra-membership`
 
-4. ตั้ง Cloudflare Secrets สำหรับ production ผ่าน `wrangler secret put <NAME> --env production`
+4. ตั้ง Cloudflare Secrets สำหรับ production
+
+   วิธีที่เร็วที่สุดคือใช้สคริปต์ที่เตรียมไว้ ซึ่งอ่านค่าจากไฟล์เดียวที่ถูก git-ignore แล้วอัปโหลดทั้งชุดในครั้งเดียว โดยค่าไม่ผ่าน command line และไม่ค้างใน shell history
+
+   ```powershell
+   # สร้าง template แล้วกรอกค่าลงไปครั้งเดียว
+   pwsh -File ./scripts/set-production-secrets.ps1 -CreateTemplate
+
+   # ตรวจว่าครบก่อนอัปโหลดจริง
+   pwsh -File ./scripts/set-production-secrets.ps1 -WhatIf
+
+   # อัปโหลด
+   pwsh -File ./scripts/set-production-secrets.ps1
+   ```
+
+   ปล่อย `PII_ENCRYPTION_KEY` ว่างไว้เพื่อให้สคริปต์สร้างค่าสุ่มให้ และ **สำรองค่านั้นไว้ที่ปลอดภัยและออฟไลน์ก่อนลบไฟล์** เพราะถ้าค่านี้หาย เลขบัตรประชาชนที่เก็บไว้จะอ่านไม่ได้อีกเลย
+
+   ลบไฟล์ค่าเมื่อเสร็จ และห้ามนำค่าใด ๆ ไปวางใน Issue, PR หรือแชท
+
+   หรือตั้งทีละตัวด้วย `wrangler secret put <NAME> --env production`
 
    | Secret                  | ใช้ทำอะไร                         |
    | ----------------------- | --------------------------------- |

--- a/scripts/set-production-secrets.ps1
+++ b/scripts/set-production-secrets.ps1
@@ -1,0 +1,236 @@
+<#
+.SYNOPSIS
+  Uploads the production secrets to Cloudflare in one pass.
+
+.DESCRIPTION
+  Every value this script handles is a secret, so it is built so that a secret
+  never has to be typed twice and never has to sit on disk longer than the run:
+
+  - Values are read from a git-ignored file under `.secrets/`, which you fill in
+    once by copying from your own notes, or entered interactively if that file
+    does not exist.
+  - The file is not read by anything else, is never committed (`.gitignore`
+    covers `.secrets/`), and `-RemoveFileWhenDone` deletes it after a successful
+    upload.
+  - Nothing is echoed back to the terminal, so the values do not end up in your
+    shell history or scrollback.
+  - `PII_ENCRYPTION_KEY` is generated for you when left blank, because it must
+    be high-entropy and must never change afterwards.
+
+.PARAMETER EnvFile
+  Path to the values file. Defaults to `.secrets/production.env`.
+
+.PARAMETER Environment
+  Wrangler environment to target. Defaults to `production`.
+
+.PARAMETER RemoveFileWhenDone
+  Deletes the values file after every secret has been uploaded successfully.
+
+.PARAMETER WhatIf
+  Reports which secrets are present and which are missing, and uploads nothing.
+
+.EXAMPLE
+  # 1. Create the template, fill it in, then upload.
+  pwsh -File ./scripts/set-production-secrets.ps1 -CreateTemplate
+  pwsh -File ./scripts/set-production-secrets.ps1 -RemoveFileWhenDone
+
+.EXAMPLE
+  # Check what is still missing without uploading anything.
+  pwsh -File ./scripts/set-production-secrets.ps1 -WhatIf
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+  [string]$EnvFile = '.secrets/production.env',
+  [string]$Environment = 'production',
+  [switch]$CreateTemplate,
+  [switch]$RemoveFileWhenDone
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+# Name, whether a blank value can be generated, and what the value is for.
+$secrets = @(
+  @{ Name = 'IAPP_API_KEY'; Generate = $false; Purpose = 'iApp Thai national ID OCR' }
+  @{ Name = 'SLIPOK_API_KEY'; Generate = $false; Purpose = 'SlipOK payment slip verification' }
+  @{ Name = 'RESEND_API_KEY'; Generate = $false; Purpose = 'Resend transactional email' }
+  @{ Name = 'RESEND_WEBHOOK_SECRET'; Generate = $false; Purpose = 'Resend webhook signature check' }
+  @{ Name = 'TURNSTILE_SECRET_KEY'; Generate = $false; Purpose = 'Turnstile server-side verification' }
+  @{ Name = 'PII_ENCRYPTION_KEY'; Generate = $true; Purpose = 'Citizen ID encryption; NEVER change once data exists' }
+  @{ Name = 'MANAGER_EMAIL'; Generate = $false; Purpose = 'Recipient of the new-application email' }
+  @{ Name = 'EMAIL_FROM'; Generate = $false; Purpose = 'Sender address for member email' }
+  @{ Name = 'VRA_BANK_NAME'; Generate = $false; Purpose = 'Shown on the payment page and checked against the slip' }
+  @{ Name = 'VRA_BANK_ACCOUNT'; Generate = $false; Purpose = 'Shown on the payment page and checked against the slip' }
+  @{ Name = 'VRA_BANK_ACCOUNT_NAME'; Generate = $false; Purpose = 'Shown on the payment page and checked against the slip' }
+)
+
+function New-EncryptionKey {
+  # 48 random bytes, base64 encoded: the same shape as `openssl rand -base64 48`.
+  #
+  # `RandomNumberGenerator::Fill` only exists on .NET Core, so it would fail on
+  # Windows PowerShell 5.1. `RNGCryptoServiceProvider` works on both, and this
+  # script has to run wherever the operator happens to be.
+  $bytes = New-Object 'byte[]' 48
+  $rng = New-Object System.Security.Cryptography.RNGCryptoServiceProvider
+  try {
+    $rng.GetBytes($bytes)
+  }
+  finally {
+    $rng.Dispose()
+  }
+  return [Convert]::ToBase64String($bytes)
+}
+
+function Write-Template {
+  param([string]$Path)
+
+  $directory = Split-Path -Parent $Path
+  if ($directory -and -not (Test-Path -LiteralPath $directory)) {
+    New-Item -ItemType Directory -Path $directory -Force | Out-Null
+  }
+
+  if (Test-Path -LiteralPath $Path) {
+    throw "Refusing to overwrite an existing values file: $Path"
+  }
+
+  $lines = @(
+    '# Production secrets for the VRA membership Worker.',
+    '#',
+    '# This file is git-ignored and must never be committed, pasted into an',
+    '# Issue or a pull request, or shared in chat. Delete it once the upload',
+    '# has succeeded (or pass -RemoveFileWhenDone).',
+    '#',
+    '# Format: NAME=value, one per line. Values are taken literally, so do not',
+    '# add quotes unless they are part of the value.',
+    '#',
+    '# Leave PII_ENCRYPTION_KEY blank to have a fresh key generated.',
+    ''
+  )
+  foreach ($secret in $secrets) {
+    $lines += "# $($secret.Purpose)"
+    $lines += "$($secret.Name)="
+    $lines += ''
+  }
+
+  Set-Content -LiteralPath $Path -Value $lines -Encoding utf8
+  Write-Host "Template written to $Path"
+  Write-Host 'Fill in the values, then run this script again.'
+}
+
+function Read-ValuesFile {
+  param([string]$Path)
+
+  $values = @{}
+  foreach ($line in Get-Content -LiteralPath $Path) {
+    $trimmed = $line.Trim()
+    if ($trimmed.Length -eq 0 -or $trimmed.StartsWith('#')) { continue }
+
+    $separator = $trimmed.IndexOf('=')
+    if ($separator -lt 1) { continue }
+
+    $name = $trimmed.Substring(0, $separator).Trim()
+    $value = $trimmed.Substring($separator + 1)
+    if ($value.Length -gt 0) { $values[$name] = $value }
+  }
+  return $values
+}
+
+function Set-CloudflareSecret {
+  param([string]$Name, [string]$Value)
+
+  # The value goes to wrangler over stdin, so it never appears in a command
+  # line, in process arguments, or in shell history.
+  $Value | & npx wrangler secret put $Name --env $Environment | Out-Null
+  if ($LASTEXITCODE -ne 0) {
+    throw "wrangler secret put failed for $Name"
+  }
+}
+
+# Everything below runs inside a trap so a thrown error exits non-zero. Without
+# this the script can fail and still report success, which for a script whose
+# job is "the production secrets are set" is the worst possible outcome.
+trap {
+  Write-Host "FAILED: $($_.Exception.Message)"
+  exit 1
+}
+
+if ($CreateTemplate) {
+  Write-Template -Path $EnvFile
+  exit 0
+}
+
+if (-not (Test-Path -LiteralPath $EnvFile)) {
+  Write-Host "No values file at $EnvFile."
+  Write-Host 'Create one with:  pwsh -File ./scripts/set-production-secrets.ps1 -CreateTemplate'
+  exit 1
+}
+
+$values = Read-ValuesFile -Path $EnvFile
+$missing = [System.Collections.Generic.List[string]]::new()
+$generated = [System.Collections.Generic.List[string]]::new()
+
+foreach ($secret in $secrets) {
+  if ($values.ContainsKey($secret.Name)) { continue }
+  if ($secret.Generate) {
+    $values[$secret.Name] = New-EncryptionKey
+    $generated.Add($secret.Name)
+  }
+  else {
+    $missing.Add($secret.Name)
+  }
+}
+
+if ($missing.Count -gt 0) {
+  Write-Host 'Missing values:'
+  $missing | ForEach-Object { Write-Host "  - $_" }
+  Write-Host ''
+  Write-Host "Add them to $EnvFile and run again. Nothing was uploaded."
+  exit 1
+}
+
+foreach ($name in $generated) {
+  Write-Host "Generated a new $name (48 random bytes, base64)."
+  Write-Host '  This value can never change once real applications exist: the'
+  Write-Host '  citizen ID ciphertext and the duplicate-lookup hash both derive'
+  Write-Host '  from it, and no plaintext copy is kept anywhere.'
+}
+
+$uploaded = 0
+foreach ($secret in $secrets) {
+  if ($PSCmdlet.ShouldProcess("$($secret.Name) (env: $Environment)", 'wrangler secret put')) {
+    Set-CloudflareSecret -Name $secret.Name -Value $values[$secret.Name]
+    Write-Host "Uploaded $($secret.Name)"
+    $uploaded += 1
+  }
+  else {
+    Write-Host "Would upload $($secret.Name)"
+  }
+}
+
+if ($uploaded -eq $secrets.Count) {
+  Write-Host ''
+  Write-Host "All $uploaded secrets are set for the '$Environment' environment."
+
+  if ($generated.Count -gt 0) {
+    Write-Host ''
+    Write-Host 'Before deleting the values file, store the generated'
+    Write-Host 'PII_ENCRYPTION_KEY somewhere durable and offline. Losing it means'
+    Write-Host 'no stored citizen ID can ever be read again.'
+  }
+
+  if ($RemoveFileWhenDone) {
+    if ($generated.Count -gt 0) {
+      Write-Host ''
+      Write-Host 'Not deleting the values file: it holds a generated key that you'
+      Write-Host 'have not had a chance to back up. Delete it yourself once you have.'
+    }
+    else {
+      Remove-Item -LiteralPath $EnvFile -Force
+      Write-Host "Deleted $EnvFile"
+    }
+  }
+  else {
+    Write-Host ''
+    Write-Host "Delete $EnvFile when you no longer need it."
+  }
+}


### PR DESCRIPTION
Refs #3

## Outcome

Reduces setting the eleven production secrets from eleven manual `wrangler secret put` invocations to filling in one git-ignored file and running one command.

## Why

Setting them by hand means eleven chances to paste the wrong value into the wrong environment, and each invocation puts a secret into shell history. It is also the last thing standing between the repository and a working production deploy, so it is worth making hard to get wrong.

## How the values are kept out of places they should not be

| Risk | Mitigation |
| --- | --- |
| Secret in shell history / process args | Values are piped to wrangler over stdin, never passed as arguments |
| Secret in terminal scrollback | Nothing is echoed back; only names are printed |
| Secret committed | Values live under `.secrets/`, already covered by `.gitignore`; verified with `git check-ignore` |
| Secret left on disk | `-RemoveFileWhenDone` deletes the file after a successful upload |
| Wrong environment | `-Environment` defaults to `production` and is printed for every operation; `-WhatIf` shows the full plan first |
| Half-configured production | An incomplete set is refused outright rather than uploaded piecemeal |

## PII_ENCRYPTION_KEY

Generated when left blank, because it must be high-entropy and can never change afterwards.

When the script generates it, it **refuses to delete the values file** even with `-RemoveFileWhenDone`. Losing that key makes every stored citizen ID permanently unreadable, and at that point the operator has not had a chance to back it up. Deleting the file for them would be the kind of helpfulness that destroys data.

## Two bugs found while self-testing

1. **`RandomNumberGenerator::Fill` is .NET Core only**, so key generation threw on Windows PowerShell 5.1 — which is what is actually installed on the machine this will be run from. Switched to `RNGCryptoServiceProvider`, which works on both editions.
2. **A thrown error still exited 0.** For a script whose job is "the production secrets are set", reporting success after failing is the worst possible outcome. Failures now exit 1.

Both were caught by running the script rather than by reading it.

## Verification

| Check | Result |
| --- | --- |
| `-CreateTemplate` | pass — template written with every name, no values |
| `-CreateTemplate` over an existing file | pass — refused, exit 1 |
| Run with an empty template | pass — lists the 10 missing names, uploads nothing, exit 1; `PII_ENCRYPTION_KEY` correctly absent from the missing list because it is generated |
| `-WhatIf` with placeholder values | pass — plans all 11 uploads against `production`, uploads nothing, exit 0 |
| `git check-ignore .secrets/production.env` | pass — matched by `.gitignore:14` |
| Self-test artefacts | deleted; `git status` shows nothing secret-related |
| `validate-repository.ps1` | pass — 97 tracked files |

No real credential was used at any point. The placeholder values were obviously synthetic (`selftest-not-a-real-key`, `@example.test`) and the files were deleted.

## Security and privacy

- [x] No secrets, real PII, ID-card images, payment-slip images, or raw provider responses are included.
- [x] Logs contain only allowlisted technical metadata.
- [x] Tests use synthetic data and mocked providers.
- [x] Authentication, authorization, payment, webhook, retention, migration, and deployment impact is described below.

Impact and mitigations:

- The script handles secrets but stores none. It reads a file the operator creates and deletes, and writes only to Cloudflare.
- It contains no values, so the repository baseline's hard-coded-secret check has nothing to catch. Verified by running it.
- It cannot be used to read a secret back: `wrangler secret put` is write-only, and Cloudflare does not expose values afterwards.
- **High risk** — touches production configuration; human review requested per `AGENTS.md`.

## Deployment / migration / rollback

No migration. Reverting removes the script; secrets already uploaded are unaffected because they live in Cloudflare, not in the repository.

## UI evidence

Not applicable.

## Human / AI handoff

- **Completed:** the script, its self-tests, and the `docs/deployment.md` steps that use it
- **Remaining on #3:** running it (needs the values), plus the custom domain, Access application, Turnstile site, edge rate-limiting rule, `CLOUDFLARE_API_TOKEN`/`CLOUDFLARE_ACCOUNT_ID`, and `CLOUDFLARE_DEPLOY_ENABLED=true`
- **Next safe action:** merge, then continue with #9

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>