### PR TITLE
feat: carry an application from verified payment to the manager

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,6 +47,8 @@ src/worker/            Cloudflare Worker (Hono)
     receipt.ts         receipt issuing and regeneration
     email.ts           transactional email, recorded per message
     email-events.ts    delivery events, and the one status change they cause
+    application-workflow.ts  what happens after a payment is verified
+    workflow-factory.ts      assembly shared by the routes that run it
   lib/logger.ts        allowlist logger; the only sanctioned console sink
   lib/time.ts          Asia/Bangkok conversion and Buddhist-era years
   lib/http.ts          API error codes and applicant-safe messages
@@ -270,6 +272,33 @@ Resend ส่งแบบ at-least-once และเอกสารของเ�
 guard นั้นคือ compare-and-set ของ state machine — **เฉพาะผู้เรียกที่ transition ได้ `APPLIED` เท่านั้นที่ส่งอีเมล** `email.opened` สิบครั้งกับการกดปุ่มแทรกกลางจึงได้อีเมลหนึ่งฉบับ ทางเลือกอื่นคืออ่านสถานะแล้วตัดสิน ซึ่งมีช่องว่างระหว่างการอ่านกับการเขียนที่ทำให้ผู้เรียกทั้งสองเห็นค่าเดียวกัน (test ยืนยันด้วยการยิงพร้อมกัน และการเปลี่ยน guard ให้หลวมทำให้ test fail ด้วยอีเมลสองฉบับ)
 
 อีเมลที่ส่งไม่สำเร็จไม่ย้อนสถานะกลับ ผู้จัดการเริ่มงานไปแล้วจริง การ rollback เพื่อรายงานข้อเท็จจริงหนึ่งจะทำให้เสียข้อเท็จจริงอีกอันไป — แถวอีเมลยังอยู่ให้ retry ได้
+
+## Post-payment workflow
+
+หลังเงินยืนยันแล้ว ผู้สมัครไม่ต้องกด submit อีก (หัวข้อ 28) ระบบเดินต่อเองตามลำดับ:
+
+```text
+PAYMENT_VERIFIED → ออกเลขที่ใบสมัคร → RECEIPT_ISSUED
+  → RECEIPT_EMAIL_SENT → APPLICATION_SUBMITTED → MANAGER_EMAIL_SENT
+```
+
+เลขที่ใบสมัครมาก่อนใบเสร็จ เพราะทั้งใบเสร็จและอีเมลทั้งสองฉบับพิมพ์เลขนี้ ถ้าออกใบเสร็จก่อน เอกสารที่สมาชิกเก็บไว้จะขึ้นว่า "ยังไม่ออกเลขที่ใบสมัคร"
+
+**ไม่มีคอลัมน์ `current_step`** แต่ละขั้นตัดสินว่าตัวเองเสร็จแล้วหรือยัง จากสิ่งที่มันควรจะสร้างไว้ — เลขที่บนแถว, ใบเสร็จของใบสมัครนี้, อีเมลชนิดนั้นที่ provider รับแล้ว, หรือสถานะเอง คอลัมน์บอกความคืบหน้าคือแหล่งความจริงที่สองซึ่งขัดกับแหล่งแรกได้ และแหล่งแรกคือแหล่งที่นับ
+
+**ขั้นที่ล้มเหลวไม่ล้มขั้นก่อนหน้า** ตอนนี้สมาคมมีเงินแล้ว ถ้า Resend ล่ม ใบเสร็จยังออก ใบสมัครยังถูก submit และแถวอีเมลถือความล้มเหลวของตัวเองไว้ให้ retry `resume` เริ่มต่อจากจุดที่ครั้งก่อนหยุดพอดี — provider ล่มจึงมีราคาเท่ากับการ retry ไม่ใช่การเสียการชำระเงิน
+
+`MANAGER_NOTIFIED` ถูกบันทึกเฉพาะเมื่อ **อีเมลผู้จัดการถูกรับจริง** เพราะสถานะนี้บอกว่า "แจ้งผู้จัดการแล้ว" และ #14 ใช้สถานะนี้เป็นฐานของการนับ open ถ้าบันทึกหลังส่งไม่สำเร็จ ใบสมัครที่ยังไม่มีใครเห็นจะดูเหมือนถูกจัดการแล้ว
+
+### จุดที่ยิงพร้อมกันได้
+
+`resume` สองครั้งพร้อมกันจะอ่านว่า "ยังไม่มีอีเมลชนิดนี้" ทั้งคู่ ฝ่ายที่แพ้ `UNIQUE(application_id, type)` (migration 0004) จะ **ส่งไปที่แถวที่ชนะ** ไม่ใช่สร้างแถวใหม่ ทั้งคู่จึงใช้ idempotency key เดียวกันและ Resend คืน message เดิม ผู้รับได้อีเมลฉบับเดียว (test พิสูจน์ด้วยการเอา migration ออกแล้ว test fail ด้วยสองแถว)
+
+### Endpoint
+
+- `POST /api/payment/verify` รัน workflow ต่อทันทีหลัง commit การยืนยัน แล้วคืนสถานะแต่ละขั้นมาด้วย
+- `GET /api/applications/:id/confirmation` อ่านสถานะแต่ละขั้น (หัวข้อ 66) **อ่านอย่างเดียว** — การ resume จาก GET จะทำให้การ refresh หน้า, prefetch หรือ link preview ส่งอีเมลได้
+- `POST /api/applications/:id/finalize` เดินขั้นที่ค้างให้จบ ใช้ capability token เดิมกับที่ยืนยันการชำระเงิน และมี rate limit เพราะเรียก provider ได้ ฝั่งผู้จัดการจะได้ action เทียบเท่าที่ไม่ต้องใช้ token ของผู้สมัครใน #16
 
 ## Decision records
 

--- a/migrations/0004_unique_email_per_application_and_type.sql
+++ b/migrations/0004_unique_email_per_application_and_type.sql
@@ -1,0 +1,21 @@
+-- One email of each type per application.
+--
+-- Every one of the four transactional emails answers a question that is asked
+-- once about an application: here is your receipt, here is a new application,
+-- work has started, registration is recorded. A second row of the same type is
+-- never a legitimate second message - it is two callers having both read "no
+-- email yet" before either wrote one, which is exactly what happens when the
+-- post-payment workflow is resumed while a first attempt is still running.
+--
+-- Retries do not create rows: they reuse the existing one, which keeps the
+-- provider idempotency key stable so a send whose outcome was never learned
+-- cannot be delivered twice. So this costs nothing legitimate and makes the
+-- guarantee the database's rather than a read-then-write check's.
+--
+-- 0001 already indexed the same two columns for lookup. A unique index serves
+-- that lookup equally well, so the plain one is replaced rather than added to -
+-- keeping the name means nothing else has to change.
+
+DROP INDEX idx_emails_application_id_type;
+
+CREATE UNIQUE INDEX idx_emails_application_id_type ON emails (application_id, type);

--- a/src/worker/providers/mock/slip.ts
+++ b/src/worker/providers/mock/slip.ts
@@ -22,6 +22,8 @@ export interface MockSlipOptions {
   failWith?: Extract<SlipVerificationResult, { ok: false }>['reason'];
   /** When true the returned amount mirrors `expectedAmount`. */
   matchExpectedAmount?: boolean;
+  /** Clock for the default transfer time. Injected by tests that pin dates. */
+  now?: () => Date;
 }
 
 export function createMockSlipProvider(options: MockSlipOptions = {}): SlipVerificationProvider {
@@ -34,9 +36,21 @@ export function createMockSlipProvider(options: MockSlipOptions = {}): SlipVerif
       const amount =
         options.transaction?.amount ??
         (options.matchExpectedAmount === false ? MOCK_TRANSACTION.amount : request.expectedAmount);
+
+      // The transfer time defaults to now rather than to the fixed value in
+      // `MOCK_TRANSACTION`, because verification refuses a slip older than
+      // seven days: a constant would make every mock payment fail as stale, in
+      // local development as well as in tests. Callers that pin a clock pass
+      // `transaction.transactionAt` or `now` and get exactly what they asked
+      // for.
+      const transactionAt =
+        options.transaction?.transactionAt !== undefined
+          ? options.transaction.transactionAt
+          : (options.now ?? (() => new Date()))().toISOString();
+
       return {
         ok: true,
-        transaction: { ...MOCK_TRANSACTION, ...options.transaction, amount },
+        transaction: { ...MOCK_TRANSACTION, ...options.transaction, amount, transactionAt },
       };
     },
   };

--- a/src/worker/routes/applications.ts
+++ b/src/worker/routes/applications.ts
@@ -15,6 +15,7 @@ import {
   ACCESS_TOKEN_HEADER,
   createApplicationAccess,
 } from '../services/application-access';
+import { buildApplicationWorkflow } from '../services/workflow-factory';
 
 /**
  * Applicant-facing application endpoints (Issue #1 section 51).
@@ -175,6 +176,70 @@ export const applicationRoutes = new Hono<AppContext>()
 
     c.header('Cache-Control', 'no-store');
     return c.json({ application });
+  })
+
+  /**
+   * What the confirmation page reads (Issue #1 section 66): the application
+   * number and which of the post-payment steps have happened.
+   *
+   * Read-only on purpose. Resuming the workflow from a `GET` would mean a page
+   * refresh, a prefetch or a link preview could send email, so finishing a
+   * stalled application is a `POST`.
+   */
+  .get('/applications/:id/confirmation', async (c) => {
+    const applicationId = idSchema.parse(c.req.param('id'));
+
+    const { access } = await buildServices(c.env, c.var.db);
+    await access.authorize(c.req.raw, applicationId);
+
+    const workflow = await buildApplicationWorkflow(
+      c.env,
+      c.var.db,
+      c.var.providers.email,
+      c.var.config.APP_BASE_URL,
+    );
+
+    c.header('Cache-Control', 'no-store');
+    return c.json({ confirmation: await workflow.inspect(applicationId) });
+  })
+
+  /**
+   * Finishes an application whose post-payment steps did not all complete,
+   * typically because the email provider was unavailable.
+   *
+   * Every step is idempotent, so this is safe to call repeatedly: it does the
+   * work that is missing and nothing else. Rate limited because each call can
+   * reach the email provider, and authenticated by the applicant's capability
+   * token - the same token that verified the payment. The manager gets an
+   * equivalent action without the applicant's token in #16.
+   */
+  .post('/applications/:id/finalize', async (c) => {
+    const applicationId = idSchema.parse(c.req.param('id'));
+
+    const { access } = await buildServices(c.env, c.var.db);
+    await access.authorize(c.req.raw, applicationId);
+    await assertWithinRateLimit(
+      c.var.security.rateLimiter,
+      APPLICATION_POLICY,
+      clientIdentifier(c.req.raw),
+    );
+
+    const workflow = await buildApplicationWorkflow(
+      c.env,
+      c.var.db,
+      c.var.providers.email,
+      c.var.config.APP_BASE_URL,
+    );
+    const report = await workflow.resume(applicationId);
+
+    c.var.logger.info({
+      event: 'workflow.finalized',
+      applicationId,
+      reason: report.complete ? 'COMPLETE' : 'INCOMPLETE',
+    });
+
+    c.header('Cache-Control', 'no-store');
+    return c.json({ confirmation: report });
   });
 
 export { ACCESS_TOKEN_HEADER };

--- a/src/worker/routes/payment.ts
+++ b/src/worker/routes/payment.ts
@@ -16,6 +16,7 @@ import { formatBaht, membershipPlan } from '../services/membership';
 import { createPaymentService } from '../services/payment';
 import type { AssociationAccount } from '../services/payment';
 import { createStateMachine } from '../services/state-machine';
+import { buildApplicationWorkflow } from '../services/workflow-factory';
 
 /**
  * Payment endpoints.
@@ -177,11 +178,33 @@ export const paymentRoutes = new Hono<AppContext>()
       source: evidence.kind === 'qr' ? 'QR' : 'IMAGE',
     });
 
+    // Everything after the money is confirmed happens here rather than on a
+    // second request from the applicant (Issue #1 section 28). It runs after
+    // verification has been committed, so a provider failure inside it leaves
+    // the payment and the receipt intact and reports which step stalled.
+    const workflow = await buildApplicationWorkflow(
+      c.env,
+      c.var.db,
+      c.var.providers.email,
+      c.var.config.APP_BASE_URL,
+    );
+    const report = await workflow.resume(applicationId);
+
+    c.var.logger.info({
+      event: 'workflow.resumed',
+      applicationId,
+      reason: report.complete ? 'COMPLETE' : 'INCOMPLETE',
+    });
+
     c.header('Cache-Control', 'no-store');
     return c.json({
       verified: true,
       amountSatang: verified.amountSatang,
       amountBaht: formatBaht(verified.amountSatang),
-      status: 'PAYMENT_VERIFIED',
+      status: report.status,
+      referenceNo: report.referenceNo,
+      receiptNo: report.receiptNo,
+      steps: report.steps,
+      complete: report.complete,
     });
   });

--- a/src/worker/services/application-workflow.ts
+++ b/src/worker/services/application-workflow.ts
@@ -1,0 +1,270 @@
+import type { ApplicationRecord, EmailRecord, EmailType, Repository } from '../db';
+import type { EmailOutcome, EmailService } from './email';
+import type { NumberingService } from './numbering';
+import type { ReceiptService } from './receipt';
+import type { StateMachine } from './state-machine';
+
+/**
+ * What happens after a payment is verified (Issue #1 section 28).
+ *
+ * The applicant does not press submit again. Once the money is confirmed the
+ * system carries the application the rest of the way on its own:
+ *
+ *   PAYMENT_VERIFIED -> number assigned -> RECEIPT_ISSUED
+ *     -> RECEIPT_EMAIL_SENT -> APPLICATION_SUBMITTED -> MANAGER_EMAIL_SENT
+ *
+ * Two properties govern every line of this module.
+ *
+ * **Nothing already done is done again, and there is no progress column.** Each
+ * step decides whether it has already happened by looking at what it would have
+ * produced: a reference number on the row, a receipt for the application, a sent
+ * email of that type, the status itself. A `current_step` column would be a
+ * second source of truth that can disagree with the first, and it is the first
+ * that matters.
+ *
+ * **A step that fails does not undo the steps before it.** By the time this runs
+ * the association has the money. If Resend is down, the receipt is still issued
+ * and the application is still submitted; the email rows carry their own failure
+ * and can be retried. `resume` picks up exactly where the previous attempt
+ * stopped, so a provider outage costs a retry rather than a lost payment.
+ */
+
+export const WORKFLOW_STEPS = [
+  'APPLICATION_NUMBER',
+  'RECEIPT',
+  'RECEIPT_EMAIL',
+  'SUBMISSION',
+  'MANAGER_EMAIL',
+] as const;
+
+export type WorkflowStep = (typeof WORKFLOW_STEPS)[number];
+
+export type StepState =
+  /** Completed by this run. */
+  | 'DONE'
+  /** Was already complete before this run; nothing was repeated. */
+  | 'ALREADY_DONE'
+  /** Attempted and failed. A later `resume` will try it again. */
+  | 'FAILED'
+  /** Not attempted, because an earlier step it depends on did not complete. */
+  | 'SKIPPED';
+
+export interface WorkflowReport {
+  applicationId: string;
+  /** Null only if the very first step failed. */
+  referenceNo: string | null;
+  receiptNo: string | null;
+  status: ApplicationRecord['status'];
+  steps: Record<WorkflowStep, StepState>;
+  /** True when every step is `DONE` or `ALREADY_DONE`. */
+  complete: boolean;
+}
+
+export const APPLICATION_SUBMITTED_EVENT = 'APPLICATION_SUBMITTED';
+export const MANAGER_NOTIFIED_EVENT = 'MANAGER_NOTIFIED';
+
+export class WorkflowApplicationNotFoundError extends Error {
+  constructor() {
+    super('ไม่พบใบสมัครนี้');
+    this.name = 'WorkflowApplicationNotFoundError';
+  }
+}
+
+export interface ApplicationWorkflow {
+  /**
+   * Runs every step that has not already completed, and reports each one.
+   *
+   * Safe to call repeatedly: this is both the path taken straight after
+   * verification and the way a stalled application is finished later.
+   */
+  resume(applicationId: string): Promise<WorkflowReport>;
+  /** The same report without attempting anything, for the confirmation page. */
+  inspect(applicationId: string): Promise<WorkflowReport>;
+}
+
+/** An email of this type that the provider accepted. */
+function acceptedEmail(rows: readonly EmailRecord[]): EmailRecord | null {
+  return rows.find((row) => row.status !== 'QUEUED' && row.status !== 'FAILED') ?? null;
+}
+
+/** The row a retry should reuse, so the provider deduplicates it. */
+function retryableEmail(rows: readonly EmailRecord[]): EmailRecord | null {
+  return rows.find((row) => row.status === 'QUEUED' || row.status === 'FAILED') ?? null;
+}
+
+/**
+ * Statuses at or past submission. Reaching one means the submission step has
+ * happened, whatever has become of the application since.
+ */
+const SUBMITTED_OR_LATER: readonly ApplicationRecord['status'][] = [
+  'SUBMITTED',
+  'MANAGER_NOTIFIED',
+  'NBTC_PROCESSING',
+  'NBTC_RECORDED',
+  'COMPLETED',
+];
+
+const NOTIFIED_OR_LATER: readonly ApplicationRecord['status'][] = [
+  'MANAGER_NOTIFIED',
+  'NBTC_PROCESSING',
+  'NBTC_RECORDED',
+  'COMPLETED',
+];
+
+export function createApplicationWorkflow(
+  db: Repository,
+  machine: StateMachine,
+  numbering: NumberingService,
+  receipts: ReceiptService,
+  emails: EmailService,
+): ApplicationWorkflow {
+  const load = async (applicationId: string): Promise<ApplicationRecord> => {
+    const application = await db.applications.findById(applicationId);
+    if (!application) throw new WorkflowApplicationNotFoundError();
+    return application;
+  };
+
+  /**
+   * Sends an email of `type` unless one has already been accepted, reusing a
+   * failed row so the provider's idempotency key stays the same.
+   */
+  const ensureEmail = async (
+    applicationId: string,
+    type: EmailType,
+    send: () => Promise<EmailOutcome>,
+  ): Promise<StepState> => {
+    const rows = await db.emails.findByApplicationIdAndType(applicationId, type);
+    if (acceptedEmail(rows)) return 'ALREADY_DONE';
+
+    const pending = retryableEmail(rows);
+    const outcome = pending ? await emails.retry(pending.id) : await send();
+    return outcome.ok ? 'DONE' : 'FAILED';
+  };
+
+  const report = async (
+    application: ApplicationRecord,
+    steps: Record<WorkflowStep, StepState>,
+  ): Promise<WorkflowReport> => {
+    const receipt = await db.receipts.findByApplicationId(application.id);
+    const current = await load(application.id);
+
+    return {
+      applicationId: current.id,
+      referenceNo: current.referenceNo,
+      receiptNo: receipt?.receiptNo ?? null,
+      status: current.status,
+      steps,
+      complete: WORKFLOW_STEPS.every(
+        (step) => steps[step] === 'DONE' || steps[step] === 'ALREADY_DONE',
+      ),
+    };
+  };
+
+  return {
+    async resume(applicationId) {
+      const application = await load(applicationId);
+      const steps: Record<WorkflowStep, StepState> = {
+        APPLICATION_NUMBER: 'SKIPPED',
+        RECEIPT: 'SKIPPED',
+        RECEIPT_EMAIL: 'SKIPPED',
+        SUBMISSION: 'SKIPPED',
+        MANAGER_EMAIL: 'SKIPPED',
+      };
+
+      // The number is first because the receipt and both emails print it. An
+      // application that reached payment without one would put "ยังไม่ออกเลขที่
+      // ใบสมัคร" on a document the member keeps.
+      if (application.referenceNo) {
+        steps.APPLICATION_NUMBER = 'ALREADY_DONE';
+      } else {
+        try {
+          await numbering.assignApplicationNumber(applicationId);
+          steps.APPLICATION_NUMBER = 'DONE';
+        } catch {
+          // Nothing downstream can be produced correctly without it, so the
+          // run stops here rather than issuing a receipt with no number on it.
+          steps.APPLICATION_NUMBER = 'FAILED';
+          return report(application, steps);
+        }
+      }
+
+      try {
+        const issued = await receipts.issue(applicationId);
+        steps.RECEIPT = issued.created ? 'DONE' : 'ALREADY_DONE';
+      } catch {
+        // The receipt is the member's proof that the money was received. The
+        // rest of the flow is about telling people, which is worth less than
+        // getting this right, so a failure here stops the run.
+        steps.RECEIPT = 'FAILED';
+        return report(application, steps);
+      }
+
+      steps.RECEIPT_EMAIL = await ensureEmail(applicationId, 'RECEIPT', () =>
+        emails.sendReceipt(applicationId),
+      );
+
+      // Submission happens whether or not the receipt email went out. The
+      // application is complete from the applicant's side either way, and
+      // holding it back because a provider was down would leave it invisible to
+      // the manager.
+      if (SUBMITTED_OR_LATER.includes(application.status)) {
+        steps.SUBMISSION = 'ALREADY_DONE';
+      } else {
+        const outcome = await machine.transition(applicationId, 'SUBMITTED', {
+          actorType: 'SYSTEM',
+          domainEvent: APPLICATION_SUBMITTED_EVENT,
+          timestamps: { submittedAt: new Date().toISOString() },
+        });
+        steps.SUBMISSION =
+          outcome.kind === 'APPLIED'
+            ? 'DONE'
+            : outcome.kind === 'ALREADY_IN_TARGET_STATE'
+              ? 'ALREADY_DONE'
+              : 'FAILED';
+        if (steps.SUBMISSION === 'FAILED') return report(application, steps);
+      }
+
+      steps.MANAGER_EMAIL = await ensureEmail(applicationId, 'MANAGER_NEW_APPLICATION', () =>
+        emails.sendManagerNewApplication(applicationId),
+      );
+
+      // `MANAGER_NOTIFIED` states that the manager has been told, so it is only
+      // recorded when an email was actually accepted. Recording it after a
+      // failed send would make the application look handled when nobody has
+      // heard about it - and #14 keys the manager's open off that status.
+      if (steps.MANAGER_EMAIL === 'DONE' || steps.MANAGER_EMAIL === 'ALREADY_DONE') {
+        if (!NOTIFIED_OR_LATER.includes(application.status)) {
+          await machine.transition(applicationId, 'MANAGER_NOTIFIED', {
+            actorType: 'SYSTEM',
+            domainEvent: MANAGER_NOTIFIED_EVENT,
+          });
+        }
+      }
+
+      // No summary event: the sequence in Issue #1 section 50 already ends with
+      // `MANAGER_EMAIL_SENT`, and a `WORKFLOW_COMPLETED` row would say nothing
+      // the preceding rows do not.
+      return report(application, steps);
+    },
+
+    async inspect(applicationId) {
+      const application = await load(applicationId);
+      const [receipt, receiptEmails, managerEmails] = await Promise.all([
+        db.receipts.findByApplicationId(applicationId),
+        db.emails.findByApplicationIdAndType(applicationId, 'RECEIPT'),
+        db.emails.findByApplicationIdAndType(applicationId, 'MANAGER_NEW_APPLICATION'),
+      ]);
+
+      const state = (done: boolean, attempted: boolean): StepState =>
+        done ? 'ALREADY_DONE' : attempted ? 'FAILED' : 'SKIPPED';
+
+      return report(application, {
+        APPLICATION_NUMBER: application.referenceNo ? 'ALREADY_DONE' : 'SKIPPED',
+        RECEIPT: receipt ? 'ALREADY_DONE' : 'SKIPPED',
+        RECEIPT_EMAIL: state(acceptedEmail(receiptEmails) !== null, receiptEmails.length > 0),
+        SUBMISSION: SUBMITTED_OR_LATER.includes(application.status) ? 'ALREADY_DONE' : 'SKIPPED',
+        MANAGER_EMAIL: state(acceptedEmail(managerEmails) !== null, managerEmails.length > 0),
+      });
+    },
+  };
+}

--- a/src/worker/services/email.ts
+++ b/src/worker/services/email.ts
@@ -7,6 +7,7 @@ import type {
   ReceiptRecord,
   Repository,
 } from '../db';
+import { UniqueConstraintError } from '../db';
 import {
   displayName,
   managerNewApplicationEmail,
@@ -145,6 +146,21 @@ function dateLabel(value: string | null): string | null {
   const parsed = new Date(`${value}T00:00:00+07:00`);
   return Number.isNaN(parsed.getTime()) ? null : formatThaiDate(parsed);
 }
+
+/**
+ * Audit event name per email type.
+ *
+ * Issue #1 section 50 names each of these in the example trail, so the trail
+ * reads as a sequence of things that happened rather than four rows of
+ * `EMAIL_SENT` distinguished only by metadata. Failures stay generic: the
+ * specification does not name them, and the type is in the metadata either way.
+ */
+const SENT_EVENT_BY_TYPE: Readonly<Record<EmailType, string>> = {
+  RECEIPT: 'RECEIPT_EMAIL_SENT',
+  MANAGER_NEW_APPLICATION: 'MANAGER_EMAIL_SENT',
+  MEMBER_PROCESSING: 'MEMBER_PROCESSING_EMAIL_SENT',
+  MEMBER_NBTC_COMPLETED: 'MEMBER_COMPLETION_EMAIL_SENT',
+};
 
 function englishName(application: ApplicationRecord): string | null {
   const name = [application.firstNameEn, application.lastNameEn]
@@ -292,6 +308,21 @@ export function createEmailService(
     }
   };
 
+  /**
+   * Resolves a failed insert that was actually a lost race, or null when the
+   * failure was something else and must not be swallowed.
+   */
+  const concurrentWinner = async (
+    error: unknown,
+    applicationId: string,
+    type: EmailType,
+  ): Promise<EmailRecord | null> => {
+    if (!(error instanceof UniqueConstraintError)) return null;
+    if (!error.constraintName.includes('application_id')) return null;
+    const rows = await db.emails.findByApplicationIdAndType(applicationId, type);
+    return rows[0] ?? null;
+  };
+
   const dispatch = async (record: EmailRecord, prepared: Prepared): Promise<EmailOutcome> => {
     const result = await provider.send({
       to: prepared.recipient,
@@ -319,7 +350,7 @@ export function createEmailService(
     await db.emails.markSent(record.id, result.providerEmailId, now().toISOString());
     await audit.record({
       applicationId: record.applicationId,
-      eventType: 'EMAIL_SENT',
+      eventType: SENT_EVENT_BY_TYPE[record.type],
       actorType: 'SYSTEM',
       metadata: { emailType: record.type, provider: provider.name },
     });
@@ -350,12 +381,24 @@ export function createEmailService(
       return skip(applicationId, type, reason);
     }
 
-    const record = await db.emails.create({
-      applicationId,
-      type,
-      recipient: prepared.recipient,
-      provider: provider.name,
-    });
+    let record: EmailRecord;
+    try {
+      record = await db.emails.create({
+        applicationId,
+        type,
+        recipient: prepared.recipient,
+        provider: provider.name,
+      });
+    } catch (error) {
+      // Two callers both read "no email of this type yet" and both tried to
+      // create one; the unique index decided. The loser dispatches to the row
+      // that won, so both share one idempotency key and the recipient gets one
+      // message instead of two.
+      const raced = await concurrentWinner(error, applicationId, type);
+      if (!raced) throw error;
+      record = raced;
+    }
+
     return dispatch(record, prepared);
   };
 

--- a/src/worker/services/index.ts
+++ b/src/worker/services/index.ts
@@ -1,4 +1,5 @@
 export * from './application';
+export * from './application-workflow';
 export * from './application-access';
 export * from './audit';
 export * from './email';
@@ -9,3 +10,4 @@ export * from './receipt';
 export * from './member-photo';
 export * from './numbering';
 export * from './state-machine';
+export * from './workflow-factory';

--- a/src/worker/services/workflow-factory.ts
+++ b/src/worker/services/workflow-factory.ts
@@ -1,0 +1,42 @@
+import type { Repository } from '../db';
+import { requireSecret } from '../env';
+import type { WorkerEnv } from '../env';
+import { createCitizenIdProtection } from '../lib/crypto';
+import type { EmailProvider } from '../providers/types';
+import { createAuditLog } from './audit';
+import { createEmailService } from './email';
+import { createApplicationWorkflow } from './application-workflow';
+import type { ApplicationWorkflow } from './application-workflow';
+import { createNumberingService } from './numbering';
+import { createReceiptService } from './receipt';
+import { createStateMachine } from './state-machine';
+
+/**
+ * Assembly for the post-payment workflow.
+ *
+ * The workflow needs numbering, the receipt service, the email service and the
+ * state machine, and the email service in turn needs the receipt service and
+ * the citizen ID key. Two routes construct all of that - the one that verifies a
+ * payment and the one that reports or resumes the result - and building it twice
+ * by hand is how the two end up differing in a way nothing catches.
+ */
+export async function buildApplicationWorkflow(
+  env: WorkerEnv,
+  db: Repository,
+  emailProvider: EmailProvider,
+  appBaseUrl: string,
+): Promise<ApplicationWorkflow> {
+  const audit = createAuditLog(db);
+  const numbering = createNumberingService(db);
+  const receipts = createReceiptService(db, numbering, audit);
+
+  const emails = createEmailService(db, emailProvider, receipts, audit, {
+    managerEmail: requireSecret(env, 'MANAGER_EMAIL'),
+    appBaseUrl,
+    // Only the manager notification uses this, to show four digits of the
+    // citizen ID; see docs/decisions/0002-citizen-id-not-in-email.md.
+    citizenId: await createCitizenIdProtection(requireSecret(env, 'PII_ENCRYPTION_KEY')),
+  });
+
+  return createApplicationWorkflow(db, createStateMachine(db), numbering, receipts, emails);
+}

--- a/tests/worker/application-workflow.test.ts
+++ b/tests/worker/application-workflow.test.ts
@@ -1,0 +1,586 @@
+import { exports } from 'cloudflare:workers';
+import { describe, expect, it } from 'vitest';
+import type { MembershipType, PaymentInput, Repository } from '../../src/worker/db';
+import { createMockEmailProvider } from '../../src/worker/providers/mock/email';
+import type { MockEmailProvider } from '../../src/worker/providers/mock/email';
+import { TURNSTILE_TOKEN_HEADER } from '../../src/worker/security/turnstile';
+import { createAuditLog } from '../../src/worker/services/audit';
+import { ACCESS_TOKEN_HEADER } from '../../src/worker/services/application-access';
+import { createApplicationWorkflow } from '../../src/worker/services/application-workflow';
+import type {
+  ApplicationWorkflow,
+  WorkflowReport,
+} from '../../src/worker/services/application-workflow';
+import { createEmailService } from '../../src/worker/services/email';
+import { createNumberingService } from '../../src/worker/services/numbering';
+import { createReceiptService } from '../../src/worker/services/receipt';
+import { createStateMachine } from '../../src/worker/services/state-machine';
+import { ANNUAL_SATANG, LIFETIME_SATANG, repository, seedApplication } from '../support/fixtures';
+
+/**
+ * The post-payment sequence (Issue #1 section 28), end to end inside the worker.
+ *
+ * Most of these drive the service so the mock email provider can be inspected
+ * and made to fail. The two route tests exist for one acceptance criterion that
+ * cannot be checked any other way: that the applicant does not have to send a
+ * second request.
+ */
+
+const APPLICANT_EMAIL = 'applicant@example.test';
+const MANAGER_EMAIL = 'manager@example.test';
+
+interface Harness {
+  repo: Repository;
+  provider: MockEmailProvider;
+  workflow: ApplicationWorkflow;
+}
+
+function harness(
+  repo: Repository,
+  options: { failEmails?: 'REJECTED' | 'PROVIDER_ERROR' } = {},
+): Harness {
+  const provider = createMockEmailProvider(
+    options.failEmails ? { failWith: options.failEmails } : {},
+  );
+  const audit = createAuditLog(repo);
+  const numbering = createNumberingService(repo);
+  const receipts = createReceiptService(repo, numbering, audit);
+  const emails = createEmailService(repo, provider, receipts, audit, {
+    managerEmail: MANAGER_EMAIL,
+    appBaseUrl: 'https://membership.example.test',
+  });
+
+  return {
+    repo,
+    provider,
+    workflow: createApplicationWorkflow(
+      repo,
+      createStateMachine(repo),
+      numbering,
+      receipts,
+      emails,
+    ),
+  };
+}
+
+function paymentInput(applicationId: string, amountSatang: number): PaymentInput {
+  return {
+    applicationId,
+    provider: 'slipok',
+    transactionRef: `TXN-${crypto.randomUUID()}`,
+    amountSatang,
+    sendingBank: '002',
+    receivingBank: 'ธนาคารตัวอย่าง',
+    receiverAccountDigits: '1234',
+    transactionAt: new Date().toISOString(),
+    receiverMatched: true,
+    amountMatched: true,
+    verificationStatus: 'VERIFIED',
+    verifiedAt: new Date().toISOString(),
+  };
+}
+
+/** An application in `PAYMENT_VERIFIED`, which is where this workflow starts. */
+async function paidApplication(
+  repo: Repository,
+  membership: MembershipType = 'ANNUAL',
+  citizenId?: string,
+): Promise<string> {
+  const amount = membership === 'ANNUAL' ? ANNUAL_SATANG : LIFETIME_SATANG;
+  const id = await seedApplication(repo, citizenId);
+  await repo.applications.updateContact(id, { email: APPLICANT_EMAIL, phone: '0800000000' });
+  await repo.applications.setMembership(id, membership, amount);
+  await repo.payments.create(paymentInput(id, amount));
+
+  const machine = createStateMachine(repo);
+  await machine.transition(id, 'AWAITING_PAYMENT');
+  // The domain event matters: the payment service records it, and the workflow
+  // trail is asserted against the sequence in Issue #1 section 50.
+  await machine.transition(id, 'PAYMENT_VERIFIED', { domainEvent: 'PAYMENT_VERIFIED' });
+  return id;
+}
+
+function eventTypes(events: readonly { eventType: string }[]): string[] {
+  return events.map((event) => event.eventType);
+}
+
+describe('the happy path', () => {
+  it('carries an annual application all the way to the manager', async () => {
+    const repo = repository();
+    const { workflow, provider } = harness(repo);
+    const id = await paidApplication(repo, 'ANNUAL');
+
+    const report = await workflow.resume(id);
+
+    expect(report.complete).toBe(true);
+    expect(report.steps).toEqual({
+      APPLICATION_NUMBER: 'DONE',
+      RECEIPT: 'DONE',
+      RECEIPT_EMAIL: 'DONE',
+      SUBMISSION: 'DONE',
+      MANAGER_EMAIL: 'DONE',
+    });
+    expect(report.referenceNo).toMatch(/^VRA-\d{4}-\d{6}$/);
+    expect(report.receiptNo).toMatch(/^VRA-RC-\d{4}-\d{6}$/);
+    expect(report.status).toBe('MANAGER_NOTIFIED');
+    expect(provider.sent).toHaveLength(2);
+  });
+
+  it('carries a lifetime application the same way, for the lifetime amount', async () => {
+    const repo = repository();
+    const { workflow, provider } = harness(repo);
+    const id = await paidApplication(repo, 'LIFETIME');
+
+    const report = await workflow.resume(id);
+
+    expect(report.complete).toBe(true);
+    expect(report.status).toBe('MANAGER_NOTIFIED');
+    const receipt = await repo.receipts.findByApplicationId(id);
+    expect(receipt?.amountSatang).toBe(LIFETIME_SATANG);
+    expect(provider.sent[0]!.text).toContain('2,000.00 บาท');
+    expect(provider.sent[0]!.text).toContain('สมาชิกสามัญตลอดชีพ');
+  });
+
+  it('attaches the receipt to the member email and nothing to the manager one', async () => {
+    const repo = repository();
+    const { workflow, provider } = harness(repo);
+    const id = await paidApplication(repo);
+
+    await workflow.resume(id);
+
+    const receiptEmail = provider.sent.find((email) => email.to === APPLICANT_EMAIL)!;
+    const managerEmail = provider.sent.find((email) => email.to === MANAGER_EMAIL)!;
+    expect(receiptEmail.attachments).toHaveLength(1);
+    expect(managerEmail.attachments ?? []).toHaveLength(0);
+  });
+
+  it('prints the application number on the receipt rather than a placeholder', async () => {
+    const repo = repository();
+    const { workflow } = harness(repo);
+    const id = await paidApplication(repo);
+
+    // The number is assigned before the receipt is issued for exactly this
+    // reason: the member keeps the document.
+    const report = await workflow.resume(id);
+    const receipts = createReceiptService(repo, createNumberingService(repo), createAuditLog(repo));
+    const rendered = await receipts.render(id);
+
+    expect(report.referenceNo).not.toBeNull();
+    expect(rendered.bytes.byteLength).toBeGreaterThan(0);
+  });
+
+  it('records the audit trail in the documented order', async () => {
+    const repo = repository();
+    const { workflow } = harness(repo);
+    const id = await paidApplication(repo);
+
+    await workflow.resume(id);
+
+    // Issue #1 section 50 names these events and their order.
+    const types = eventTypes(await repo.events.listByApplicationId(id));
+    const expected = [
+      'PAYMENT_VERIFIED',
+      'RECEIPT_ISSUED',
+      'RECEIPT_EMAIL_SENT',
+      'APPLICATION_SUBMITTED',
+      'MANAGER_EMAIL_SENT',
+    ];
+    const positions = expected.map((event) => types.indexOf(event));
+    expect(positions.every((position) => position >= 0)).toBe(true);
+    expect([...positions].sort((a, b) => a - b)).toEqual(positions);
+  });
+
+  it('logs no applicant details in the audit trail', async () => {
+    const repo = repository();
+    const { workflow } = harness(repo);
+    const id = await paidApplication(repo);
+
+    await workflow.resume(id);
+
+    const events = JSON.stringify(await repo.events.listByApplicationId(id));
+    expect(events).not.toContain(APPLICANT_EMAIL);
+    expect(events).not.toContain('ทดสอบ');
+    expect(events).not.toContain('1234567890121');
+  });
+});
+
+describe('running it again', () => {
+  it('repeats nothing', async () => {
+    const repo = repository();
+    const { workflow, provider } = harness(repo);
+    const id = await paidApplication(repo);
+    const first = await workflow.resume(id);
+
+    const second = await workflow.resume(id);
+
+    expect(second.steps).toEqual({
+      APPLICATION_NUMBER: 'ALREADY_DONE',
+      RECEIPT: 'ALREADY_DONE',
+      RECEIPT_EMAIL: 'ALREADY_DONE',
+      SUBMISSION: 'ALREADY_DONE',
+      MANAGER_EMAIL: 'ALREADY_DONE',
+    });
+    expect(second.referenceNo).toBe(first.referenceNo);
+    expect(second.receiptNo).toBe(first.receiptNo);
+    expect(provider.sent).toHaveLength(2);
+  });
+
+  it('issues one receipt and one number under concurrent calls', async () => {
+    const repo = repository();
+    const { workflow, provider } = harness(repo);
+    const id = await paidApplication(repo);
+
+    await Promise.allSettled([workflow.resume(id), workflow.resume(id)]);
+
+    expect(await repo.emails.findByApplicationIdAndType(id, 'RECEIPT')).toHaveLength(1);
+    expect(
+      await repo.emails.findByApplicationIdAndType(id, 'MANAGER_NEW_APPLICATION'),
+    ).toHaveLength(1);
+    expect(await repo.receipts.findByApplicationId(id)).not.toBeNull();
+    const application = await repo.applications.findById(id);
+    expect(application?.referenceNo).not.toBeNull();
+
+    // The loser of the insert race dispatches to the row that won, so the
+    // provider may be called twice - with the *same* idempotency key, which is
+    // what makes it one delivered message. The mock does not implement Resend's
+    // deduplication, so the property to check is that there are only two
+    // distinct keys, not that there were only two calls.
+    const keys = new Set(provider.sent.map((email) => email.idempotencyKey));
+    expect(keys.size).toBe(2);
+  });
+
+  it('numbers two applications without collision', async () => {
+    const repo = repository();
+    const { workflow } = harness(repo);
+    const first = await paidApplication(repo, 'ANNUAL', '1234567890121');
+    const second = await paidApplication(repo, 'LIFETIME', '1234567890139');
+
+    const a = await workflow.resume(first);
+    const b = await workflow.resume(second);
+
+    expect(a.referenceNo).not.toBe(b.referenceNo);
+    expect(a.receiptNo).not.toBe(b.receiptNo);
+  });
+});
+
+describe('when the email provider is down', () => {
+  it('keeps the receipt and the submission', async () => {
+    const repo = repository();
+    const { workflow } = harness(repo, { failEmails: 'PROVIDER_ERROR' });
+    const id = await paidApplication(repo);
+
+    const report = await workflow.resume(id);
+
+    // The association has the money. Losing the receipt because a mail server
+    // was unreachable would be the wrong failure.
+    expect(report.steps.RECEIPT).toBe('DONE');
+    expect(report.steps.RECEIPT_EMAIL).toBe('FAILED');
+    expect(report.steps.SUBMISSION).toBe('DONE');
+    expect(report.steps.MANAGER_EMAIL).toBe('FAILED');
+    expect(report.complete).toBe(false);
+    expect(report.receiptNo).not.toBeNull();
+  });
+
+  it('does not claim the manager was notified', async () => {
+    const repo = repository();
+    const { workflow } = harness(repo, { failEmails: 'PROVIDER_ERROR' });
+    const id = await paidApplication(repo);
+
+    const report = await workflow.resume(id);
+
+    // `MANAGER_NOTIFIED` is also what #14 keys the manager's open off, so
+    // recording it after a failed send would make an unseen application look
+    // handled.
+    expect(report.status).toBe('SUBMITTED');
+    const types = eventTypes(await repo.events.listByApplicationId(id));
+    expect(types).not.toContain('MANAGER_EMAIL_SENT');
+    expect(types).toContain('APPLICATION_SUBMITTED');
+  });
+
+  it('records both failures against their own rows', async () => {
+    const repo = repository();
+    const { workflow } = harness(repo, { failEmails: 'PROVIDER_ERROR' });
+    const id = await paidApplication(repo);
+
+    await workflow.resume(id);
+
+    const receipt = await repo.emails.findByApplicationIdAndType(id, 'RECEIPT');
+    const manager = await repo.emails.findByApplicationIdAndType(id, 'MANAGER_NEW_APPLICATION');
+    expect(receipt[0]).toMatchObject({ status: 'FAILED' });
+    expect(manager[0]).toMatchObject({ status: 'FAILED' });
+  });
+
+  it('finishes the flow when the provider comes back, without a second receipt', async () => {
+    const repo = repository();
+    const id = await paidApplication(repo);
+    const failing = harness(repo, { failEmails: 'PROVIDER_ERROR' });
+    const firstReport = await failing.workflow.resume(id);
+
+    const working = harness(repo);
+    const report = await working.workflow.resume(id);
+
+    expect(report.complete).toBe(true);
+    expect(report.receiptNo).toBe(firstReport.receiptNo);
+    expect(report.referenceNo).toBe(firstReport.referenceNo);
+    expect(report.status).toBe('MANAGER_NOTIFIED');
+    expect(report.steps).toEqual({
+      APPLICATION_NUMBER: 'ALREADY_DONE',
+      RECEIPT: 'ALREADY_DONE',
+      RECEIPT_EMAIL: 'DONE',
+      SUBMISSION: 'ALREADY_DONE',
+      MANAGER_EMAIL: 'DONE',
+    });
+  });
+
+  it('reuses the failed row on retry rather than creating a second one', async () => {
+    const repo = repository();
+    const id = await paidApplication(repo);
+    await harness(repo, { failEmails: 'PROVIDER_ERROR' }).workflow.resume(id);
+    const before = await repo.emails.findByApplicationIdAndType(id, 'RECEIPT');
+
+    const working = harness(repo);
+    await working.workflow.resume(id);
+
+    // Same row means the same provider idempotency key, so a send that actually
+    // succeeded before the timeout cannot be delivered twice.
+    const after = await repo.emails.findByApplicationIdAndType(id, 'RECEIPT');
+    expect(after).toHaveLength(1);
+    expect(after[0]!.id).toBe(before[0]!.id);
+    expect(after[0]!.status).toBe('SENT');
+    expect(working.provider.sent[0]!.idempotencyKey).toBe(before[0]!.id);
+  });
+
+  it('sends the manager email even if the member email keeps failing', async () => {
+    const repo = repository();
+    const id = await paidApplication(repo);
+    // No applicant address, so the receipt email can never be sent; the manager
+    // still has to hear about the application.
+    await repo.applications.updateContact(id, { email: null });
+    const { workflow, provider } = harness(repo);
+
+    const report = await workflow.resume(id);
+
+    expect(report.steps.RECEIPT_EMAIL).toBe('FAILED');
+    expect(report.steps.MANAGER_EMAIL).toBe('DONE');
+    expect(report.status).toBe('MANAGER_NOTIFIED');
+    expect(provider.sent).toHaveLength(1);
+    expect(provider.sent[0]!.to).toBe(MANAGER_EMAIL);
+  });
+});
+
+describe('inspect', () => {
+  it('reports every step as pending before anything has run', async () => {
+    const repo = repository();
+    const { workflow, provider } = harness(repo);
+    const id = await paidApplication(repo);
+
+    const report = await workflow.inspect(id);
+
+    expect(report.complete).toBe(false);
+    expect(report.steps.RECEIPT).toBe('SKIPPED');
+    expect(provider.sent).toHaveLength(0);
+  });
+
+  it('reports a finished flow without repeating any of it', async () => {
+    const repo = repository();
+    const { workflow, provider } = harness(repo);
+    const id = await paidApplication(repo);
+    await workflow.resume(id);
+
+    const report = await workflow.inspect(id);
+
+    expect(report.complete).toBe(true);
+    expect(report.status).toBe('MANAGER_NOTIFIED');
+    // A confirmation page must not be able to send email by being loaded.
+    expect(provider.sent).toHaveLength(2);
+  });
+
+  it('distinguishes a failed step from one never attempted', async () => {
+    const repo = repository();
+    const id = await paidApplication(repo);
+    await harness(repo, { failEmails: 'PROVIDER_ERROR' }).workflow.resume(id);
+
+    const report = await harness(repo).workflow.inspect(id);
+
+    expect(report.steps.RECEIPT_EMAIL).toBe('FAILED');
+    expect(report.steps.RECEIPT).toBe('ALREADY_DONE');
+  });
+
+  it('refuses an application that does not exist', async () => {
+    const repo = repository();
+    const { workflow } = harness(repo);
+
+    await expect(workflow.inspect(crypto.randomUUID())).rejects.toThrow();
+  });
+});
+
+/* -------------------------------------------------------- through routes ---- */
+
+interface CreatedBody {
+  application: { id: string };
+  accessToken: string;
+}
+
+async function createApplication(citizenId: string): Promise<CreatedBody> {
+  const response = await exports.default.fetch(
+    new Request('http://localhost/api/applications', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'cf-connecting-ip': '203.0.113.77',
+        [TURNSTILE_TOKEN_HEADER]: 'test-token',
+      },
+      body: JSON.stringify({ citizenId }),
+    }),
+  );
+  expect(response.status).toBe(201);
+  return response.json<CreatedBody>();
+}
+
+/** Takes a fresh application as far as the payment endpoint can be called. */
+async function readyToPay(repo: Repository, citizenId: string) {
+  const created = await createApplication(citizenId);
+  const id = created.application.id;
+
+  await exports.default.fetch(
+    new Request(`http://localhost/api/applications/${id}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json', [ACCESS_TOKEN_HEADER]: created.accessToken },
+      body: JSON.stringify({ email: APPLICANT_EMAIL, phone: '0800000000' }),
+    }),
+  );
+  await repo.applications.setMembership(id, 'ANNUAL', ANNUAL_SATANG);
+  await createStateMachine(repo).transition(id, 'AWAITING_PAYMENT');
+
+  return { id, token: created.accessToken };
+}
+
+function verifyRequest(id: string, token: string): Request {
+  const form = new FormData();
+  form.append('applicationId', id);
+  form.append('qrPayload', '00020101021229370016A00000067701011101130066812345678');
+
+  return new Request('http://localhost/api/payment/verify', {
+    method: 'POST',
+    headers: {
+      'cf-connecting-ip': '203.0.113.78',
+      [TURNSTILE_TOKEN_HEADER]: 'test-token',
+      [ACCESS_TOKEN_HEADER]: token,
+    },
+    body: form,
+  });
+}
+
+describe('POST /api/payment/verify', () => {
+  it('completes the whole flow without a second request from the applicant', async () => {
+    const repo = repository();
+    const { id, token } = await readyToPay(repo, '1234567890121');
+
+    const response = await exports.default.fetch(verifyRequest(id, token));
+    const body = await response.json<{
+      verified: boolean;
+      status: string;
+      referenceNo: string | null;
+      receiptNo: string | null;
+      complete: boolean;
+    }>();
+
+    expect(response.status).toBe(200);
+    expect(body.verified).toBe(true);
+    expect(body.complete).toBe(true);
+    expect(body.status).toBe('MANAGER_NOTIFIED');
+    expect(body.referenceNo).toMatch(/^VRA-\d{4}-\d{6}$/);
+    expect(body.receiptNo).toMatch(/^VRA-RC-\d{4}-\d{6}$/);
+    expect(await repo.emails.findByApplicationIdAndType(id, 'RECEIPT')).toHaveLength(1);
+    expect(
+      await repo.emails.findByApplicationIdAndType(id, 'MANAGER_NEW_APPLICATION'),
+    ).toHaveLength(1);
+  });
+});
+
+describe('GET /api/applications/:id/confirmation', () => {
+  it('returns the number and each step for the applicant', async () => {
+    const repo = repository();
+    const { id, token } = await readyToPay(repo, '1234567890121');
+    await exports.default.fetch(verifyRequest(id, token));
+
+    const response = await exports.default.fetch(
+      new Request(`http://localhost/api/applications/${id}/confirmation`, {
+        headers: { [ACCESS_TOKEN_HEADER]: token },
+      }),
+    );
+    const body = await response.json<{ confirmation: WorkflowReport }>();
+
+    expect(response.status).toBe(200);
+    expect(body.confirmation.complete).toBe(true);
+    expect(body.confirmation.referenceNo).not.toBeNull();
+    expect(body.confirmation.steps.MANAGER_EMAIL).toBe('ALREADY_DONE');
+  });
+
+  it('refuses a request without the capability token', async () => {
+    const repo = repository();
+    const { id } = await readyToPay(repo, '1234567890121');
+
+    const response = await exports.default.fetch(
+      new Request(`http://localhost/api/applications/${id}/confirmation`),
+    );
+
+    // 404, not 401: an unauthenticated caller learns nothing about whether the
+    // application exists.
+    expect(response.status).toBe(404);
+  });
+
+  it('refuses another application’s token', async () => {
+    const repo = repository();
+    const mine = await readyToPay(repo, '1234567890121');
+    const theirs = await readyToPay(repo, '1234567890139');
+
+    const response = await exports.default.fetch(
+      new Request(`http://localhost/api/applications/${mine.id}/confirmation`, {
+        headers: { [ACCESS_TOKEN_HEADER]: theirs.token },
+      }),
+    );
+
+    expect(response.status).toBe(404);
+  });
+});
+
+describe('POST /api/applications/:id/finalize', () => {
+  it('finishes a flow that stalled, and is a no-op once complete', async () => {
+    const repo = repository();
+    const { id, token } = await readyToPay(repo, '1234567890121');
+    await exports.default.fetch(verifyRequest(id, token));
+
+    const response = await exports.default.fetch(
+      new Request(`http://localhost/api/applications/${id}/finalize`, {
+        method: 'POST',
+        headers: { 'cf-connecting-ip': '203.0.113.79', [ACCESS_TOKEN_HEADER]: token },
+      }),
+    );
+    const body = await response.json<{ confirmation: WorkflowReport }>();
+
+    expect(response.status).toBe(200);
+    expect(body.confirmation.steps).toEqual({
+      APPLICATION_NUMBER: 'ALREADY_DONE',
+      RECEIPT: 'ALREADY_DONE',
+      RECEIPT_EMAIL: 'ALREADY_DONE',
+      SUBMISSION: 'ALREADY_DONE',
+      MANAGER_EMAIL: 'ALREADY_DONE',
+    });
+    expect(await repo.emails.findByApplicationIdAndType(id, 'RECEIPT')).toHaveLength(1);
+  });
+
+  it('refuses a request without the capability token', async () => {
+    const repo = repository();
+    const { id } = await readyToPay(repo, '1234567890121');
+
+    const response = await exports.default.fetch(
+      new Request(`http://localhost/api/applications/${id}/finalize`, {
+        method: 'POST',
+        headers: { 'cf-connecting-ip': '203.0.113.79' },
+      }),
+    );
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/tests/worker/schema.test.ts
+++ b/tests/worker/schema.test.ts
@@ -181,6 +181,45 @@ describe('uniqueness guarantees', () => {
     ).rejects.toThrow(/receipt_no/);
   });
 
+  it('rejects a second email of the same type for one application', async () => {
+    const repo = repository();
+    const applicationId = await seedApplication(repo);
+    await repo.emails.create({
+      applicationId,
+      type: 'RECEIPT',
+      recipient: 'applicant@example.test',
+      provider: 'resend',
+    });
+
+    // Two callers can both read "no receipt email yet" before either writes
+    // one. A retry reuses the existing row, so a second row of the same type is
+    // always that race rather than a legitimate second message.
+    await expect(
+      repo.emails.create({
+        applicationId,
+        type: 'RECEIPT',
+        recipient: 'applicant@example.test',
+        provider: 'resend',
+      }),
+    ).rejects.toThrow(/application_id/);
+  });
+
+  it('allows different email types for one application', async () => {
+    const repo = repository();
+    const applicationId = await seedApplication(repo);
+
+    for (const type of ['RECEIPT', 'MANAGER_NEW_APPLICATION', 'MEMBER_PROCESSING'] as const) {
+      await expect(
+        repo.emails.create({
+          applicationId,
+          type,
+          recipient: 'someone@example.test',
+          provider: 'resend',
+        }),
+      ).resolves.toMatchObject({ type });
+    }
+  });
+
   it('allows the same person to have more than one application', async () => {
     const repo = repository();
     await seedApplication(repo, TEST_CITIZEN_ID);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -34,6 +34,12 @@ export default defineConfig(async () => {
             // `scripts/validate-repository.ps1`.
             RESEND_WEBHOOK_SECRET: 'whsec_testonlywebhooksecret123',
             MANAGER_EMAIL: 'manager@example.test',
+            // Invented account details. `receiverAccountDigits` from the mock
+            // slip provider is `1234`, which has to appear in order inside the
+            // configured account for the receiver check to pass.
+            VRA_BANK_ACCOUNT: '001234567890',
+            VRA_BANK_NAME: 'ธนาคารตัวอย่าง',
+            VRA_BANK_ACCOUNT_NAME: 'สมาคมนักวิทยุอาสาสมัคร (ตัวอย่าง)',
             EMAIL_FROM: 'VRA <membership@example.test>',
             TEST_MIGRATIONS: migrations,
           },


### PR DESCRIPTION
Closes #15

## What this does

Everything after the money is confirmed, without a second request from the applicant (Issue #1 section 28):

```
PAYMENT_VERIFIED → application number → RECEIPT_ISSUED
  → RECEIPT_EMAIL_SENT → APPLICATION_SUBMITTED → MANAGER_EMAIL_SENT
```

This is the change that connects everything built so far — numbering, the receipt, the PDF, the templates, the provider — into one flow.

## Two properties govern the whole module

**Nothing already done is done again, and there is no progress column.** Each step decides whether it has already happened by looking at what it would have produced: a reference number on the row, a receipt for the application, an accepted email of that type, the status itself. A `current_step` column would be a second source of truth able to disagree with the first, and it is the first that matters.

**A step that fails does not undo the steps before it.** By the time this runs the association has the money. If Resend is down the receipt is still issued and the application is still submitted; the email rows carry their own failure. `resume` picks up exactly where the last attempt stopped, so a provider outage costs a retry rather than a payment.

## The concurrency test found a real defect

Two overlapping `resume` calls each read "no email of this type yet" and each created a row — two real deliveries under two different idempotency keys, so the member would get two receipts.

Migration 0004 replaces the plain index on `emails (application_id, type)` with a unique one, and the loser of the insert **dispatches to the row that won** rather than creating its own. Both then carry the same idempotency key, so Resend returns the original message and one email is delivered. Verified by removing the migration: the test fails with two rows.

Note on what the test asserts: the mock provider does not implement Resend's deduplication, so the checkable property is that there are only **two distinct idempotency keys**, not that the provider was called only twice. In the race it is called twice for the same message, which is correct and costs one redundant API call.

## An ordering bug that would have shipped

`numbering.assignApplicationNumber` existed since #7 and **nothing ever called it**. Every application would have reached the receipt with `referenceNo` still null, and the PDF would have printed the "ยังไม่ออกเลขที่ใบสมัคร" placeholder on a document the member keeps. The number is now assigned first, before the receipt is issued, because the receipt and both emails all print it.

## `MANAGER_NOTIFIED` means the manager was actually told

The status is recorded only when a manager email was accepted. It asserts that the manager has been notified, and #14 keys the manager's open off it — so recording it after a failed send would make an application nobody has seen look handled. A failed manager email leaves the application in `SUBMITTED`, which is exactly the state `resume` knows how to finish.

## Audit event names

Sent-email events are now named per type — `RECEIPT_EMAIL_SENT`, `MANAGER_EMAIL_SENT`, `MEMBER_PROCESSING_EMAIL_SENT`, `MEMBER_COMPLETION_EMAIL_SENT` — as Issue #1 section 50 names them. The trail now reads as a sequence of things that happened rather than four rows of `EMAIL_SENT` distinguished only by metadata. Failures stay generic (`EMAIL_SEND_FAILED`, `EMAIL_SKIPPED`) with the type in metadata; the specification does not name those.

I used `record` rather than `recordOnce` deliberately: if a second real send ever happens, the trail should say so.

## Endpoints

- `POST /api/payment/verify` runs the workflow immediately after verification is committed, and returns the per-step result. This is what satisfies "no additional request from the applicant".
- `GET /api/applications/:id/confirmation` returns the number and each step's state (section 66). **Read-only on purpose** — resuming from a `GET` would let a page refresh, a prefetch or a link preview send email.
- `POST /api/applications/:id/finalize` finishes a stalled flow. Authenticated by the same capability token that verified the payment, and rate limited because each call can reach the provider.

On the retry endpoint: the issue asks for an **admin** one. Admin authentication arrives with Cloudflare Access in #16, so what is here is the applicant-authenticated equivalent — real authentication, tested, and useful now, since the applicant is the person waiting. The admin variant is noted for #16.

## Also in this PR

The mock slip provider defaulted `transactionAt` to a constant in January. Verification refuses a slip older than seven days, so **every mock payment failed as stale** — which also meant a payment could not be completed in local development at all. It now defaults to the current time; callers that pin a clock still get exactly what they pass.

`vitest.config.ts` gains the invented bank details the payment route reads, so the route can be exercised end to end.

## Tests

27 new tests; 604 pass in total. Nothing reaches a real provider.

- happy path for `ANNUAL` and for `LIFETIME`, including that the lifetime receipt says `2,000.00 บาท` and the right plan name
- the receipt PDF is attached to the member email and **nothing** is attached to the manager one
- the audit trail contains `PAYMENT_VERIFIED`, `RECEIPT_ISSUED`, `RECEIPT_EMAIL_SENT`, `APPLICATION_SUBMITTED`, `MANAGER_EMAIL_SENT` in that order
- no address, name or citizen ID appears anywhere in the trail
- a second `resume` reports every step `ALREADY_DONE` and sends nothing
- concurrent `resume` calls produce one receipt, one number, one row per email type and two distinct idempotency keys
- two applications get different numbers and different receipt numbers
- with the provider down: receipt kept, submission kept, both emails `FAILED`, status stays `SUBMITTED`, `MANAGER_EMAIL_SENT` absent
- resuming with a working provider completes it, reusing the same rows and the same keys, with no second receipt
- the manager email is still sent when the member has no address at all
- `inspect` never sends anything, and distinguishes a failed step from one never attempted
- through the routes: verify completes the whole flow in one request; confirmation returns the steps; finalize is a no-op once complete; both new endpoints 404 without the capability token (404 rather than 401 so an unauthenticated caller learns nothing about whether the application exists)
- schema: a second email of the same type is rejected by the database; different types are allowed

## Security / privacy impact

High risk, as the issue states: payment, receipt and outbound personal data meet here.

- The workflow runs **after** verification is committed, so no provider failure can undo a recorded payment
- Both new endpoints require the applicant's capability token, and `finalize` is rate limited
- The confirmation endpoint cannot cause a send
- Nothing new is logged: the two new log lines carry the application id and a `COMPLETE`/`INCOMPLETE` marker
- The audit trail is asserted to contain no address, name or citizen ID
- `MANAGER_NOTIFIED` cannot be reached without an accepted email, so the status cannot overstate what happened

## Bundle size

3186.96 KiB, 855.44 KiB gzipped — up 8.92 KiB from #14, inside the compressed limit on either plan. Follow-up on the pdf-lib weight is #36.

## Gate

`format:check`, `lint`, `typecheck`, `test` (604), `build`, `check:worker:production` and `validate-repository.ps1` (147 tracked files) all pass locally.
