### PR TITLE
feat: add the member photo pipeline and private R2 storage

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,12 +38,14 @@ src/worker/            Cloudflare Worker (Hono)
     state-machine.ts   validated, idempotent, concurrency-safe transitions
     numbering.ts       application and receipt numbers
     audit.ts           audit trail with an allowlist for metadata
+    member-photo.ts    the only image the system keeps
   lib/logger.ts        allowlist logger; the only sanctioned console sink
   lib/time.ts          Asia/Bangkok conversion and Buddhist-era years
   lib/http.ts          API error codes and applicant-safe messages
   lib/crypto.ts        citizen ID encryption and duplicate-lookup hashing
   lib/citizen-id.ts    citizen ID normalisation and check-digit validation
   lib/files.ts         magic-byte sniffing and size-limited body reads
+  lib/images.ts        dimension reading and JPEG metadata stripping
   providers/types.ts   OcrProvider, SlipVerificationProvider, EmailProvider
   providers/iapp/      Thai national ID OCR adapter; narrows the response
   providers/mock/      deterministic adapters used by development and tests
@@ -142,6 +144,28 @@ Admin endpoint ที่เปลี่ยนสถานะเพิ่มอ�
 - **ข้อความ error ไม่มีค่าที่ผู้ใช้ส่งมา** ค่าเหล่านั้นคือเลขบัตร ที่อยู่ และ email ตอบกลับเฉพาะ path ของ field กับข้อความภาษาไทยตามชนิดของข้อผิดพลาด
 - **Rate limit counter อยู่ใน D1 ไม่ใช่ในหน่วยความจำของ isolate** Worker หนึ่งตัวรันหลาย isolate พร้อมกัน counter ในหน่วยความจำจึงไม่จำกัดอะไรเลย และ bucket ที่เก็บเป็น keyed hash ของ `<scope>:<identifier>` ไม่ใช่ IP ตรง ๆ
 - **rate limit ใน application layer ไม่แทน rule ที่ edge** rule ของ Cloudflare หยุด traffic ก่อนถึง Worker จึงกันทั้งค่า invocation และค่า D1 write ที่ counter ใช้ ต้องตั้งทั้งสองชั้น
+
+## Images
+
+ระบบแตะภาพสามชนิดและปฏิบัติกับมันต่างกันโดยเจตนา
+
+| ภาพ                       | ที่อยู่        | อายุ                   |
+| ------------------------- | -------------- | ---------------------- |
+| บัตรประชาชนด้านหน้า       | request memory | ถูกทิ้งเมื่อจบ request |
+| สลิปการชำระเงิน           | request memory | ถูกทิ้งเมื่อจบ request |
+| รูปสมาชิกที่ผู้สมัครเลือก | private R2     | เก็บไว้เพื่อทำบัตร     |
+
+รูปสมาชิกเป็นภาพเดียวที่ถูกเก็บ กฎที่บังคับไว้
+
+- **Object key เป็น UUID สุ่ม** ไม่มีเลขบัตร ชื่อ callsign หรือ application id อยู่ในนั้น การ list bucket ต้องไม่กลายเป็นทะเบียนสมาชิก
+- **ไม่มี R2 custom metadata** เพราะเป็นอีกที่ที่ข้อมูลส่วนบุคคลจะสะสมได้ ความเชื่อมโยงอยู่ใน database แล้ว
+- **การเปลี่ยนรูปลบ object เดิม** ถ้าไม่ลบ การถ่ายใหม่ทุกครั้งจะทิ้งใบหน้าที่ไม่มีอะไรอ้างถึงไว้ใน bucket และไม่มีใครจะไปลบมัน
+- **EXIF ถูกลบก่อนเขียนลง bucket** ภาพจากมือถืออาจมีพิกัด GPS หมายเลขเครื่อง และเวลาถ่าย เมื่อผูกกับใบหน้าของคนที่ระบุตัวได้ นั่นคือประวัติตำแหน่ง
+- **ต้องมีการยืนยันอย่างชัดเจน** การใช้ภาพใบหน้าจากบัตรโดยผู้สมัครไม่ได้เลือกเองคือสิ่งที่ Issue #1 หัวข้อ 61 ห้าม
+
+การครอบตัดและ re-encode ทำที่ browser ส่วน Worker เป็นฝ่าย **ตรวจ** ไม่ใช่เชื่อ: อ่านขนาดพิกเซลจาก container header (ไม่ต้องมี decoder) ตรวจสัดส่วน 3:4 และลบ metadata segment ทิ้ง Worker ไม่มี canvas และการใส่ WASM decoder จะเพิ่ม bundle size กับ CPU ทุก upload โดยไม่คุ้มที่ปริมาณ 1-2 ใบสมัครต่อวัน
+
+รับเฉพาะ JPEG สำหรับรูปที่เก็บ เพราะ metadata ของ PNG และ WebP อยู่ใน chunk ที่โมดูลนี้ไม่ได้เขียนใหม่ การรับไว้จะเท่ากับเก็บ chunk ที่อาจมี EXIF หรือข้อความติดมา
 
 ## Decision records
 

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -8,6 +8,7 @@ import { createLogger } from './lib/logger';
 import { ProviderNotConfiguredError, createProviders } from './providers';
 import { ValidationError, createSecurityServices, validationErrorBody } from './security';
 import { healthRoutes } from './routes/health';
+import { memberPhotoRoutes } from './routes/member-photo';
 import { OcrFailedError, ocrRoutes } from './routes/ocr';
 
 const GENERIC_ERROR_MESSAGE = 'เกิดข้อผิดพลาดภายในระบบ กรุณาลองใหม่อีกครั้ง';
@@ -61,6 +62,7 @@ app.use('*', async (c, next) => {
 
 app.route('/api', healthRoutes);
 app.route('/api', ocrRoutes);
+app.route('/api', memberPhotoRoutes);
 
 /** API 404s must be JSON so the SPA fallback never masks a routing mistake. */
 app.notFound((c) => {

--- a/src/worker/lib/images.ts
+++ b/src/worker/lib/images.ts
@@ -1,0 +1,291 @@
+import { ApiError } from './http';
+import type { SupportedImageType } from './files';
+
+/**
+ * Image inspection for the stored member photo.
+ *
+ * A Worker has no canvas and no image decoder, and adding a WASM one would cost
+ * bundle size and CPU on every upload for a service handling one or two
+ * applications a day. So the split is: the browser crops and re-encodes to the
+ * target shape (Issue #1 sections 11-12), and the Worker verifies the result
+ * rather than trusting it.
+ *
+ * Verification reads the pixel dimensions straight out of the container header,
+ * which needs no decoder, and strips the metadata segments that carry the data
+ * nobody asked to share.
+ *
+ * The EXIF strip is the part that matters most. A photo taken on a phone can
+ * carry GPS coordinates, the device serial and the capture timestamp. A canvas
+ * re-encode drops all of that, but the Worker must not assume the client did it
+ * - the client is where an attacker sits.
+ */
+
+export interface ImageDimensions {
+  width: number;
+  height: number;
+}
+
+const MESSAGES = {
+  undecodable: 'ไม่สามารถอ่านขนาดของภาพได้ กรุณาเลือกภาพใหม่',
+  tooSmall: 'ภาพมีความละเอียดต่ำเกินไปสำหรับใช้ทำบัตรสมาชิก กรุณาใช้ภาพที่ใหญ่ขึ้น',
+  tooLarge: 'ภาพมีความละเอียดสูงเกินกำหนด กรุณาย่อขนาดภาพ',
+  aspect: 'สัดส่วนภาพไม่ถูกต้อง กรุณาครอบตัดภาพเป็นสัดส่วน 3:4 ก่อนส่ง',
+} as const;
+
+/* ------------------------------------------------------- dimensions ------- */
+
+function readJpegDimensions(bytes: Uint8Array): ImageDimensions | null {
+  // Walk the marker chain looking for a Start Of Frame, which carries the size.
+  let offset = 2; // skip SOI
+
+  while (offset + 9 < bytes.byteLength) {
+    if (bytes[offset] !== 0xff) return null;
+
+    const marker = bytes[offset + 1]!;
+    // Standalone markers carry no length.
+    if (marker === 0xd8 || marker === 0xd9 || (marker >= 0xd0 && marker <= 0xd7)) {
+      offset += 2;
+      continue;
+    }
+
+    const length = (bytes[offset + 2]! << 8) | bytes[offset + 3]!;
+
+    // SOF0/1/2/3/5/6/7/9/10/11/13/14/15. DHT (0xc4), JPG (0xc8) and DAC (0xcc)
+    // sit in the same numeric range but are not frame headers.
+    const isStartOfFrame =
+      marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc;
+
+    if (isStartOfFrame) {
+      return {
+        height: (bytes[offset + 5]! << 8) | bytes[offset + 6]!,
+        width: (bytes[offset + 7]! << 8) | bytes[offset + 8]!,
+      };
+    }
+
+    offset += 2 + length;
+  }
+
+  return null;
+}
+
+function readPngDimensions(bytes: Uint8Array): ImageDimensions | null {
+  // IHDR is always the first chunk: 8-byte signature, 4-byte length, "IHDR".
+  if (bytes.byteLength < 24) return null;
+
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  return { width: view.getUint32(16), height: view.getUint32(20) };
+}
+
+function readWebpDimensions(bytes: Uint8Array): ImageDimensions | null {
+  if (bytes.byteLength < 30) return null;
+
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const format = String.fromCharCode(bytes[12]!, bytes[13]!, bytes[14]!, bytes[15]!);
+
+  if (format === 'VP8 ') {
+    // Lossy: 14-bit dimensions after the 3-byte start code at offset 23.
+    return {
+      width: view.getUint16(26, true) & 0x3fff,
+      height: view.getUint16(28, true) & 0x3fff,
+    };
+  }
+
+  if (format === 'VP8L') {
+    // Lossless: 14 bits each, packed little-endian from offset 21.
+    const packed = view.getUint32(21, true);
+    return { width: (packed & 0x3fff) + 1, height: ((packed >> 14) & 0x3fff) + 1 };
+  }
+
+  if (format === 'VP8X') {
+    // Extended: 24-bit canvas size minus one, from offset 24.
+    const width = (bytes[24]! | (bytes[25]! << 8) | (bytes[26]! << 16)) + 1;
+    const height = (bytes[27]! | (bytes[28]! << 8) | (bytes[29]! << 16)) + 1;
+    return { width, height };
+  }
+
+  return null;
+}
+
+/** Pixel dimensions from the container header, or null when unreadable. */
+export function readImageDimensions(
+  bytes: Uint8Array,
+  contentType: SupportedImageType,
+): ImageDimensions | null {
+  const dimensions =
+    contentType === 'image/jpeg'
+      ? readJpegDimensions(bytes)
+      : contentType === 'image/png'
+        ? readPngDimensions(bytes)
+        : readWebpDimensions(bytes);
+
+  if (!dimensions) return null;
+  if (dimensions.width <= 0 || dimensions.height <= 0) return null;
+  return dimensions;
+}
+
+/* ---------------------------------------------------- metadata strip ------ */
+
+/**
+ * Removes JPEG APPn and COM segments.
+ *
+ * APP1 holds EXIF (GPS, device, capture time) and XMP; APP2 holds ICC and
+ * sometimes Flashpix; APP13 holds Photoshop IRB, which can contain IPTC
+ * captions. None of it is needed to print a membership card, and all of it
+ * would otherwise sit in the bucket attached to a named person.
+ *
+ * Everything from the Start Of Scan onwards is image data and is copied
+ * verbatim, so the result is still a valid JPEG.
+ */
+export function stripJpegMetadata(bytes: Uint8Array): Uint8Array {
+  if (bytes.byteLength < 4 || bytes[0] !== 0xff || bytes[1] !== 0xd8) return bytes;
+
+  const keep: Array<{ start: number; end: number }> = [];
+  let offset = 2;
+
+  while (offset + 3 < bytes.byteLength) {
+    if (bytes[offset] !== 0xff) break;
+
+    const marker = bytes[offset + 1]!;
+
+    if (marker === 0xda) {
+      // Start Of Scan: the rest of the file is entropy-coded image data.
+      keep.push({ start: offset, end: bytes.byteLength });
+      break;
+    }
+
+    if (marker === 0xd9 || (marker >= 0xd0 && marker <= 0xd7)) {
+      keep.push({ start: offset, end: offset + 2 });
+      offset += 2;
+      continue;
+    }
+
+    const length = (bytes[offset + 2]! << 8) | bytes[offset + 3]!;
+    if (length < 2) break;
+
+    const isMetadata = (marker >= 0xe0 && marker <= 0xef) || marker === 0xfe;
+    if (!isMetadata) {
+      keep.push({ start: offset, end: offset + 2 + length });
+    }
+
+    offset += 2 + length;
+  }
+
+  const total = keep.reduce((sum, range) => sum + (range.end - range.start), 2);
+  const output = new Uint8Array(total);
+  output.set([0xff, 0xd8], 0);
+
+  let cursor = 2;
+  for (const range of keep) {
+    output.set(bytes.subarray(range.start, range.end), cursor);
+    cursor += range.end - range.start;
+  }
+
+  return output;
+}
+
+/** True when the JPEG carries an EXIF or XMP segment. */
+export function hasJpegMetadata(bytes: Uint8Array): boolean {
+  if (bytes.byteLength < 4 || bytes[0] !== 0xff || bytes[1] !== 0xd8) return false;
+
+  let offset = 2;
+  while (offset + 3 < bytes.byteLength) {
+    if (bytes[offset] !== 0xff) return false;
+
+    const marker = bytes[offset + 1]!;
+    if (marker === 0xda) return false;
+    if (marker === 0xd9 || (marker >= 0xd0 && marker <= 0xd7)) {
+      offset += 2;
+      continue;
+    }
+
+    if ((marker >= 0xe0 && marker <= 0xef) || marker === 0xfe) return true;
+
+    const length = (bytes[offset + 2]! << 8) | bytes[offset + 3]!;
+    if (length < 2) return false;
+    offset += 2 + length;
+  }
+
+  return false;
+}
+
+/* ------------------------------------------------------- validation ------- */
+
+/**
+ * Target shape for a member photo (Issue #1 section 11).
+ *
+ * The aspect tolerance exists because a browser crop lands on whole pixels, so
+ * an exact 0.75 is not reachable at every size.
+ */
+export const MEMBER_PHOTO_SHAPE = {
+  aspectRatio: 3 / 4,
+  aspectTolerance: 0.02,
+  minWidth: 300,
+  minHeight: 400,
+  maxWidth: 2400,
+  maxHeight: 3200,
+} as const;
+
+export interface VerifiedMemberPhoto {
+  bytes: Uint8Array;
+  contentType: SupportedImageType;
+  dimensions: ImageDimensions;
+  /** True when metadata segments were present and removed. */
+  metadataStripped: boolean;
+}
+
+/**
+ * Verifies the shape of a member photo and removes its metadata.
+ *
+ * Throws `ApiError` with an applicant-safe message; each one says what to do,
+ * because "invalid image" leaves the applicant with no next step.
+ */
+export function verifyMemberPhoto(
+  bytes: Uint8Array,
+  contentType: SupportedImageType,
+): VerifiedMemberPhoto {
+  const dimensions = readImageDimensions(bytes, contentType);
+  if (!dimensions) {
+    throw new ApiError('UNSUPPORTED_MEDIA_TYPE', MESSAGES.undecodable);
+  }
+
+  if (
+    dimensions.width < MEMBER_PHOTO_SHAPE.minWidth ||
+    dimensions.height < MEMBER_PHOTO_SHAPE.minHeight
+  ) {
+    throw new ApiError('VALIDATION_FAILED', MESSAGES.tooSmall);
+  }
+
+  if (
+    dimensions.width > MEMBER_PHOTO_SHAPE.maxWidth ||
+    dimensions.height > MEMBER_PHOTO_SHAPE.maxHeight
+  ) {
+    throw new ApiError('VALIDATION_FAILED', MESSAGES.tooLarge);
+  }
+
+  const ratio = dimensions.width / dimensions.height;
+  if (Math.abs(ratio - MEMBER_PHOTO_SHAPE.aspectRatio) > MEMBER_PHOTO_SHAPE.aspectTolerance) {
+    throw new ApiError('VALIDATION_FAILED', MESSAGES.aspect);
+  }
+
+  if (contentType !== 'image/jpeg') {
+    // PNG and WebP metadata lives in chunks this module does not rewrite. The
+    // stored photo is therefore always re-encoded to JPEG by the client, and
+    // anything else is refused rather than stored with metadata intact.
+    throw new ApiError('UNSUPPORTED_MEDIA_TYPE', MESSAGES.undecodable);
+  }
+
+  const hadMetadata = hasJpegMetadata(bytes);
+  const stripped = hadMetadata ? stripJpegMetadata(bytes) : bytes;
+
+  // Stripping must not have broken the container.
+  if (readImageDimensions(stripped, contentType) === null) {
+    throw new ApiError('UNSUPPORTED_MEDIA_TYPE', MESSAGES.undecodable);
+  }
+
+  return {
+    bytes: stripped,
+    contentType,
+    dimensions,
+    metadataStripped: hadMetadata,
+  };
+}

--- a/src/worker/lib/logger.ts
+++ b/src/worker/lib/logger.ts
@@ -23,6 +23,8 @@ const ALLOWED_FIELDS = [
   'errorCode',
   'provider',
   'providerStatus',
+  // Enum-valued: 'ID_CARD' or 'UPLOAD' for a member photo. Never a file name.
+  'source',
   'attempt',
   'count',
   'reason',

--- a/src/worker/routes/member-photo.ts
+++ b/src/worker/routes/member-photo.ts
@@ -1,0 +1,108 @@
+import { Hono } from 'hono';
+import { z } from 'zod';
+import type { AppContext } from '../context';
+import { PHOTO_SOURCES } from '../db';
+import { validateImageBytes } from '../lib/files';
+import { ApiError } from '../lib/http';
+import { assertWithinRateLimit, clientIdentifier, PHOTO_POLICY } from '../security/rate-limit';
+import { assertHumanRequest } from '../security/turnstile';
+import { parseWithSchema } from '../security/validation';
+import { createAuditLog } from '../services/audit';
+import { createMemberPhotoService } from '../services/member-photo';
+
+/**
+ * `POST /api/member-photo` - stores the photo the applicant chose for their card.
+ *
+ * Sent as multipart so the image and the choice that goes with it arrive
+ * together: which source it came from, and the explicit confirmation that this
+ * is the photo they want. Issue #1 section 61 requires that choice to be
+ * deliberate, so it is a required field rather than a default.
+ */
+
+/** Generous enough for a 2400x3200 JPEG, small enough to bound memory. */
+const MAX_UPLOAD_BYTES = 3 * 1024 * 1024;
+
+const metadataSchema = z
+  .object({
+    applicationId: z.string().uuid(),
+    source: z.enum(PHOTO_SOURCES),
+    // Sent as a string because multipart has no booleans.
+    confirmed: z.literal('true'),
+  })
+  .strict();
+
+const MESSAGES = {
+  form: 'ข้อมูลที่ส่งมาไม่ครบ กรุณาลองอีกครั้ง',
+  missingFile: 'ไม่พบไฟล์รูป กรุณาเลือกรูปอีกครั้ง',
+  tooLarge: 'ไฟล์รูปมีขนาดใหญ่เกินกำหนด กรุณาย่อขนาดรูป',
+} as const;
+
+export const memberPhotoRoutes = new Hono<AppContext>().post('/member-photo', async (c) => {
+  await assertHumanRequest(c.var.security.turnstile, c.req.raw);
+  await assertWithinRateLimit(
+    c.var.security.rateLimiter,
+    PHOTO_POLICY,
+    clientIdentifier(c.req.raw),
+  );
+
+  const declaredLength = Number(c.req.header('content-length') ?? '');
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_UPLOAD_BYTES) {
+    throw new ApiError('PAYLOAD_TOO_LARGE', MESSAGES.tooLarge);
+  }
+
+  let form: FormData;
+  try {
+    form = await c.req.formData();
+  } catch {
+    // The parser error can quote the payload, so it is discarded.
+    throw new ApiError('BAD_REQUEST', MESSAGES.form);
+  }
+
+  const metadata = parseWithSchema(metadataSchema, {
+    applicationId: form.get('applicationId'),
+    source: form.get('source'),
+    confirmed: form.get('confirmed'),
+  });
+
+  const file = form.get('photo');
+  if (!(file instanceof File)) {
+    throw new ApiError('BAD_REQUEST', MESSAGES.missingFile);
+  }
+  if (file.size > MAX_UPLOAD_BYTES) {
+    throw new ApiError('PAYLOAD_TOO_LARGE', MESSAGES.tooLarge);
+  }
+
+  // The type is decided by the bytes, never by what the form claimed.
+  const image = validateImageBytes(new Uint8Array(await file.arrayBuffer()), {
+    maxBytes: MAX_UPLOAD_BYTES,
+  });
+
+  const service = createMemberPhotoService(c.var.db, c.env.MEMBER_PHOTOS, createAuditLog(c.var.db));
+
+  const stored = await service.store({
+    applicationId: metadata.applicationId,
+    source: metadata.source,
+    confirmed: metadata.confirmed === 'true',
+    bytes: image.bytes,
+    contentType: image.contentType,
+  });
+
+  c.var.logger.info({
+    event: 'member_photo.stored',
+    applicationId: metadata.applicationId,
+    source: stored.source,
+    count: stored.byteLength,
+  });
+
+  // The key is never returned. The client has no use for it, and it is the one
+  // string that points directly at a stored face.
+  c.header('Cache-Control', 'no-store');
+  return c.json({
+    stored: true,
+    source: stored.source,
+    width: stored.width,
+    height: stored.height,
+    metadataStripped: stored.metadataStripped,
+    replacedPrevious: stored.replacedPrevious,
+  });
+});

--- a/src/worker/services/index.ts
+++ b/src/worker/services/index.ts
@@ -1,3 +1,4 @@
 export * from './audit';
+export * from './member-photo';
 export * from './numbering';
 export * from './state-machine';

--- a/src/worker/services/member-photo.ts
+++ b/src/worker/services/member-photo.ts
@@ -1,0 +1,160 @@
+import type { PhotoSource, Repository } from '../db';
+import { ApiError } from '../lib/http';
+import { verifyMemberPhoto } from '../lib/images';
+import type { SupportedImageType } from '../lib/files';
+import type { AuditLog } from './audit';
+
+/**
+ * Member photo storage.
+ *
+ * This is the only image in the whole system that is kept. The ID card and the
+ * payment slip pass through memory and are discarded; the member photo is
+ * stored because the association needs it to print a card (Issue #1 section 13).
+ *
+ * Three rules shape the implementation:
+ *
+ * 1. **The object key is random and carries nothing.** Not the citizen ID, not
+ *    the name, not the callsign. A bucket listing must not be a membership
+ *    roster.
+ * 2. **Replacing a photo deletes the old object.** Otherwise every retake
+ *    leaves an orphaned face in the bucket that nothing references and nobody
+ *    will ever delete.
+ * 3. **Storing requires an explicit choice.** Using the face from the ID card
+ *    without the applicant saying so is exactly what Issue #1 section 61
+ *    forbids, so consent is a required input rather than an assumption.
+ */
+
+const KEY_PREFIX = 'member-photos/';
+
+const MESSAGES = {
+  notFound: 'ไม่พบใบสมัครนี้ กรุณาเริ่มขั้นตอนใหม่',
+  consent: 'กรุณายืนยันการเลือกรูปสำหรับบัตรสมาชิกก่อนบันทึก',
+  notEditable: 'ใบสมัครนี้อยู่ในขั้นตอนที่ไม่สามารถเปลี่ยนรูปได้แล้ว',
+} as const;
+
+/**
+ * Statuses in which the photo may still be set or replaced.
+ *
+ * Once the manager has been notified, the photo may already be in use for a
+ * printed card, so changing it silently would leave the card and the record
+ * disagreeing.
+ */
+const EDITABLE_STATUSES = ['DRAFT', 'AWAITING_PAYMENT', 'PAYMENT_VERIFIED', 'SUBMITTED'] as const;
+
+export interface StoreMemberPhotoInput {
+  applicationId: string;
+  source: PhotoSource;
+  /** The applicant's explicit confirmation of this photo (Issue #1 section 12). */
+  confirmed: boolean;
+  bytes: Uint8Array;
+  contentType: SupportedImageType;
+}
+
+export interface StoredMemberPhoto {
+  key: string;
+  source: PhotoSource;
+  width: number;
+  height: number;
+  byteLength: number;
+  /** True when EXIF or similar metadata was present and removed. */
+  metadataStripped: boolean;
+  /** True when this replaced an earlier photo, whose object was deleted. */
+  replacedPrevious: boolean;
+}
+
+export interface MemberPhotoService {
+  store(input: StoreMemberPhotoInput): Promise<StoredMemberPhoto>;
+  /** Reads a stored photo. Callers must have authenticated the requester. */
+  read(applicationId: string): Promise<{ body: ReadableStream; contentType: string } | null>;
+}
+
+export interface MemberPhotoOptions {
+  now?: () => Date;
+  newKey?: () => string;
+}
+
+export function createMemberPhotoService(
+  db: Repository,
+  bucket: R2Bucket,
+  audit: AuditLog,
+  options: MemberPhotoOptions = {},
+): MemberPhotoService {
+  const now = options.now ?? (() => new Date());
+  // A UUID and nothing else: the key must reveal nothing about whose face it is.
+  const newKey = options.newKey ?? (() => `${KEY_PREFIX}${crypto.randomUUID()}.jpg`);
+
+  return {
+    async store(input) {
+      if (!input.confirmed) {
+        throw new ApiError('VALIDATION_FAILED', MESSAGES.consent);
+      }
+
+      const application = await db.applications.findById(input.applicationId);
+      if (!application) {
+        throw new ApiError('NOT_FOUND', MESSAGES.notFound);
+      }
+
+      if (!EDITABLE_STATUSES.includes(application.status as (typeof EDITABLE_STATUSES)[number])) {
+        throw new ApiError('CONFLICT', MESSAGES.notEditable);
+      }
+
+      const verified = verifyMemberPhoto(input.bytes, input.contentType);
+      const key = newKey();
+      const uploadedAt = now().toISOString();
+
+      await bucket.put(key, verified.bytes as ArrayBufferView, {
+        httpMetadata: { contentType: verified.contentType },
+        // Deliberately no customMetadata: R2 metadata is another place personal
+        // data could accumulate, and the database already holds the link.
+      });
+
+      await db.applications.setPhoto(input.applicationId, {
+        key,
+        source: input.source,
+        uploadedAt,
+      });
+
+      // The old object is deleted after the new one is recorded. In the reverse
+      // order a failure between the two steps would leave the application
+      // pointing at an object that no longer exists.
+      const previousKey = application.photoKey;
+      let replacedPrevious = false;
+      if (previousKey && previousKey !== key) {
+        await bucket.delete(previousKey);
+        replacedPrevious = true;
+      }
+
+      await audit.record({
+        applicationId: input.applicationId,
+        eventType: 'PHOTO_SELECTED',
+        actorType: 'APPLICANT',
+        // `source` is an enum value. The key is not recorded: it is the one
+        // string that points at a person's face.
+        metadata: { source: input.source },
+      });
+
+      return {
+        key,
+        source: input.source,
+        width: verified.dimensions.width,
+        height: verified.dimensions.height,
+        byteLength: verified.bytes.byteLength,
+        metadataStripped: verified.metadataStripped,
+        replacedPrevious,
+      };
+    },
+
+    async read(applicationId) {
+      const application = await db.applications.findById(applicationId);
+      if (!application?.photoKey) return null;
+
+      const object = await bucket.get(application.photoKey);
+      if (!object) return null;
+
+      return {
+        body: object.body,
+        contentType: object.httpMetadata?.contentType ?? 'application/octet-stream',
+      };
+    },
+  };
+}

--- a/tests/support/images.ts
+++ b/tests/support/images.ts
@@ -1,0 +1,115 @@
+/**
+ * Synthetic JPEG builders for tests.
+ *
+ * These are structurally valid JPEGs assembled by hand rather than real photos:
+ * the tests need a container whose header says a particular size and whose
+ * metadata segments are known, and a real photo would give neither.
+ */
+
+const SOI = [0xff, 0xd8];
+const EOI = [0xff, 0xd9];
+
+function segment(marker: number, payload: number[]): number[] {
+  const length = payload.length + 2;
+  return [0xff, marker, (length >> 8) & 0xff, length & 0xff, ...payload];
+}
+
+/** SOF0 with the given dimensions: one 8-bit component, no subsampling. */
+function startOfFrame(width: number, height: number): number[] {
+  return segment(0xc0, [
+    0x08,
+    (height >> 8) & 0xff,
+    height & 0xff,
+    (width >> 8) & 0xff,
+    width & 0xff,
+    0x01,
+    0x01,
+    0x11,
+    0x00,
+  ]);
+}
+
+/** APP1 carrying an EXIF header and a recognisable GPS-like payload. */
+function exifSegment(): number[] {
+  const marker = [0x45, 0x78, 0x69, 0x66, 0x00, 0x00]; // "Exif\0\0"
+  const payload = [...marker, ...new TextEncoder().encode('GPSLatitude=13.7563')];
+  return segment(0xe1, payload);
+}
+
+/** APP13 Photoshop IRB, another place captions and locations hide. */
+function photoshopSegment(): number[] {
+  const payload = [...new TextEncoder().encode('Photoshop 3.0\0'), 0x38, 0x42, 0x49, 0x4d];
+  return segment(0xed, payload);
+}
+
+/** COM comment segment. */
+function commentSegment(text: string): number[] {
+  return segment(0xfe, [...new TextEncoder().encode(text)]);
+}
+
+/** Minimal scan data so the file has a body after the SOS marker. */
+function startOfScan(): number[] {
+  return [...segment(0xda, [0x01, 0x01, 0x00, 0x00, 0x3f, 0x00]), 0x00, 0x11, 0x22, 0x33];
+}
+
+export interface JpegOptions {
+  width: number;
+  height: number;
+  withExif?: boolean;
+  withPhotoshop?: boolean;
+  comment?: string;
+  /**
+   * Extra scan bytes to append.
+   *
+   * Absolute rather than "pad the file to N bytes": a total-size target would
+   * give a file with metadata less scan data than one without, so stripping the
+   * first could never reproduce the second.
+   */
+  scanPaddingBytes?: number;
+}
+
+export function makeJpeg(options: JpegOptions): Uint8Array {
+  const parts: number[] = [...SOI];
+
+  if (options.withExif) parts.push(...exifSegment());
+  if (options.withPhotoshop) parts.push(...photoshopSegment());
+  if (options.comment !== undefined) parts.push(...commentSegment(options.comment));
+
+  parts.push(...startOfFrame(options.width, options.height));
+  parts.push(...startOfScan());
+
+  for (let index = 0; index < (options.scanPaddingBytes ?? 0); index += 1) {
+    parts.push(0x55);
+  }
+
+  parts.push(...EOI);
+  return new Uint8Array(parts);
+}
+
+/** A member photo of the expected 3:4 shape, large enough to be accepted. */
+export function makeMemberPhoto(overrides: Partial<JpegOptions> = {}): Uint8Array {
+  return makeJpeg({ width: 600, height: 800, scanPaddingBytes: 200, ...overrides });
+}
+
+export function makePng(width: number, height: number): Uint8Array {
+  const bytes = new Uint8Array(32);
+  bytes.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+  const view = new DataView(bytes.buffer);
+  view.setUint32(8, 13); // IHDR length
+  bytes.set([0x49, 0x48, 0x44, 0x52], 12); // "IHDR"
+  view.setUint32(16, width);
+  view.setUint32(20, height);
+  return bytes;
+}
+
+/** Lossy WebP (`VP8 `) with the given dimensions. */
+export function makeWebp(width: number, height: number): Uint8Array {
+  const bytes = new Uint8Array(40);
+  bytes.set([0x52, 0x49, 0x46, 0x46], 0); // "RIFF"
+  bytes.set([0x57, 0x45, 0x42, 0x50], 8); // "WEBP"
+  bytes.set([0x56, 0x50, 0x38, 0x20], 12); // "VP8 "
+  const view = new DataView(bytes.buffer);
+  view.setUint16(26, width & 0x3fff, true);
+  view.setUint16(28, height & 0x3fff, true);
+  return bytes;
+}

--- a/tests/unit/images.test.ts
+++ b/tests/unit/images.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from 'vitest';
+import { ApiError } from '../../src/worker/lib/http';
+import {
+  hasJpegMetadata,
+  readImageDimensions,
+  stripJpegMetadata,
+  verifyMemberPhoto,
+} from '../../src/worker/lib/images';
+import { makeJpeg, makeMemberPhoto, makePng, makeWebp } from '../support/images';
+
+const GPS_MARKER = 'GPSLatitude=13.7563';
+
+function contains(bytes: Uint8Array, needle: string): boolean {
+  const haystack = new TextDecoder('latin1').decode(bytes);
+  return haystack.includes(needle);
+}
+
+describe('readImageDimensions', () => {
+  it('reads JPEG dimensions from the frame header', () => {
+    expect(readImageDimensions(makeJpeg({ width: 600, height: 800 }), 'image/jpeg')).toEqual({
+      width: 600,
+      height: 800,
+    });
+  });
+
+  it('reads JPEG dimensions past leading metadata segments', () => {
+    // The frame header comes after APP1 and APP13, so the marker walk has to
+    // skip them rather than assume a fixed offset.
+    const jpeg = makeJpeg({
+      width: 900,
+      height: 1200,
+      withExif: true,
+      withPhotoshop: true,
+      comment: 'a comment',
+    });
+
+    expect(readImageDimensions(jpeg, 'image/jpeg')).toEqual({ width: 900, height: 1200 });
+  });
+
+  it('reads PNG dimensions from IHDR', () => {
+    expect(readImageDimensions(makePng(300, 400), 'image/png')).toEqual({
+      width: 300,
+      height: 400,
+    });
+  });
+
+  it('reads lossy WebP dimensions', () => {
+    expect(readImageDimensions(makeWebp(600, 800), 'image/webp')).toEqual({
+      width: 600,
+      height: 800,
+    });
+  });
+
+  it('returns null for a truncated header', () => {
+    expect(readImageDimensions(new Uint8Array([0xff, 0xd8, 0xff]), 'image/jpeg')).toBeNull();
+    expect(readImageDimensions(new Uint8Array(4), 'image/png')).toBeNull();
+  });
+
+  it('returns null rather than a zero dimension', () => {
+    expect(readImageDimensions(makeJpeg({ width: 0, height: 800 }), 'image/jpeg')).toBeNull();
+  });
+});
+
+describe('hasJpegMetadata', () => {
+  it('detects an EXIF segment', () => {
+    expect(hasJpegMetadata(makeJpeg({ width: 600, height: 800, withExif: true }))).toBe(true);
+  });
+
+  it('detects a comment segment', () => {
+    expect(hasJpegMetadata(makeJpeg({ width: 600, height: 800, comment: 'hi' }))).toBe(true);
+  });
+
+  it('reports none for a clean JPEG', () => {
+    expect(hasJpegMetadata(makeJpeg({ width: 600, height: 800 }))).toBe(false);
+  });
+});
+
+describe('stripJpegMetadata', () => {
+  it('removes the EXIF payload', () => {
+    const withExif = makeJpeg({ width: 600, height: 800, withExif: true });
+    expect(contains(withExif, GPS_MARKER)).toBe(true);
+
+    const stripped = stripJpegMetadata(withExif);
+
+    // A phone photo can carry the coordinates of where it was taken. Attached
+    // to a named applicant's face in a bucket, that is a location history.
+    expect(contains(stripped, GPS_MARKER)).toBe(false);
+    expect(contains(stripped, 'Exif')).toBe(false);
+  });
+
+  it('removes Photoshop and comment segments too', () => {
+    const dirty = makeJpeg({
+      width: 600,
+      height: 800,
+      withPhotoshop: true,
+      comment: 'a caption that should not survive',
+    });
+
+    const stripped = stripJpegMetadata(dirty);
+
+    expect(contains(stripped, 'Photoshop')).toBe(false);
+    expect(contains(stripped, 'a caption that should not survive')).toBe(false);
+  });
+
+  it('leaves the image readable and the dimensions intact', () => {
+    const stripped = stripJpegMetadata(
+      makeJpeg({ width: 600, height: 800, withExif: true, scanPaddingBytes: 400 }),
+    );
+
+    expect(readImageDimensions(stripped, 'image/jpeg')).toEqual({ width: 600, height: 800 });
+  });
+
+  it('keeps the scan data byte for byte', () => {
+    const clean = makeJpeg({ width: 600, height: 800, scanPaddingBytes: 400 });
+    const dirty = makeJpeg({ width: 600, height: 800, withExif: true, scanPaddingBytes: 400 });
+
+    // Stripping a dirty file must produce the same bytes as the clean one:
+    // metadata gone, image untouched.
+    expect(Array.from(stripJpegMetadata(dirty))).toEqual(Array.from(clean));
+  });
+
+  it('is a no-op on an already clean JPEG', () => {
+    const clean = makeJpeg({ width: 600, height: 800, scanPaddingBytes: 200 });
+
+    expect(Array.from(stripJpegMetadata(clean))).toEqual(Array.from(clean));
+  });
+
+  it('leaves a non-JPEG untouched', () => {
+    const png = makePng(300, 400);
+    expect(Array.from(stripJpegMetadata(png))).toEqual(Array.from(png));
+  });
+});
+
+describe('verifyMemberPhoto', () => {
+  it('accepts a 3:4 photo of adequate size', () => {
+    const verified = verifyMemberPhoto(makeMemberPhoto(), 'image/jpeg');
+
+    expect(verified.dimensions).toEqual({ width: 600, height: 800 });
+    expect(verified.metadataStripped).toBe(false);
+  });
+
+  it('strips metadata and reports that it did', () => {
+    const verified = verifyMemberPhoto(makeMemberPhoto({ withExif: true }), 'image/jpeg');
+
+    expect(verified.metadataStripped).toBe(true);
+    expect(contains(verified.bytes, GPS_MARKER)).toBe(false);
+  });
+
+  it('accepts other sizes at the same ratio', () => {
+    expect(
+      verifyMemberPhoto(makeMemberPhoto({ width: 900, height: 1200 }), 'image/jpeg'),
+    ).toBeTruthy();
+    expect(
+      verifyMemberPhoto(makeMemberPhoto({ width: 300, height: 400 }), 'image/jpeg'),
+    ).toBeTruthy();
+  });
+
+  it('rejects a photo that is not 3:4', () => {
+    // A square or landscape crop would print wrong on the card.
+    expect(() =>
+      verifyMemberPhoto(makeMemberPhoto({ width: 800, height: 800 }), 'image/jpeg'),
+    ).toThrow(ApiError);
+    expect(() =>
+      verifyMemberPhoto(makeMemberPhoto({ width: 800, height: 600 }), 'image/jpeg'),
+    ).toThrow(ApiError);
+  });
+
+  it('tolerates the rounding a browser crop produces', () => {
+    // 601x800 is 0.75125, which a pixel-aligned crop can easily land on.
+    expect(
+      verifyMemberPhoto(makeMemberPhoto({ width: 601, height: 800 }), 'image/jpeg'),
+    ).toBeTruthy();
+  });
+
+  it('rejects a photo too small to print', () => {
+    expect(() =>
+      verifyMemberPhoto(makeMemberPhoto({ width: 150, height: 200 }), 'image/jpeg'),
+    ).toThrow(ApiError);
+  });
+
+  it('rejects an implausibly large photo', () => {
+    expect(() =>
+      verifyMemberPhoto(makeMemberPhoto({ width: 3000, height: 4000 }), 'image/jpeg'),
+    ).toThrow(ApiError);
+  });
+
+  it('rejects PNG and WebP, whose metadata this module does not rewrite', () => {
+    // Accepting them would mean storing chunks that could carry EXIF or text.
+    expect(() => verifyMemberPhoto(makePng(600, 800), 'image/png')).toThrow(ApiError);
+    expect(() => verifyMemberPhoto(makeWebp(600, 800), 'image/webp')).toThrow(ApiError);
+  });
+
+  it('rejects bytes whose dimensions cannot be read', () => {
+    expect(() => verifyMemberPhoto(new Uint8Array([0xff, 0xd8, 0xff]), 'image/jpeg')).toThrow(
+      ApiError,
+    );
+  });
+
+  it('never echoes image content in a rejection message', () => {
+    try {
+      verifyMemberPhoto(
+        makeMemberPhoto({ width: 800, height: 800, comment: GPS_MARKER }),
+        'image/jpeg',
+      );
+      expect.unreachable('verifyMemberPhoto should have thrown');
+    } catch (error) {
+      expect((error as ApiError).publicMessage).not.toContain(GPS_MARKER);
+    }
+  });
+});

--- a/tests/worker/member-photo.test.ts
+++ b/tests/worker/member-photo.test.ts
@@ -1,0 +1,426 @@
+import { env, exports } from 'cloudflare:workers';
+import { describe, expect, it } from 'vitest';
+import { createAuditLog } from '../../src/worker/services/audit';
+import { createMemberPhotoService } from '../../src/worker/services/member-photo';
+import { createStateMachine } from '../../src/worker/services/state-machine';
+import { TURNSTILE_TOKEN_HEADER } from '../../src/worker/security/turnstile';
+import { makeMemberPhoto, makePng } from '../support/images';
+import {
+  OTHER_TEST_CITIZEN_ID,
+  repository,
+  seedApplication,
+  TEST_CITIZEN_ID,
+} from '../support/fixtures';
+
+const GPS_MARKER = 'GPSLatitude=13.7563';
+
+function service(repo = repository()) {
+  return createMemberPhotoService(repo, env.MEMBER_PHOTOS, createAuditLog(repo));
+}
+
+async function objectKeys(): Promise<string[]> {
+  const listing = await env.MEMBER_PHOTOS.list();
+  return listing.objects.map((object) => object.key).sort();
+}
+
+async function objectText(key: string): Promise<string> {
+  const object = await env.MEMBER_PHOTOS.get(key);
+  const bytes = new Uint8Array(await object!.arrayBuffer());
+  return new TextDecoder('latin1').decode(bytes);
+}
+
+describe('storing a member photo', () => {
+  it('stores the photo and records it on the application', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+
+    const stored = await service(repo).store({
+      applicationId: id,
+      source: 'UPLOAD',
+      confirmed: true,
+      bytes: makeMemberPhoto(),
+      contentType: 'image/jpeg',
+    });
+
+    expect(stored.width).toBe(600);
+    expect(stored.height).toBe(800);
+    await expect(repo.applications.findById(id)).resolves.toMatchObject({
+      photoKey: stored.key,
+      photoSource: 'UPLOAD',
+    });
+    await expect(objectKeys()).resolves.toEqual([stored.key]);
+  });
+
+  it('uses a random key that reveals nothing about the applicant', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+
+    const stored = await service(repo).store({
+      applicationId: id,
+      source: 'ID_CARD',
+      confirmed: true,
+      bytes: makeMemberPhoto(),
+      contentType: 'image/jpeg',
+    });
+
+    // A bucket listing must not be a membership roster (Issue #1 section 13).
+    expect(stored.key).toMatch(/^member-photos\/[0-9a-f-]{36}\.jpg$/);
+    expect(stored.key).not.toContain(TEST_CITIZEN_ID);
+    expect(stored.key).not.toContain('ทดสอบ');
+    expect(stored.key).not.toContain(id);
+  });
+
+  it('strips EXIF before the bytes reach the bucket', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+
+    const stored = await service(repo).store({
+      applicationId: id,
+      source: 'UPLOAD',
+      confirmed: true,
+      bytes: makeMemberPhoto({ withExif: true }),
+      contentType: 'image/jpeg',
+    });
+
+    expect(stored.metadataStripped).toBe(true);
+    // Read it back out of R2: the guarantee is about what is stored, not about
+    // what the function returned.
+    await expect(objectText(stored.key)).resolves.not.toContain(GPS_MARKER);
+  });
+
+  it('stores no R2 custom metadata', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+    const stored = await service(repo).store({
+      applicationId: id,
+      source: 'UPLOAD',
+      confirmed: true,
+      bytes: makeMemberPhoto(),
+      contentType: 'image/jpeg',
+    });
+
+    const object = await env.MEMBER_PHOTOS.get(stored.key);
+    // Object metadata is another place personal data could accumulate.
+    expect(object!.customMetadata ?? {}).toEqual({});
+    expect(object!.httpMetadata?.contentType).toBe('image/jpeg');
+  });
+
+  it('deletes the previous object when the photo is replaced', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+    const photos = service(repo);
+
+    const first = await photos.store({
+      applicationId: id,
+      source: 'ID_CARD',
+      confirmed: true,
+      bytes: makeMemberPhoto(),
+      contentType: 'image/jpeg',
+    });
+    const second = await photos.store({
+      applicationId: id,
+      source: 'UPLOAD',
+      confirmed: true,
+      bytes: makeMemberPhoto({ width: 900, height: 1200 }),
+      contentType: 'image/jpeg',
+    });
+
+    expect(second.replacedPrevious).toBe(true);
+    // Without this, every retake leaves an orphaned face that nothing
+    // references and nobody will ever delete.
+    await expect(objectKeys()).resolves.toEqual([second.key]);
+    await expect(env.MEMBER_PHOTOS.get(first.key)).resolves.toBeNull();
+  });
+
+  it('reports the source change on a replacement', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+    const photos = service(repo);
+
+    await photos.store({
+      applicationId: id,
+      source: 'ID_CARD',
+      confirmed: true,
+      bytes: makeMemberPhoto(),
+      contentType: 'image/jpeg',
+    });
+    await photos.store({
+      applicationId: id,
+      source: 'UPLOAD',
+      confirmed: true,
+      bytes: makeMemberPhoto(),
+      contentType: 'image/jpeg',
+    });
+
+    await expect(repo.applications.findById(id)).resolves.toMatchObject({
+      photoSource: 'UPLOAD',
+    });
+  });
+
+  it('keeps one photo per applicant even across several applications', async () => {
+    const repo = repository();
+    const mine = await seedApplication(repo, TEST_CITIZEN_ID);
+    const other = await seedApplication(repo, OTHER_TEST_CITIZEN_ID);
+    const photos = service(repo);
+
+    await photos.store({
+      applicationId: mine,
+      source: 'UPLOAD',
+      confirmed: true,
+      bytes: makeMemberPhoto(),
+      contentType: 'image/jpeg',
+    });
+    await photos.store({
+      applicationId: other,
+      source: 'UPLOAD',
+      confirmed: true,
+      bytes: makeMemberPhoto(),
+      contentType: 'image/jpeg',
+    });
+
+    await expect(objectKeys()).resolves.toHaveLength(2);
+  });
+});
+
+describe('consent and eligibility', () => {
+  it('refuses to store without an explicit confirmation', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+
+    // Using the face from the ID card without the applicant saying so is
+    // exactly what Issue #1 section 61 forbids.
+    await expect(
+      service(repo).store({
+        applicationId: id,
+        source: 'ID_CARD',
+        confirmed: false,
+        bytes: makeMemberPhoto(),
+        contentType: 'image/jpeg',
+      }),
+    ).rejects.toThrow(/ยืนยันการเลือกรูป/);
+
+    await expect(objectKeys()).resolves.toEqual([]);
+  });
+
+  it('refuses an unknown application', async () => {
+    await expect(
+      service().store({
+        applicationId: crypto.randomUUID(),
+        source: 'UPLOAD',
+        confirmed: true,
+        bytes: makeMemberPhoto(),
+        contentType: 'image/jpeg',
+      }),
+    ).rejects.toThrow();
+
+    await expect(objectKeys()).resolves.toEqual([]);
+  });
+
+  it('refuses once the application has moved past the editable states', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+    const machine = createStateMachine(repo);
+    for (const status of [
+      'AWAITING_PAYMENT',
+      'PAYMENT_VERIFIED',
+      'SUBMITTED',
+      'MANAGER_NOTIFIED',
+    ] as const) {
+      await machine.transition(id, status);
+    }
+
+    // The photo may already be on a printed card by now, so changing it
+    // silently would leave the card and the record disagreeing.
+    await expect(
+      service(repo).store({
+        applicationId: id,
+        source: 'UPLOAD',
+        confirmed: true,
+        bytes: makeMemberPhoto(),
+        contentType: 'image/jpeg',
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('records a PHOTO_SELECTED audit event carrying only the source', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+    const stored = await service(repo).store({
+      applicationId: id,
+      source: 'ID_CARD',
+      confirmed: true,
+      bytes: makeMemberPhoto(),
+      contentType: 'image/jpeg',
+    });
+
+    const events = await repo.events.listByApplicationId(id);
+    const selected = events.find((event) => event.eventType === 'PHOTO_SELECTED');
+    expect(selected).toMatchObject({ actorType: 'APPLICANT', metadata: { source: 'ID_CARD' } });
+    // The key is the one string that points straight at a stored face.
+    expect(JSON.stringify(events)).not.toContain(stored.key);
+  });
+});
+
+describe('reading a stored photo', () => {
+  it('returns the stored bytes', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+    const photos = service(repo);
+    await photos.store({
+      applicationId: id,
+      source: 'UPLOAD',
+      confirmed: true,
+      bytes: makeMemberPhoto(),
+      contentType: 'image/jpeg',
+    });
+
+    const read = await photos.read(id);
+    expect(read?.contentType).toBe('image/jpeg');
+  });
+
+  it('returns null when the application has no photo', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+
+    await expect(service(repo).read(id)).resolves.toBeNull();
+  });
+
+  it('returns null for an unknown application', async () => {
+    await expect(service().read(crypto.randomUUID())).resolves.toBeNull();
+  });
+});
+
+/* ------------------------------------------------------------- endpoint --- */
+
+function photoForm(
+  applicationId: string,
+  overrides: { source?: string; confirmed?: string; bytes?: Uint8Array; omitFile?: boolean } = {},
+): FormData {
+  const form = new FormData();
+  form.append('applicationId', applicationId);
+  form.append('source', overrides.source ?? 'UPLOAD');
+  form.append('confirmed', overrides.confirmed ?? 'true');
+  if (!overrides.omitFile) {
+    const bytes = overrides.bytes ?? makeMemberPhoto();
+    form.append('photo', new Blob([bytes], { type: 'image/jpeg' }), 'photo.jpg');
+  }
+  return form;
+}
+
+function photoRequest(form: FormData, headers: Record<string, string> = {}): Request {
+  return new Request('http://localhost/api/member-photo', {
+    method: 'POST',
+    headers: {
+      'cf-connecting-ip': '203.0.113.30',
+      [TURNSTILE_TOKEN_HEADER]: 'test-token',
+      ...headers,
+    },
+    body: form,
+  });
+}
+
+describe('POST /api/member-photo', () => {
+  it('stores the photo and reports the shape without leaking the key', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+
+    const response = await exports.default.fetch(photoRequest(photoForm(id)));
+
+    expect(response.status).toBe(200);
+    const body = await response.json<Record<string, unknown>>();
+    expect(body).toMatchObject({ stored: true, source: 'UPLOAD', width: 600, height: 800 });
+    // The client has no use for the key, and it points directly at a face.
+    expect(JSON.stringify(body)).not.toContain('member-photos/');
+    expect(response.headers.get('cache-control')).toBe('no-store');
+  });
+
+  it('refuses a request with no Turnstile token', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+
+    const response = await exports.default.fetch(
+      photoRequest(photoForm(id), { [TURNSTILE_TOKEN_HEADER]: '' }),
+    );
+
+    expect(response.status).toBe(403);
+    await expect(objectKeys()).resolves.toEqual([]);
+  });
+
+  it('refuses when the confirmation is absent', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+
+    const response = await exports.default.fetch(
+      photoRequest(photoForm(id, { confirmed: 'false' })),
+    );
+
+    expect(response.status).toBe(422);
+    await expect(objectKeys()).resolves.toEqual([]);
+  });
+
+  it('refuses an unknown photo source', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+
+    const response = await exports.default.fetch(
+      photoRequest(photoForm(id, { source: 'SCANNED' })),
+    );
+
+    expect(response.status).toBe(422);
+  });
+
+  it('refuses a file that is not really an image', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+    const pdf = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34]);
+
+    const response = await exports.default.fetch(photoRequest(photoForm(id, { bytes: pdf })));
+
+    expect(response.status).toBe(415);
+    await expect(objectKeys()).resolves.toEqual([]);
+  });
+
+  it('refuses a PNG, because its metadata is not rewritten', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+
+    const response = await exports.default.fetch(
+      photoRequest(photoForm(id, { bytes: makePng(600, 800) })),
+    );
+
+    expect(response.status).toBe(415);
+  });
+
+  it('refuses a photo that is not 3:4', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+
+    const response = await exports.default.fetch(
+      photoRequest(photoForm(id, { bytes: makeMemberPhoto({ width: 800, height: 800 }) })),
+    );
+
+    expect(response.status).toBe(422);
+    await expect(objectKeys()).resolves.toEqual([]);
+  });
+
+  it('refuses a request with no file', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+
+    const response = await exports.default.fetch(photoRequest(photoForm(id, { omitFile: true })));
+
+    expect(response.status).toBe(400);
+  });
+
+  it('refuses an application id that is not a uuid', async () => {
+    const response = await exports.default.fetch(photoRequest(photoForm('not-a-uuid')));
+
+    expect(response.status).toBe(422);
+  });
+
+  it('reports a missing application as not found', async () => {
+    const response = await exports.default.fetch(photoRequest(photoForm(crypto.randomUUID())));
+
+    expect(response.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Linked Issue

Closes #10

## Outcome

`POST /api/member-photo` stores the photo the applicant explicitly chose for their membership card, in a private bucket, under a key that reveals nothing, with EXIF removed.

## Scope

- Changed:
  - `src/worker/lib/images.ts` (new) — dimension reading for JPEG/PNG/WebP, JPEG metadata stripping, member photo shape verification
  - `src/worker/services/member-photo.ts` (new) — storage, replacement, consent and eligibility rules, audit event
  - `src/worker/routes/member-photo.ts` (new) — the endpoint
  - `src/worker/lib/logger.ts` — `source` added to the field allowlist (enum-valued, never a file name)
  - `src/worker/index.ts`, `src/worker/services/index.ts` — wiring
  - `tests/support/images.ts` (new) — synthetic JPEG/PNG/WebP builders
  - `tests/unit/images.test.ts`, `tests/worker/member-photo.test.ts` (new)
  - `docs/architecture.md`

- Explicitly not changed:
  - No admin download endpoint. Serving the photo to an authenticated manager is #16; the service exposes a `read` method for it to use.
  - No UI. Preview, crop and the confirmation checklist are #17.
  - No retention or deletion policy. That is #19, and the schema already cascades.

## Why the crop happens in the browser

A Worker has no canvas and no image decoder. The options were a WASM decoder in the Worker, Cloudflare Images, or letting the browser crop and having the Worker verify.

The first costs bundle size and CPU on every upload; the second costs money. For a service handling one or two applications a day, neither is justified — and Issue #1 sections 11 and 12 already put preview and crop in the browser, because that is where the applicant can see what they are choosing.

So the Worker **verifies rather than trusts**: it reads pixel dimensions straight out of the container header, which needs no decoder, checks the 3:4 shape and the size bounds, and strips metadata itself rather than assuming the client's re-encode did.

## Decisions worth reviewing

**1. The object key is a UUID and nothing else**

Not the citizen ID, not the name, not the callsign, not even the application id. A bucket listing must not be a membership roster. A test asserts the key contains none of those.

No R2 `customMetadata` is written either. It is another place personal data would accumulate, and the database already records which application owns which key.

**2. Replacing a photo deletes the old object, and the order matters**

The new key is recorded first, then the old object is deleted. The reverse order would leave the application pointing at an object that no longer exists if the process died between the two steps — and a broken reference is worse than a briefly orphaned object.

Without the delete, every retake would leave a face in the bucket that nothing references and nobody will ever find to delete.

**3. EXIF is stripped in the Worker, not trusted to the client**

APP1 (EXIF, XMP), APP2 (ICC, Flashpix), APP13 (Photoshop IRB, which can hold IPTC captions) and COM are all removed. A phone photo can carry GPS coordinates, the device serial and the capture timestamp; attached to a named applicant's face in a bucket, that is a location history nobody agreed to hand over.

A canvas re-encode in the browser drops all of it, but the client is where an attacker sits.

The test that gives this teeth compares a stripped dirty JPEG against a clean one byte for byte: metadata gone, image data untouched. And the endpoint test reads the object back **out of R2** rather than checking the return value, because the guarantee is about what is stored.

**4. Only JPEG is stored**

PNG and WebP keep metadata in chunks this module does not rewrite (`tEXt`, `iTXt`, `eXIf`, WebP `EXIF`/`XMP`). Accepting them would mean storing exactly the data the strip exists to remove. They are refused, and the client re-encodes to JPEG.

**5. Consent is a required input**

`confirmed` is a required field that must equal `'true'`. Using the face from the ID card because it happens to be available is precisely what Issue #1 section 61 forbids. A test asserts that without it, nothing is written to the bucket at all.

**6. The photo is frozen once the manager is notified**

Editable in `DRAFT`, `AWAITING_PAYMENT`, `PAYMENT_VERIFIED` and `SUBMITTED`. After `MANAGER_NOTIFIED` the photo may already be on a printed card, and changing it silently would leave the card and the record disagreeing.

**7. The key is never returned to the client**

The response reports the shape and whether metadata was stripped. The client has no use for the key, and it is the one string that points directly at a stored face. Asserted by searching the response body for `member-photos/`.

## Verification

| Command / check | Result |
| --- | --- |
| `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\scripts\validate-repository.ps1` | pass — 103 tracked files |
| `npm run lint` | pass |
| `npm run format:check` | pass |
| `npm run typecheck` | pass |
| `npm test` | pass — 19 files / 361 tests (up from 312) |
| `npm run build` | pass |
| `npm run check:worker:production` | pass |

Tests covering the acceptance criteria directly:

- **Random key with no personal data** — asserted against the citizen ID, the Thai name and the application id
- **EXIF removed from the stored bytes** — read back from R2 and searched for the GPS marker
- **Old object deleted on replace** — bucket listing asserted to hold exactly one key, and the old key asserted to be gone
- **No R2 custom metadata** — asserted empty
- **Consent required** — without it, 422 and an empty bucket
- **Only JPEG stored** — a PNG of correct dimensions is refused 415
- **Shape enforced** — square and landscape crops refused; 601x800 accepted, because a pixel-aligned browser crop cannot always hit exactly 0.75
- **Audit event** — `PHOTO_SELECTED` carries only the source, and the whole event list is searched to confirm the key is not in it
- **Frozen after notification** — walking the application to `MANAGER_NOTIFIED` makes the store call fail

A note on a test I had to correct: the byte-for-byte strip comparison originally failed, and the fault was in my test helper, not the code. `padToBytes` padded to a *total file size*, so the file carrying an EXIF segment ended up with less scan data than the clean one, and stripping it could never reproduce the clean file. Padding is now an absolute number of scan bytes, which is what the comparison actually needs.

## Security and privacy

- [x] No secrets, real PII, ID-card images, payment-slip images, or raw provider responses are included.
- [x] Logs contain only allowlisted technical metadata.
- [x] Tests use synthetic data and mocked providers.
- [x] Authentication, authorization, payment, webhook, retention, migration, and deployment impact is described below.

Impact and mitigations:

- **This is the one image that persists**, so it gets the strictest storage rules in the codebase: random key, no metadata, EXIF stripped, old copy deleted, explicit consent, private bucket with `r2.dev` disabled and no custom domain (verified in #26).
- **Access control is not in this PR.** The service exposes `read`, but nothing serves it yet. #16 puts it behind Cloudflare Access. Until then there is no route that returns a stored photo, which is the safe default.
- **Logging** — the store log carries the event, the internal application id, the enum source and the byte length. Not the key, not the file name the applicant chose, not the bytes. `source` was added to the logger allowlist and is enum-valued.
- **Audit trail** — `PHOTO_SELECTED` with `source` only. The key is deliberately absent.
- **Error surface** — every rejection message says what to do (crop to 3:4, use a larger image, shrink the file) without echoing anything from the file. A test puts the GPS marker in a COM segment and confirms it does not appear in the rejection message.
- **Response caching** — `Cache-Control: no-store`.
- **High risk** — stores biometric-adjacent data; human review requested per `AGENTS.md`.

## Deployment / migration / rollback

No migration; `photo_key`, `photo_source` and `photo_uploaded_at` already exist from #6.

Reverting removes the endpoint. Any objects already stored would remain in the bucket with the database still referencing them, so a revert after real use needs no cleanup — but re-applying would then be required before applicants could change a photo.

**Required before this works in production:** `TURNSTILE_SECRET_KEY`. The bucket itself is already provisioned and verified private.

## UI evidence

Not applicable — no UI in this PR.

## Human / AI handoff

- **Completed:** dimension reading for three formats, JPEG metadata stripping, shape verification, the storage service with consent and eligibility rules, the endpoint, 49 new tests
- **Remaining:** #29 (application endpoints) and #11 (payment) are next; #16 will serve the photo to the manager
- **Changed paths:** as listed under Scope
- **Risks / assumptions:**
  - The 3:4 tolerance is 0.02, which accepts roughly 601x800 but rejects 620x800. If real browser crops land outside that, the tolerance needs widening rather than the check removing.
  - Size bounds are 300x400 to 2400x3200. The lower bound is a guess at what prints acceptably on a card and should be checked against whatever the association actually prints with.
  - Rejecting PNG and WebP means the client must re-encode to JPEG. #17 has to do that, or applicants who pick a PNG from their gallery will be refused with a message that does not explain why their file type is wrong.
  - `verifyMemberPhoto` reads dimensions from the header without decoding, so a file whose header disagrees with its pixel data would pass. That would produce a broken card image, not a security problem, and detecting it needs a decoder.
- **Next safe action:** merge, then #29 on `feat/issue-29-application-endpoints`
