### PR TITLE
feat: add the admin API behind verified Cloudflare Access

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,6 +24,7 @@ src/worker/            Cloudflare Worker (Hono)
   context.ts           Hono generics shared by every route
   routes/              HTTP routes
     webhooks.ts        provider callbacks; signature is the only authentication
+    admin.ts           manager endpoints, authenticated in the Worker itself
   db/                  data access layer; the only module that knows SQL
     types.ts           internal models and the status/type unions
     mappers.ts         row to model conversion
@@ -32,6 +33,7 @@ src/worker/            Cloudflare Worker (Hono)
   security/            controls applied before business rules run
     turnstile.ts       bot protection, verified before any provider call
     rate-limit.ts      fixed-window counters in D1, hashed identifiers
+    access.ts          Cloudflare Access JWT verification, done again here
     csrf.ts            origin check plus double-submit token for admin POSTs
     validation.ts      strict zod parsing that never echoes a submitted value
     context.ts         per-request assembly of the above
@@ -48,6 +50,8 @@ src/worker/            Cloudflare Worker (Hono)
     email.ts           transactional email, recorded per message
     email-events.ts    delivery events, and the one status change they cause
     application-workflow.ts  what happens after a payment is verified
+    nbtc-completion.ts       recording the registration and finishing
+    admin-view.ts            what the manager sees; the only audited decrypt
     workflow-factory.ts      assembly shared by the routes that run it
   lib/logger.ts        allowlist logger; the only sanctioned console sink
   lib/time.ts          Asia/Bangkok conversion and Buddhist-era years
@@ -299,6 +303,42 @@ PAYMENT_VERIFIED → ออกเลขที่ใบสมัคร → RECEIP
 - `POST /api/payment/verify` รัน workflow ต่อทันทีหลัง commit การยืนยัน แล้วคืนสถานะแต่ละขั้นมาด้วย
 - `GET /api/applications/:id/confirmation` อ่านสถานะแต่ละขั้น (หัวข้อ 66) **อ่านอย่างเดียว** — การ resume จาก GET จะทำให้การ refresh หน้า, prefetch หรือ link preview ส่งอีเมลได้
 - `POST /api/applications/:id/finalize` เดินขั้นที่ค้างให้จบ ใช้ capability token เดิมกับที่ยืนยันการชำระเงิน และมี rate limit เพราะเรียก provider ได้ ฝั่งผู้จัดการจะได้ action เทียบเท่าที่ไม่ต้องใช้ token ของผู้สมัครใน #16
+
+## Admin
+
+**ทุก route ตรวจ Access JWT ในตัว Worker เอง ไม่ใช่พึ่งการตั้งค่าที่ edge เท่านั้น** Access ที่วางไว้หน้า `/admin*` และ `/api/admin/*` คือ setting เดียวใน dashboard — ถ้ามันถูกลบ, ถูกผูกกับ hostname ผิด หรือ path ไม่ตรง ทุก endpoint จะกลายเป็นสาธารณะทันที การตรวจซ้ำในนี้ทำให้ความผิดพลาดใน dashboard มีราคาเท่ากับ downtime ไม่ใช่ข้อมูลรั่ว
+
+Token เป็น JWT ที่เซ็นด้วย RS256 ตรวจ signature กับ certificate ของทีม (`/cdn-cgi/access/certs`) แล้วตรวจ claim: `iss` ต้องเป็นทีมนี้, `aud` ต้องเป็น **application นี้** — ข้อนี้สำคัญที่สุด เพราะถ้าไม่ตรวจ token ที่ออกให้ application อื่นในบัญชีเดียวกันจะใช้ที่นี่ได้ — และช่วงเวลาต้องยังไม่หมดอายุ `alg` ถูกกำหนดเป็น RS256 ไม่อ่านจาก token เพราะการอ่านจาก token เปิดทาง `alg: none` และการใช้ public key เป็น shared secret
+
+ค่า tolerance ของนาฬิกาใช้กับ `nbf` และ `iat` เท่านั้น ไม่ใช้กับ `exp` — การผ่อนที่ `exp` คือการต่ออายุ token ที่หมดแล้ว และ Access token มีอายุเป็นชั่วโมงอยู่แล้วจึงไม่ต้องผ่อน
+
+ทุกความล้มเหลวตอบข้อความเดียวกัน ผู้เรียกรู้แค่ว่าเข้าได้หรือไม่ได้ ไม่รู้ว่าด่านไหนปฏิเสธ — ความต่างระหว่าง "aud ผิด" กับ "หมดอายุ" คือสิ่งที่คนกำลังลองเจาะอยากรู้พอดี
+
+ถ้า certificate endpoint ติดต่อไม่ได้ ระบบ **ปฏิเสธทุกคำขอ** การ fail open ตอน outage คือการเปิด admin API ให้สาธารณะ
+
+### GET ไม่เปลี่ยนสถานะ เด็ดขาด
+
+Email security scanner เปิด URL ในอีเมลเอง ถ้า `GET` เปลี่ยนสถานะได้ gateway ป้องกันไวรัสจะกดรับเรื่องหรือกดยืนยันการบันทึกทะเบียนแทนผู้จัดการ (หัวข้อ 37) ทุกการเปลี่ยนสถานะจึงเป็น `POST` และต้องผ่าน origin check กับ double-submit CSRF token เพิ่ม เพราะ Access authenticate ด้วย cookie และ cookie ถูกส่งไปกับ cross-site request ด้วย
+
+link ในอีเมลผู้จัดการชี้ไปหน้าใน portal ไม่ใช่ endpoint เหล่านี้ — หน้านั้นแสดงว่ากำลังจะเกิดอะไรแล้ว POST จากที่นั่น
+
+### เลขบัตรประชาชนกับการ audit
+
+`admin-view.ts` เป็นที่เดียวใน admin flow ที่ถอดรหัสเลขบัตร และมันบันทึก `CITIZEN_ID_ACCESSED` ในการเรียกเดียวกัน จึงไม่มีทางเพิ่มผู้อ่านคนที่สองภายหลังแล้วลืมบันทึก ทุกครั้งที่เปิดหน้ารายละเอียดถูกนับหนึ่งครั้ง — trail จึงตอบได้ว่าใครดูกี่ครั้ง
+
+list view ไม่มีข้อมูลส่วนบุคคลเกินชื่อ ผู้จัดการที่ไล่ดูคิวงานไม่ต้องใช้ที่อยู่หรือเบอร์โทร และ list endpoint คือตัวที่มีโอกาสถูก log, cache หรือถ่ายจอมากที่สุด
+
+รูปสมาชิกส่งผ่าน Worker ที่ authenticate แล้วเท่านั้น ไม่มี signed URL — URL ที่ใช้ได้โดยไม่ผ่าน Access จะอยู่นานกว่า session ของผู้จัดการและถูก forward ได้ (หัวข้อ 14)
+
+### บันทึกทะเบียน กสทช.
+
+`nbtc-completion.ts` มีรูปเดียวกับ post-payment workflow และด้วยเหตุผลเดียวกัน:
+
+```text
+NBTC_RECORDED → MEMBER_COMPLETION_EMAIL_SENT → COMPLETED
+```
+
+`COMPLETED` บันทึกเมื่อสมาชิกได้รับแจ้งแล้วเท่านั้น เพราะนั่นคือสิ่งที่สถานะนี้อ้าง ถ้าอีเมลล้ม การบันทึกทะเบียนยังอยู่ (`NBTC_RECORDED`) และการเรียกซ้ำจะทำเฉพาะส่วนที่ยังขาด ตัวตนผู้จัดการถูกเก็บใน `nbtc_recorded_by` และใน audit event — เป็นที่เดียวที่ระบบเก็บตัวตนของเจ้าหน้าที่ และจำเป็น เพราะการบันทึกทะเบียนกับหน่วยงานกำกับต้องระบุได้ว่าใครทำ
 
 ## Decision records
 

--- a/docs/owner-actions.md
+++ b/docs/owner-actions.md
@@ -23,19 +23,21 @@ pwsh -File ./scripts/set-production-secrets.ps1 -WhatIf
 pwsh -File ./scripts/set-production-secrets.ps1
 ```
 
-| Secret                                                       | ได้จากไหน                                    |
-| ------------------------------------------------------------ | -------------------------------------------- |
-| `IAPP_API_KEY`                                               | บัญชี iApp                                   |
-| `SLIPOK_API_KEY`                                             | บัญชี SlipOK                                 |
-| `SLIPOK_BRANCH_ID`                                           | SlipOK — branch id ที่อยู่ใน endpoint path   |
-| `RESEND_API_KEY`                                             | บัญชี Resend                                 |
-| `RESEND_WEBHOOK_SECRET`                                      | Resend → Webhooks → signing secret           |
-| `TURNSTILE_SECRET_KEY`                                       | Cloudflare → Turnstile → widget ที่สร้างใหม่ |
-| `PII_ENCRYPTION_KEY`                                         | ปล่อยว่างไว้ สคริปต์สร้างให้                 |
-| `MANAGER_EMAIL`                                              | email ผู้จัดการสมาคม                         |
-| `EMAIL_FROM`                                                 | sender ของ transactional email               |
-| `VRA_BANK_NAME`, `VRA_BANK_ACCOUNT`, `VRA_BANK_ACCOUNT_NAME` | ข้อมูลบัญชีสมาคม                             |
-| `EMAIL_FROM_TRACKED` (ไม่บังคับ)                             | sender แยกสำหรับ open tracking — ดูข้อ 2     |
+| Secret                                                       | ได้จากไหน                                                      |
+| ------------------------------------------------------------ | -------------------------------------------------------------- |
+| `IAPP_API_KEY`                                               | บัญชี iApp                                                     |
+| `SLIPOK_API_KEY`                                             | บัญชี SlipOK                                                   |
+| `SLIPOK_BRANCH_ID`                                           | SlipOK — branch id ที่อยู่ใน endpoint path                     |
+| `RESEND_API_KEY`                                             | บัญชี Resend                                                   |
+| `RESEND_WEBHOOK_SECRET`                                      | Resend → Webhooks → signing secret                             |
+| `TURNSTILE_SECRET_KEY`                                       | Cloudflare → Turnstile → widget ที่สร้างใหม่                   |
+| `PII_ENCRYPTION_KEY`                                         | ปล่อยว่างไว้ สคริปต์สร้างให้                                   |
+| `MANAGER_EMAIL`                                              | email ผู้จัดการสมาคม                                           |
+| `EMAIL_FROM`                                                 | sender ของ transactional email                                 |
+| `VRA_BANK_NAME`, `VRA_BANK_ACCOUNT`, `VRA_BANK_ACCOUNT_NAME` | ข้อมูลบัญชีสมาคม                                               |
+| `EMAIL_FROM_TRACKED` (ไม่บังคับ)                             | sender แยกสำหรับ open tracking — ดูข้อ 2                       |
+| `CF_ACCESS_TEAM_DOMAIN`                                      | Cloudflare Zero Trust → Settings → team domain                 |
+| `CF_ACCESS_AUD`                                              | Access application → Overview → Application Audience (AUD) tag |
 
 > **`PII_ENCRYPTION_KEY` เปลี่ยนไม่ได้หลังมีข้อมูลจริง** ciphertext ของเลขบัตรและ hash ที่ใช้ค้นหาซ้ำ derive จาก key นี้ทั้งคู่ และไม่มีสำเนา plaintext เก็บไว้ที่ไหนเลย **สำรอง key ไว้ที่ปลอดภัยและออฟไลน์ก่อนลบไฟล์ค่า** ถ้า key หาย เลขบัตรทุกใบอ่านไม่ได้อีกเลย
 >
@@ -47,7 +49,8 @@ pwsh -File ./scripts/set-production-secrets.ps1
 
 - [ ] **Turnstile site** — สร้าง widget เก็บ secret key ไว้ใส่ในข้อ 1 ส่วน site key เป็นค่าสาธารณะที่จะใส่ใน client build (#17)
 - [ ] **Custom domain** — ผูก `member.vra.or.th` เข้ากับ Worker `vra-membership` (`wrangler.jsonc` ประกาศ route ไว้แล้ว จะถูกสร้างตอน deploy ครั้งแรก แต่ DNS ต้องพร้อม)
-- [ ] **Cloudflare Access application** — ครอบ `/admin*` และ `/api/admin/*` กำหนดผู้ใช้ที่เข้าได้ (ผู้จัดการสมาคม + ผู้ดูแล) ใช้จริงเมื่อ #16 เสร็จ
+- [ ] **Cloudflare Access application** — ครอบ `/admin*` และ `/api/admin/*` กำหนดผู้ใช้ที่เข้าได้ (ผู้จัดการสมาคม + ผู้ดูแล) แล้วคัดลอก **AUD tag** จากหน้า Overview ของ application ไปใส่ `CF_ACCESS_AUD` และ team domain ไปใส่ `CF_ACCESS_TEAM_DOMAIN` ในข้อ 1
+      Worker ตรวจ JWT เองอีกชั้นด้วย ดังนั้น **ถ้าสอง secret นี้ยังไม่ได้ตั้ง ทุก admin endpoint จะปฏิเสธทุกคำขอ** ซึ่งเป็นพฤติกรรมที่ต้องการ — ไม่มีสถานะ "ยังไม่ตั้งค่าแล้วเข้าได้เลย"
 - [ ] **Edge rate limiting rule** — สำหรับ `/api/ocr`, `/api/payment/verify`, `/api/member-photo` ระบบมี rate limiting ใน application layer อยู่แล้ว แต่ rule ที่ edge หยุด traffic ก่อนถึง Worker จึงกันทั้งค่า invocation และค่า D1 write ที่ counter ใช้
 - [ ] **Resend — endpoint ของ webhook** — เพิ่ม endpoint `https://member.vra.or.th/api/webhooks/resend` แล้วเลือก event `email.sent`, `email.delivered`, `email.opened`, `email.clicked`, `email.bounced` จากนั้นคัดลอก signing secret ไปใส่ `RESEND_WEBHOOK_SECRET` ในข้อ 1
       ระบบตอบ 2xx ให้ event ที่ไม่ได้เลือกด้วย จึงเลือกเพิ่มได้โดยไม่พัง แต่ **การเปลี่ยนสถานะใบสมัครอาศัย `email.opened`** ถ้าไม่เลือก ผู้จัดการต้องกดปุ่ม "รับเรื่อง / เริ่มดำเนินการ" เอง

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -9,6 +9,7 @@ import { createProviders } from './providers';
 import { ValidationError, createSecurityServices, validationErrorBody } from './security';
 import { PaymentRejectedError } from './services/payment';
 import { healthRoutes } from './routes/health';
+import { adminRoutes } from './routes/admin';
 import { applicationRoutes } from './routes/applications';
 import { memberPhotoRoutes } from './routes/member-photo';
 import { OcrFailedError, ocrRoutes } from './routes/ocr';
@@ -69,6 +70,7 @@ app.route('/api', memberPhotoRoutes);
 app.route('/api', applicationRoutes);
 app.route('/api', paymentRoutes);
 app.route('/api', webhookRoutes);
+app.route('/api', adminRoutes);
 
 /** API 404s must be JSON so the SPA fallback never masks a routing mistake. */
 app.notFound((c) => {

--- a/src/worker/providers/mock/email.ts
+++ b/src/worker/providers/mock/email.ts
@@ -16,22 +16,24 @@ export interface MockEmailOptions {
 
 export function createMockEmailProvider(options: MockEmailOptions = {}): MockEmailProvider {
   const sent: OutboundEmail[] = [];
-  let counter = 0;
 
   return {
     name: 'mock-email',
     sent,
     reset() {
       sent.length = 0;
-      counter = 0;
     },
     async send(email: OutboundEmail): Promise<EmailSendResult> {
       if (options.failWith) {
         return { ok: false, reason: options.failWith };
       }
       sent.push(email);
-      counter += 1;
-      return { ok: true, providerEmailId: `mock-email-${counter}` };
+      // A random id, not a per-instance counter. `emails.provider_email_id` is
+      // unique, and a counter restarting at 1 for every new provider instance -
+      // one per request - collided across requests. A real provider's ids are
+      // globally unique, so the stand-in has to be too or it fails in a way the
+      // real thing cannot.
+      return { ok: true, providerEmailId: `mock-email-${crypto.randomUUID()}` };
     },
     async verifyWebhookSignature(): Promise<boolean> {
       return options.signatureValid ?? true;

--- a/src/worker/routes/admin.ts
+++ b/src/worker/routes/admin.ts
@@ -1,0 +1,315 @@
+import { Hono } from 'hono';
+import { z } from 'zod';
+import type { AppContext } from '../context';
+import { requireSecret } from '../env';
+import { APPLICATION_STATUSES } from '../db';
+import type { ApplicationStatus } from '../db';
+import { createCitizenIdProtection } from '../lib/crypto';
+import { ApiError } from '../lib/http';
+import { createAccessVerifier } from '../security/access';
+import type { AccessIdentity } from '../security/access';
+import {
+  CSRF_HEADER_NAME,
+  assertCsrfProtected,
+  csrfCookie,
+  generateCsrfToken,
+} from '../security/csrf';
+import { createAdminView } from '../services/admin-view';
+import { createAuditLog } from '../services/audit';
+import { createEmailEventService } from '../services/email-events';
+import { createEmailService } from '../services/email';
+import { createMemberPhotoService } from '../services/member-photo';
+import { createNbtcCompletion } from '../services/nbtc-completion';
+import { createNumberingService } from '../services/numbering';
+import { createReceiptService } from '../services/receipt';
+import { createStateMachine } from '../services/state-machine';
+import { buildApplicationWorkflow } from '../services/workflow-factory';
+
+/**
+ * Manager endpoints (Issue #1 sections 51-53).
+ *
+ * Every route here is authenticated by the Worker itself, not only by the Access
+ * application in front of it - see `src/worker/security/access.ts` for why.
+ *
+ * The read/write split is deliberate and load-bearing. Email security scanners
+ * open links in messages, so a `GET` that changed status would let an anti-virus
+ * gateway acknowledge an application or mark it registered on the manager's
+ * behalf (Issue #1 section 37). Every `GET` here is therefore read-only, and
+ * every state change is a `POST` that additionally has to pass the origin and
+ * double-submit CSRF checks - because Access authenticates with a cookie, and a
+ * cookie is sent on cross-site requests too.
+ *
+ * The links in the manager's email point at portal pages, not at these
+ * endpoints. The page shows what is about to happen and posts from there.
+ */
+
+const idSchema = z.string().uuid();
+
+const MESSAGES = {
+  noPhoto: 'ใบสมัครนี้ยังไม่มีรูปสมาชิก',
+} as const;
+
+const listQuerySchema = z.object({
+  status: z
+    .string()
+    .transform((value) =>
+      value
+        .split(',')
+        .map((part) => part.trim())
+        .filter(Boolean),
+    )
+    .pipe(z.array(z.enum(APPLICATION_STATUSES)))
+    .optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+  offset: z.coerce.number().int().min(0).optional(),
+});
+
+/**
+ * Authenticates the caller and returns their identity.
+ *
+ * The team domain and audience are read per request rather than captured once,
+ * so a rotated audience takes effect without a redeploy.
+ */
+async function authenticate(c: {
+  env: AppContext['Bindings'];
+  req: { raw: Request };
+}): Promise<AccessIdentity> {
+  const verifier = createAccessVerifier({
+    teamDomain: requireSecret(c.env, 'CF_ACCESS_TEAM_DOMAIN'),
+    audience: requireSecret(c.env, 'CF_ACCESS_AUD'),
+  });
+  return verifier.authenticate(c.req.raw);
+}
+
+export const adminRoutes: Hono<AppContext> = new Hono<AppContext>()
+  /**
+   * Issues the CSRF token the portal echoes back on every state change.
+   *
+   * Authenticated like everything else: an unauthenticated caller has no use
+   * for a token, and handing one out would be a small oracle for whether Access
+   * is configured.
+   */
+  .get('/admin/session', async (c) => {
+    const identity = await authenticate(c);
+    const token = generateCsrfToken();
+
+    c.header(
+      'Set-Cookie',
+      csrfCookie(token, { secure: c.var.config.ENVIRONMENT !== 'development' }),
+    );
+    c.header('Cache-Control', 'no-store');
+    return c.json({
+      manager: { email: identity.email },
+      csrf: { header: CSRF_HEADER_NAME, token },
+    });
+  })
+
+  .get('/admin/applications', async (c) => {
+    await authenticate(c);
+
+    const query = listQuerySchema.parse({
+      status: c.req.query('status'),
+      limit: c.req.query('limit'),
+      offset: c.req.query('offset'),
+    });
+
+    const view = await buildAdminView(c);
+    const statuses: ApplicationStatus[] | undefined = query.status;
+
+    c.header('Cache-Control', 'no-store');
+    return c.json({
+      applications: await view.list({
+        ...(statuses ? { statuses } : {}),
+        ...(query.limit === undefined ? {} : { limit: query.limit }),
+        ...(query.offset === undefined ? {} : { offset: query.offset }),
+      }),
+    });
+  })
+
+  .get('/admin/applications/:id', async (c) => {
+    const identity = await authenticate(c);
+    const applicationId = idSchema.parse(c.req.param('id'));
+
+    const view = await buildAdminView(c);
+    const detail = await view.detail(applicationId, identity.email);
+
+    c.var.logger.info({ event: 'admin.detail_read', applicationId });
+
+    c.header('Cache-Control', 'no-store');
+    return c.json({ detail });
+  })
+
+  /**
+   * The manager's explicit "I have started" (Issue #1 section 34).
+   *
+   * Reaches the same status as their email being opened, and sends the member's
+   * processing notice only if this call is the one that moved it.
+   */
+  .post('/admin/applications/:id/acknowledge', async (c) => {
+    const identity = await authenticate(c);
+    assertCsrfProtected(c.req.raw, c.var.config.APP_BASE_URL);
+    const applicationId = idSchema.parse(c.req.param('id'));
+
+    const events = await buildEmailEvents(c);
+    const outcome = await events.acknowledgeByManager(applicationId, identity.email);
+
+    c.var.logger.info({
+      event: 'admin.acknowledged',
+      applicationId,
+      reason: outcome.transition.kind,
+    });
+
+    c.header('Cache-Control', 'no-store');
+    return c.json({
+      transition: outcome.transition.kind,
+      processingEmailSent: outcome.processingEmailSent,
+    });
+  })
+
+  /**
+   * Records the NBTC registration (sections 38-40).
+   *
+   * A `POST` only, and CSRF-protected, because this is the irreversible one:
+   * it tells the member their registration is complete.
+   */
+  .post('/admin/applications/:id/nbtc-complete', async (c) => {
+    const identity = await authenticate(c);
+    assertCsrfProtected(c.req.raw, c.var.config.APP_BASE_URL);
+    const applicationId = idSchema.parse(c.req.param('id'));
+
+    const completion = createNbtcCompletion(
+      c.var.db,
+      createStateMachine(c.var.db),
+      await buildEmailService(c),
+    );
+    const report = await completion.confirm(applicationId, identity.email);
+
+    c.var.logger.info({
+      event: 'admin.nbtc_completed',
+      applicationId,
+      reason: report.complete ? 'COMPLETE' : 'INCOMPLETE',
+    });
+
+    c.header('Cache-Control', 'no-store');
+    return c.json({ completion: report });
+  })
+
+  /** Finishes a post-payment flow that stalled, without the applicant's token. */
+  .post('/admin/applications/:id/finalize', async (c) => {
+    await authenticate(c);
+    assertCsrfProtected(c.req.raw, c.var.config.APP_BASE_URL);
+    const applicationId = idSchema.parse(c.req.param('id'));
+
+    const workflow = await buildApplicationWorkflow(
+      c.env,
+      c.var.db,
+      c.var.providers.email,
+      c.var.config.APP_BASE_URL,
+    );
+    const report = await workflow.resume(applicationId);
+
+    c.var.logger.info({
+      event: 'admin.finalized',
+      applicationId,
+      reason: report.complete ? 'COMPLETE' : 'INCOMPLETE',
+    });
+
+    c.header('Cache-Control', 'no-store');
+    return c.json({ confirmation: report });
+  })
+
+  /**
+   * The member photo, streamed through the Worker.
+   *
+   * The bucket is private and there is no signed-URL path: a URL that works
+   * without Access would outlive the manager's session and could be forwarded
+   * (Issue #1 section 14).
+   */
+  .get('/admin/applications/:id/photo', async (c) => {
+    await authenticate(c);
+    const applicationId = idSchema.parse(c.req.param('id'));
+
+    const photos = createMemberPhotoService(
+      c.var.db,
+      c.env.MEMBER_PHOTOS,
+      createAuditLog(c.var.db),
+    );
+    const photo = await photos.read(applicationId);
+    if (!photo) {
+      throw new ApiError('NOT_FOUND', MESSAGES.noPhoto);
+    }
+
+    c.header('Content-Type', photo.contentType);
+    c.header('Cache-Control', 'no-store');
+    c.header('Content-Disposition', 'inline');
+    return c.body(photo.body);
+  })
+
+  /** The receipt, regenerated from the record rather than stored (#12). */
+  .get('/admin/applications/:id/receipt', async (c) => {
+    const identity = await authenticate(c);
+    const applicationId = idSchema.parse(c.req.param('id'));
+
+    const db = c.var.db;
+    const audit = createAuditLog(db);
+    const receipts = createReceiptService(db, createNumberingService(db), audit);
+    const { bytes, filename } = await receipts.render(applicationId);
+
+    // The document contains personal data and leaves the system, so the access
+    // is recorded like any other read of it.
+    await audit.record({
+      applicationId,
+      eventType: 'RECEIPT_DOWNLOADED',
+      actorType: 'MANAGER',
+      actorId: identity.email,
+    });
+
+    return new Response(bytes, {
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Cache-Control': 'no-store',
+        'Content-Disposition': `attachment; filename="${filename}"`,
+      },
+    });
+  });
+
+/* ------------------------------------------------------------ assembly ---- */
+
+async function buildEmailService(c: { env: AppContext['Bindings']; var: AppContext['Variables'] }) {
+  const db = c.var.db;
+  const audit = createAuditLog(db);
+  const receipts = createReceiptService(db, createNumberingService(db), audit);
+
+  return createEmailService(db, c.var.providers.email, receipts, audit, {
+    managerEmail: requireSecret(c.env, 'MANAGER_EMAIL'),
+    appBaseUrl: c.var.config.APP_BASE_URL,
+    citizenId: await createCitizenIdProtection(requireSecret(c.env, 'PII_ENCRYPTION_KEY')),
+  });
+}
+
+async function buildEmailEvents(c: { env: AppContext['Bindings']; var: AppContext['Variables'] }) {
+  const db = c.var.db;
+  return createEmailEventService(
+    db,
+    createStateMachine(db),
+    await buildEmailService(c),
+    createAuditLog(db),
+  );
+}
+
+async function buildAdminView(c: { env: AppContext['Bindings']; var: AppContext['Variables'] }) {
+  const db = c.var.db;
+  const workflow = await buildApplicationWorkflow(
+    c.env,
+    db,
+    c.var.providers.email,
+    c.var.config.APP_BASE_URL,
+  );
+
+  return createAdminView(
+    db,
+    await createCitizenIdProtection(requireSecret(c.env, 'PII_ENCRYPTION_KEY')),
+    workflow,
+    createAuditLog(db),
+  );
+}

--- a/src/worker/security/access.ts
+++ b/src/worker/security/access.ts
@@ -1,0 +1,295 @@
+import { ApiError } from '../lib/http';
+
+/**
+ * Cloudflare Access authentication for admin routes (Issue #1 sections 14, 51,
+ * 57).
+ *
+ * Access sits in front of `/admin*` and `/api/admin/*` and will not let an
+ * unauthenticated request reach the Worker at all. This module verifies the
+ * token anyway, because that edge configuration is one setting in a dashboard:
+ * if it is removed, misapplied to the wrong hostname, or bypassed by a route
+ * that does not match the application's path, every admin endpoint becomes
+ * public. Verifying here means the Worker refuses on its own, and a mistake in
+ * the dashboard costs an outage rather than a data breach.
+ *
+ * The token is a JWT signed with RS256 by the team's own key. Verification
+ * checks the signature against the team's published certificates and then the
+ * claims: `iss` must be the team, `aud` must be *this* application's tag, and
+ * the validity window must contain now. The `aud` check is the one that matters
+ * most - without it a token minted for any other application in the same
+ * account would be accepted here.
+ */
+
+/** Where Access puts the token. The header is the reliable one. */
+export const ACCESS_JWT_HEADER = 'cf-access-jwt-assertion';
+export const ACCESS_JWT_COOKIE = 'CF_Authorization';
+
+/** How long a fetched certificate set is reused within an isolate. */
+const CERTS_TTL_MS = 60 * 60 * 1000;
+
+/**
+ * Tolerance for clock skew between Cloudflare and the Worker.
+ *
+ * Applied to `nbf` and `iat` only, where skew makes a freshly minted token look
+ * future-dated. It is deliberately *not* applied to `exp`: tolerance there would
+ * extend the life of an expired token, and Access tokens last hours, so nothing
+ * needs it.
+ */
+const CLOCK_SKEW_SECONDS = 60;
+
+const MESSAGES = {
+  /** Deliberately identical for every failure: see `reject`. */
+  denied: 'ไม่มีสิทธิ์เข้าถึงส่วนผู้จัดการ',
+} as const;
+
+export interface AccessIdentity {
+  /** The `email` claim: who performed the action, for the audit trail. */
+  email: string;
+  /** The `sub` claim, stable per user. */
+  subject: string;
+}
+
+export interface AccessVerifier {
+  /**
+   * Returns the caller's identity, or throws `FORBIDDEN`.
+   *
+   * Every failure produces the same error. A caller learns whether they are
+   * allowed in, and nothing about which check refused them - the difference
+   * between "wrong audience" and "expired" is exactly what someone probing the
+   * endpoint would want to know.
+   */
+  authenticate(request: Request): Promise<AccessIdentity>;
+}
+
+export interface AccessOptions {
+  /** Team domain, with or without the `.cloudflareaccess.com` suffix. */
+  teamDomain: string;
+  /** The Access application's AUD tag. */
+  audience: string;
+  /** Injected by tests so no suite reaches Cloudflare. */
+  fetchCerts?: (url: string) => Promise<Response>;
+  now?: () => Date;
+}
+
+interface JsonWebKey {
+  kid?: unknown;
+  kty?: unknown;
+  alg?: unknown;
+  n?: unknown;
+  e?: unknown;
+}
+
+interface CachedCerts {
+  keys: Map<string, CryptoKey>;
+  fetchedAt: number;
+}
+
+/** Per-isolate certificate cache, keyed by the certs URL. */
+const certCache = new Map<string, CachedCerts>();
+
+/**
+ * Clears the certificate cache.
+ *
+ * Exported for tests, which serve their own key set per case: a cache that
+ * survived between them would make one test pass on another's keys.
+ */
+export function resetAccessCertCache(): void {
+  certCache.clear();
+}
+
+function reject(): never {
+  throw new ApiError('FORBIDDEN', MESSAGES.denied);
+}
+
+function base64UrlToBytes(value: string): Uint8Array {
+  const padded = value.replaceAll('-', '+').replaceAll('_', '/');
+  const binary = atob(padded.padEnd(Math.ceil(padded.length / 4) * 4, '='));
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+function decodeJson(segment: string): Record<string, unknown> | null {
+  try {
+    const parsed: unknown = JSON.parse(new TextDecoder().decode(base64UrlToBytes(segment)));
+    return typeof parsed === 'object' && parsed !== null
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Normalises `team`, `team.cloudflareaccess.com` and a full URL to an origin. */
+export function accessIssuer(teamDomain: string): string {
+  const trimmed = teamDomain
+    .trim()
+    .replace(/^https?:\/\//, '')
+    .replace(/\/+$/, '');
+  const host = trimmed.endsWith('.cloudflareaccess.com')
+    ? trimmed
+    : `${trimmed}.cloudflareaccess.com`;
+  return `https://${host}`;
+}
+
+async function importKeys(payload: unknown): Promise<Map<string, CryptoKey>> {
+  const keys = new Map<string, CryptoKey>();
+  if (typeof payload !== 'object' || payload === null) return keys;
+
+  const list = (payload as { keys?: unknown }).keys;
+  if (!Array.isArray(list)) return keys;
+
+  for (const entry of list as JsonWebKey[]) {
+    if (typeof entry.kid !== 'string' || entry.kty !== 'RSA') continue;
+    if (typeof entry.n !== 'string' || typeof entry.e !== 'string') continue;
+
+    try {
+      const key = await crypto.subtle.importKey(
+        'jwk',
+        { kty: 'RSA', n: entry.n, e: entry.e, alg: 'RS256', ext: true },
+        { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+        false,
+        ['verify'],
+      );
+      keys.set(entry.kid, key);
+    } catch {
+      // A malformed key in the set is skipped rather than failing the whole
+      // fetch: the others may still verify this token.
+      continue;
+    }
+  }
+
+  return keys;
+}
+
+export function createAccessVerifier(options: AccessOptions): AccessVerifier {
+  const issuer = accessIssuer(options.teamDomain);
+  const certsUrl = `${issuer}/cdn-cgi/access/certs`;
+  const fetchCerts = options.fetchCerts ?? ((url: string) => fetch(url));
+  const now = options.now ?? (() => new Date());
+
+  const loadKeys = async (force: boolean): Promise<Map<string, CryptoKey>> => {
+    const cached = certCache.get(certsUrl);
+    if (!force && cached && now().getTime() - cached.fetchedAt < CERTS_TTL_MS) {
+      return cached.keys;
+    }
+
+    let response: Response;
+    try {
+      response = await fetchCerts(certsUrl);
+    } catch {
+      // An unreachable certificate endpoint must not let a request through.
+      return cached?.keys ?? new Map();
+    }
+    if (!response.ok) return cached?.keys ?? new Map();
+
+    let payload: unknown;
+    try {
+      payload = await response.json();
+    } catch {
+      return cached?.keys ?? new Map();
+    }
+
+    const keys = await importKeys(payload);
+    if (keys.size === 0) return cached?.keys ?? new Map();
+
+    certCache.set(certsUrl, { keys, fetchedAt: now().getTime() });
+    return keys;
+  };
+
+  /**
+   * Resolves the signing key, refetching once for an unknown `kid`.
+   *
+   * Access rotates keys, so a token signed with a new one arrives before the
+   * cache expires. Refetching on an unknown id is what keeps a rotation from
+   * locking the manager out for an hour; it is bounded to one extra request
+   * because an attacker could otherwise force a fetch per request.
+   */
+  const keyFor = async (kid: string): Promise<CryptoKey | null> => {
+    const cached = await loadKeys(false);
+    const key = cached.get(kid);
+    if (key) return key;
+    return (await loadKeys(true)).get(kid) ?? null;
+  };
+
+  return {
+    async authenticate(request) {
+      const token =
+        request.headers.get(ACCESS_JWT_HEADER) ?? readCookieValue(request, ACCESS_JWT_COOKIE);
+      if (!token) reject();
+
+      const segments = token.split('.');
+      if (segments.length !== 3) reject();
+
+      const header = decodeJson(segments[0]!);
+      const claims = decodeJson(segments[1]!);
+      if (!header || !claims) reject();
+
+      // Only RS256. Accepting `alg` from the token would allow `none`, and
+      // accepting an HMAC algorithm would let the public key be used as a
+      // shared secret.
+      if (header['alg'] !== 'RS256' || typeof header['kid'] !== 'string') reject();
+
+      const key = await keyFor(header['kid']);
+      if (!key) reject();
+
+      let valid = false;
+      try {
+        valid = await crypto.subtle.verify(
+          'RSASSA-PKCS1-v1_5',
+          key,
+          base64UrlToBytes(segments[2]!),
+          new TextEncoder().encode(`${segments[0]!}.${segments[1]!}`),
+        );
+      } catch {
+        reject();
+      }
+      if (!valid) reject();
+
+      if (claims['iss'] !== issuer) reject();
+
+      // `aud` is an array in Access tokens. Without this check a token minted
+      // for any other application in the same account would be accepted.
+      const audience = claims['aud'];
+      const audiences = Array.isArray(audience) ? audience : [audience];
+      if (!audiences.includes(options.audience)) reject();
+
+      const seconds = Math.floor(now().getTime() / 1000);
+      const expiry = claims['exp'];
+      if (typeof expiry !== 'number' || seconds >= expiry) reject();
+
+      const notBefore = claims['nbf'];
+      if (typeof notBefore === 'number' && seconds + CLOCK_SKEW_SECONDS < notBefore) reject();
+
+      const issuedAt = claims['iat'];
+      if (typeof issuedAt === 'number' && seconds + CLOCK_SKEW_SECONDS < issuedAt) reject();
+
+      const subject = claims['sub'];
+      if (typeof subject !== 'string' || subject.length === 0) reject();
+
+      const email = claims['email'];
+      return {
+        subject,
+        // Service tokens carry no email; the subject still identifies the
+        // caller, so the action is attributable either way.
+        email: typeof email === 'string' && email.length > 0 ? email : subject,
+      };
+    },
+  };
+}
+
+/** Local copy so this module does not depend on the CSRF one. */
+function readCookieValue(request: Request, name: string): string | null {
+  const header = request.headers.get('cookie');
+  if (!header) return null;
+
+  for (const part of header.split(';')) {
+    const separator = part.indexOf('=');
+    if (separator === -1) continue;
+    if (part.slice(0, separator).trim() !== name) continue;
+    return part.slice(separator + 1).trim();
+  }
+  return null;
+}

--- a/src/worker/security/index.ts
+++ b/src/worker/security/index.ts
@@ -1,3 +1,4 @@
+export * from './access';
 export * from './context';
 export * from './csrf';
 export * from './rate-limit';

--- a/src/worker/services/admin-view.ts
+++ b/src/worker/services/admin-view.ts
@@ -1,0 +1,232 @@
+import type {
+  AddressRecord,
+  ApplicationEventRecord,
+  ApplicationListQuery,
+  ApplicationRecord,
+  ApplicationStatus,
+  MembershipType,
+  PaymentRecord,
+  ReceiptRecord,
+  Repository,
+} from '../db';
+import type { CitizenIdProtection } from '../lib/crypto';
+import { ApiError } from '../lib/http';
+import type { AuditLog } from './audit';
+import type { ApplicationWorkflow, WorkflowReport } from './application-workflow';
+import { formatBaht, membershipPlan } from './membership';
+
+/**
+ * What the manager sees (Issue #1 sections 52-53).
+ *
+ * This module exists so that reading an application's full details is one code
+ * path with the audit event attached to it. The citizen ID is decrypted here and
+ * nowhere else in the admin flow, and `CITIZEN_ID_ACCESSED` is recorded on the
+ * same call - so there is no way to add a second reader later that forgets to
+ * record it.
+ *
+ * The list view carries no personal data beyond a name. A manager scanning a
+ * queue does not need addresses or contact details, and a list endpoint is the
+ * one most likely to be logged, cached or screenshotted.
+ */
+
+export const CITIZEN_ID_ACCESSED_EVENT = 'CITIZEN_ID_ACCESSED';
+
+/**
+ * Thrown for an unknown application.
+ *
+ * An `ApiError` rather than a bespoke class so the entrypoint maps it to 404
+ * without a per-service branch - a custom error here surfaced as a 500 and told
+ * the caller nothing.
+ */
+export function adminApplicationNotFound(): ApiError {
+  return new ApiError('NOT_FOUND', 'ไม่พบใบสมัครนี้');
+}
+
+export interface AdminListItem {
+  id: string;
+  referenceNo: string | null;
+  status: ApplicationStatus;
+  name: string | null;
+  membershipType: MembershipType | null;
+  amountBaht: string | null;
+  submittedAt: string | null;
+  createdAt: string;
+}
+
+export interface AdminDetail {
+  application: {
+    id: string;
+    referenceNo: string | null;
+    status: ApplicationStatus;
+    title: string | null;
+    firstName: string | null;
+    lastName: string | null;
+    firstNameEn: string | null;
+    lastNameEn: string | null;
+    birthDate: string | null;
+    cardExpiryDate: string | null;
+    /** Full number. Decrypted for this call only, and audited. */
+    citizenId: string | null;
+    phone: string | null;
+    email: string | null;
+    callsign: string | null;
+    membershipType: MembershipType | null;
+    membershipLabel: string | null;
+    amountBaht: string | null;
+    hasPhoto: boolean;
+    photoSource: string | null;
+    submittedAt: string | null;
+    managerAcknowledgedAt: string | null;
+    nbtcRecordedAt: string | null;
+    nbtcRecordedBy: string | null;
+    createdAt: string;
+    updatedAt: string;
+  };
+  address: AddressRecord | null;
+  payment: {
+    transactionRef: string;
+    amountBaht: string;
+    sendingBank: string | null;
+    receivingBank: string | null;
+    transactionAt: string | null;
+    verifiedAt: string | null;
+  } | null;
+  receipt: { receiptNo: string; amountBaht: string; issuedAt: string } | null;
+  /** Which post-payment steps have happened, without attempting any of them. */
+  workflow: WorkflowReport;
+  events: ApplicationEventRecord[];
+}
+
+export interface AdminViewService {
+  list(query?: ApplicationListQuery): Promise<AdminListItem[]>;
+  /**
+   * The full record, decrypting the citizen ID and recording that it was read.
+   *
+   * `actor` is the manager's Access identity, so the trail says who looked.
+   */
+  detail(applicationId: string, actor: string): Promise<AdminDetail>;
+}
+
+function fullName(record: ApplicationRecord): string | null {
+  const name = [record.title, record.firstName, record.lastName]
+    .map((part) => part?.trim() ?? '')
+    .filter((part) => part.length > 0)
+    .join(' ');
+  return name.length > 0 ? name : null;
+}
+
+function latestVerified(payments: readonly PaymentRecord[]): PaymentRecord | null {
+  return payments.filter((payment) => payment.verificationStatus === 'VERIFIED').at(-1) ?? null;
+}
+
+function receiptView(receipt: ReceiptRecord | null): AdminDetail['receipt'] {
+  if (!receipt) return null;
+  return {
+    receiptNo: receipt.receiptNo,
+    amountBaht: formatBaht(receipt.amountSatang),
+    issuedAt: receipt.issuedAt,
+  };
+}
+
+export function createAdminView(
+  db: Repository,
+  citizenId: CitizenIdProtection,
+  workflow: ApplicationWorkflow,
+  audit: AuditLog,
+): AdminViewService {
+  return {
+    async list(query) {
+      const records = await db.applications.list(query);
+      return records.map((record) => ({
+        id: record.id,
+        referenceNo: record.referenceNo,
+        status: record.status,
+        name: fullName(record),
+        membershipType: record.membershipType,
+        amountBaht:
+          record.membershipAmountSatang === null ? null : formatBaht(record.membershipAmountSatang),
+        submittedAt: record.submittedAt,
+        createdAt: record.createdAt,
+      }));
+    },
+
+    async detail(applicationId, actor) {
+      const application = await db.applications.findById(applicationId);
+      if (!application) throw adminApplicationNotFound();
+
+      const [address, payments, receipt, events, report] = await Promise.all([
+        db.addresses.findByApplicationId(applicationId),
+        db.payments.findByApplicationId(applicationId),
+        db.receipts.findByApplicationId(applicationId),
+        db.events.listByApplicationId(applicationId),
+        workflow.inspect(applicationId),
+      ]);
+
+      // Decrypting is the sensitive act, so it is recorded before the value is
+      // used. An envelope that cannot be read leaves the field null rather than
+      // failing the page: the manager still needs everything else.
+      let plainCitizenId: string | null;
+      try {
+        plainCitizenId = await citizenId.decrypt(application.citizenIdCiphertext);
+        await audit.record({
+          applicationId,
+          eventType: CITIZEN_ID_ACCESSED_EVENT,
+          actorType: 'MANAGER',
+          actorId: actor,
+        });
+      } catch {
+        plainCitizenId = null;
+      }
+
+      const payment = latestVerified(payments);
+      const plan = application.membershipType ? membershipPlan(application.membershipType) : null;
+
+      return {
+        application: {
+          id: application.id,
+          referenceNo: application.referenceNo,
+          status: application.status,
+          title: application.title,
+          firstName: application.firstName,
+          lastName: application.lastName,
+          firstNameEn: application.firstNameEn,
+          lastNameEn: application.lastNameEn,
+          birthDate: application.birthDate,
+          cardExpiryDate: application.cardExpiryDate,
+          citizenId: plainCitizenId,
+          phone: application.phone,
+          email: application.email,
+          callsign: application.callsign,
+          membershipType: application.membershipType,
+          membershipLabel: plan?.labelTh ?? null,
+          amountBaht:
+            application.membershipAmountSatang === null
+              ? null
+              : formatBaht(application.membershipAmountSatang),
+          hasPhoto: application.photoKey !== null,
+          photoSource: application.photoSource,
+          submittedAt: application.submittedAt,
+          managerAcknowledgedAt: application.managerAcknowledgedAt,
+          nbtcRecordedAt: application.nbtcRecordedAt,
+          nbtcRecordedBy: application.nbtcRecordedBy,
+          createdAt: application.createdAt,
+          updatedAt: application.updatedAt,
+        },
+        address,
+        payment: payment
+          ? {
+              transactionRef: payment.transactionRef,
+              amountBaht: formatBaht(payment.amountSatang),
+              sendingBank: payment.sendingBank,
+              receivingBank: payment.receivingBank,
+              transactionAt: payment.transactionAt,
+              verifiedAt: payment.verifiedAt,
+            }
+          : null,
+        receipt: receiptView(receipt),
+        workflow: report,
+        events,
+      };
+    },
+  };
+}

--- a/src/worker/services/application-workflow.ts
+++ b/src/worker/services/application-workflow.ts
@@ -1,4 +1,5 @@
 import type { ApplicationRecord, EmailRecord, EmailType, Repository } from '../db';
+import { ApiError } from '../lib/http';
 import type { EmailOutcome, EmailService } from './email';
 import type { NumberingService } from './numbering';
 import type { ReceiptService } from './receipt';
@@ -63,11 +64,15 @@ export interface WorkflowReport {
 export const APPLICATION_SUBMITTED_EVENT = 'APPLICATION_SUBMITTED';
 export const MANAGER_NOTIFIED_EVENT = 'MANAGER_NOTIFIED';
 
-export class WorkflowApplicationNotFoundError extends Error {
-  constructor() {
-    super('ไม่พบใบสมัครนี้');
-    this.name = 'WorkflowApplicationNotFoundError';
-  }
+/**
+ * Thrown for an unknown application.
+ *
+ * An `ApiError` rather than a bespoke class so the entrypoint maps it to 404
+ * without a per-service branch - a custom error here surfaced as a 500 and told
+ * the caller nothing.
+ */
+export function workflowApplicationNotFound(): ApiError {
+  return new ApiError('NOT_FOUND', 'ไม่พบใบสมัครนี้');
 }
 
 export interface ApplicationWorkflow {
@@ -120,7 +125,7 @@ export function createApplicationWorkflow(
 ): ApplicationWorkflow {
   const load = async (applicationId: string): Promise<ApplicationRecord> => {
     const application = await db.applications.findById(applicationId);
-    if (!application) throw new WorkflowApplicationNotFoundError();
+    if (!application) throw workflowApplicationNotFound();
     return application;
   };
 

--- a/src/worker/services/index.ts
+++ b/src/worker/services/index.ts
@@ -1,6 +1,7 @@
 export * from './application';
 export * from './application-workflow';
 export * from './application-access';
+export * from './admin-view';
 export * from './audit';
 export * from './email';
 export * from './email-events';
@@ -8,6 +9,7 @@ export * from './membership';
 export * from './payment';
 export * from './receipt';
 export * from './member-photo';
+export * from './nbtc-completion';
 export * from './numbering';
 export * from './state-machine';
 export * from './workflow-factory';

--- a/src/worker/services/nbtc-completion.ts
+++ b/src/worker/services/nbtc-completion.ts
@@ -1,0 +1,149 @@
+import type { ApplicationRecord, Repository } from '../db';
+import { ApiError } from '../lib/http';
+import type { EmailService } from './email';
+import type { StateMachine, TransitionOutcome } from './state-machine';
+
+/**
+ * Recording the NBTC registration (Issue #1 sections 37-40).
+ *
+ * The manager does the registration by hand in the regulator's own system and
+ * then confirms it here. That confirmation is the last thing anyone has to do,
+ * and it produces three effects in order: the record, the member's completion
+ * email, and the final status.
+ *
+ *   NBTC_RECORDED -> MEMBER_COMPLETION_EMAIL_SENT -> COMPLETED
+ *
+ * The shape mirrors the post-payment workflow, for the same reasons. Each step
+ * asks what it would have produced rather than reading a progress marker, so
+ * calling this twice is safe and calling it again after a provider outage
+ * finishes the part that did not happen. `COMPLETED` is only recorded once the
+ * member has actually been told, because that is what the status claims.
+ *
+ * The manager's identity is stored on the row and on the audit event. It is the
+ * only place a staff member's identity is persisted, and it is required: a
+ * registration with the regulator has to be attributable to the person who made
+ * it.
+ */
+
+export const MANAGER_CONFIRMED_EVENT = 'MANAGER_CONFIRMED_NBTC_RECORD';
+
+/**
+ * Thrown for an unknown application.
+ *
+ * An `ApiError` rather than a bespoke class so the entrypoint maps it to 404
+ * without a per-service branch - a custom error here surfaced as a 500 and told
+ * the caller nothing.
+ */
+export function nbtcApplicationNotFound(): ApiError {
+  return new ApiError('NOT_FOUND', 'ไม่พบใบสมัครนี้');
+}
+
+export type NbtcStepState = 'DONE' | 'ALREADY_DONE' | 'FAILED' | 'SKIPPED';
+
+export interface NbtcCompletionReport {
+  applicationId: string;
+  status: ApplicationRecord['status'];
+  recorded: NbtcStepState;
+  completionEmail: NbtcStepState;
+  completed: NbtcStepState;
+  /** True when all three steps are done. */
+  complete: boolean;
+}
+
+export interface NbtcCompletionService {
+  /**
+   * Records the registration and finishes the application.
+   *
+   * Idempotent: a second confirmation, or a retry after the email provider
+   * failed, does only the part that is still missing.
+   */
+  confirm(applicationId: string, managerIdentity: string): Promise<NbtcCompletionReport>;
+}
+
+const RECORDED_OR_LATER: readonly ApplicationRecord['status'][] = ['NBTC_RECORDED', 'COMPLETED'];
+
+function stateFor(outcome: TransitionOutcome): NbtcStepState {
+  if (outcome.kind === 'APPLIED') return 'DONE';
+  if (outcome.kind === 'ALREADY_IN_TARGET_STATE') return 'ALREADY_DONE';
+  return 'FAILED';
+}
+
+export function createNbtcCompletion(
+  db: Repository,
+  machine: StateMachine,
+  emails: EmailService,
+  options: { now?: () => Date } = {},
+): NbtcCompletionService {
+  const now = options.now ?? (() => new Date());
+
+  return {
+    async confirm(applicationId, managerIdentity) {
+      const application = await db.applications.findById(applicationId);
+      if (!application) throw nbtcApplicationNotFound();
+
+      const report: NbtcCompletionReport = {
+        applicationId,
+        status: application.status,
+        recorded: 'SKIPPED',
+        completionEmail: 'SKIPPED',
+        completed: 'SKIPPED',
+        complete: false,
+      };
+
+      if (RECORDED_OR_LATER.includes(application.status)) {
+        report.recorded = 'ALREADY_DONE';
+      } else {
+        const outcome = await machine.transition(applicationId, 'NBTC_RECORDED', {
+          actorType: 'MANAGER',
+          actorId: managerIdentity,
+          domainEvent: MANAGER_CONFIRMED_EVENT,
+          timestamps: {
+            nbtcRecordedAt: now().toISOString(),
+            nbtcRecordedBy: managerIdentity,
+          },
+        });
+        report.recorded = stateFor(outcome);
+        if (report.recorded === 'FAILED') {
+          const current = await db.applications.findById(applicationId);
+          report.status = current?.status ?? application.status;
+          return report;
+        }
+      }
+
+      const existing = await db.emails.findByApplicationIdAndType(
+        applicationId,
+        'MEMBER_NBTC_COMPLETED',
+      );
+      const accepted = existing.find((row) => row.status !== 'QUEUED' && row.status !== 'FAILED');
+
+      if (accepted) {
+        report.completionEmail = 'ALREADY_DONE';
+      } else {
+        const pending = existing[0];
+        const outcome = pending
+          ? await emails.retry(pending.id)
+          : await emails.sendMemberCompleted(applicationId);
+        report.completionEmail = outcome.ok ? 'DONE' : 'FAILED';
+      }
+
+      // `COMPLETED` is the end of the process as the member experiences it, so
+      // it waits for the message that tells them. The registration itself is
+      // already recorded and cannot be lost by stopping here.
+      if (report.completionEmail === 'DONE' || report.completionEmail === 'ALREADY_DONE') {
+        const outcome = await machine.transition(applicationId, 'COMPLETED', {
+          actorType: 'SYSTEM',
+        });
+        report.completed = stateFor(outcome);
+      }
+
+      const current = await db.applications.findById(applicationId);
+      report.status = current?.status ?? application.status;
+      // The email step is the only one that can be `FAILED` at this point: the
+      // record step returns early on failure, and `completed` is only reached
+      // once the email succeeded.
+      report.complete = report.completed === 'DONE' || report.completed === 'ALREADY_DONE';
+
+      return report;
+    },
+  };
+}

--- a/tests/support/access.ts
+++ b/tests/support/access.ts
@@ -1,0 +1,144 @@
+/**
+ * A stand-in for Cloudflare Access, built from a real RSA key pair.
+ *
+ * The point is that nothing here is a mock of the verification: the tests mint
+ * genuine RS256 JWTs and serve a genuine JWKS, so `createAccessVerifier` runs
+ * its real signature check, real claim checks and real certificate fetch. A mock
+ * that answered "authenticated" would leave the one control standing between
+ * the internet and the manager's data untested.
+ *
+ * No request reaches Cloudflare: the certificate fetch is intercepted.
+ */
+
+export const TEST_TEAM_DOMAIN = 'vra-test';
+export const TEST_AUDIENCE = 'test-only-access-audience-tag';
+export const TEST_ISSUER = `https://${TEST_TEAM_DOMAIN}.cloudflareaccess.com`;
+export const TEST_CERTS_URL = `${TEST_ISSUER}/cdn-cgi/access/certs`;
+
+/** The public half as a certs endpoint publishes it. */
+export interface AccessJwk {
+  kty: string;
+  n?: string | undefined;
+  e?: string | undefined;
+  alg: string;
+  kid: string;
+}
+
+export interface AccessKeyPair {
+  keyId: string;
+  privateKey: CryptoKey;
+  jwk: AccessJwk;
+}
+
+function base64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/, '');
+}
+
+function encodeJson(value: unknown): string {
+  return base64Url(new TextEncoder().encode(JSON.stringify(value)));
+}
+
+/** Generates a signing key and the public JWK a certs endpoint would publish. */
+export async function createAccessKeyPair(keyId = 'test-key-1'): Promise<AccessKeyPair> {
+  const pair = (await crypto.subtle.generateKey(
+    {
+      name: 'RSASSA-PKCS1-v1_5',
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: 'SHA-256',
+    },
+    true,
+    ['sign', 'verify'],
+  )) as CryptoKeyPair;
+
+  const exported = (await crypto.subtle.exportKey('jwk', pair.publicKey)) as {
+    n?: string;
+    e?: string;
+  };
+  return {
+    keyId,
+    privateKey: pair.privateKey,
+    jwk: { kty: 'RSA', n: exported.n, e: exported.e, alg: 'RS256', kid: keyId },
+  };
+}
+
+/** The body a Cloudflare Access certs endpoint returns. */
+export function certsResponse(...pairs: AccessKeyPair[]): Response {
+  return new Response(JSON.stringify({ keys: pairs.map((pair) => pair.jwk) }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+export interface TokenOptions {
+  audience?: string | string[];
+  issuer?: string;
+  email?: string | null;
+  subject?: string | null;
+  /** Seconds from now. Negative for an already-expired token. */
+  expiresInSeconds?: number;
+  notBeforeSeconds?: number;
+  issuedAtSeconds?: number;
+  algorithm?: string;
+  /** Signs with this key instead, to produce a signature that will not verify. */
+  signWith?: AccessKeyPair;
+}
+
+/** Mints a token the real verifier will accept, unless told otherwise. */
+export async function createAccessToken(
+  pair: AccessKeyPair,
+  options: TokenOptions = {},
+): Promise<string> {
+  const seconds = Math.floor(Date.now() / 1000);
+  const signer = options.signWith ?? pair;
+
+  const header = {
+    alg: options.algorithm ?? 'RS256',
+    kid: pair.keyId,
+    typ: 'JWT',
+  };
+
+  const claims: Record<string, unknown> = {
+    aud: options.audience ?? [TEST_AUDIENCE],
+    iss: options.issuer ?? TEST_ISSUER,
+    exp: seconds + (options.expiresInSeconds ?? 3600),
+    iat: seconds + (options.issuedAtSeconds ?? 0),
+    nbf: seconds + (options.notBeforeSeconds ?? 0),
+  };
+  if (options.email !== null) claims['email'] = options.email ?? 'manager@example.test';
+  if (options.subject !== null) claims['sub'] = options.subject ?? 'access-subject-1';
+
+  const signingInput = `${encodeJson(header)}.${encodeJson(claims)}`;
+  const signature = new Uint8Array(
+    await crypto.subtle.sign(
+      'RSASSA-PKCS1-v1_5',
+      signer.privateKey,
+      new TextEncoder().encode(signingInput),
+    ),
+  );
+
+  return `${signingInput}.${base64Url(signature)}`;
+}
+
+/**
+ * Intercepts the certificate fetch and nothing else.
+ *
+ * Any other URL falls through to the original `fetch`, so a test that
+ * accidentally reaches a provider still fails loudly rather than being served a
+ * certificate set.
+ */
+export function serveCerts(...pairs: AccessKeyPair[]): () => void {
+  const original = globalThis.fetch;
+
+  globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+    if (url === TEST_CERTS_URL) return certsResponse(...pairs);
+    return original(input, init);
+  };
+
+  return () => {
+    globalThis.fetch = original;
+  };
+}

--- a/tests/unit/providers.test.ts
+++ b/tests/unit/providers.test.ts
@@ -172,8 +172,28 @@ describe('mock email provider', () => {
       text: 'test',
     });
 
-    expect(result).toEqual({ ok: true, providerEmailId: 'mock-email-1' });
+    expect(result.ok).toBe(true);
     expect(email.sent).toHaveLength(1);
+  });
+
+  it('returns a distinct id for every message, across instances', async () => {
+    const outbound = {
+      to: 'member@example.test',
+      subject: 'test',
+      html: '<p>test</p>',
+      text: 'test',
+    };
+    const first = await createMockEmailProvider().send(outbound);
+    const second = await createMockEmailProvider().send(outbound);
+
+    // `emails.provider_email_id` is unique. A per-instance counter restarting
+    // at 1 - one instance per request - collided across requests, which a real
+    // provider's globally unique ids never would.
+    expect(first).toMatchObject({ ok: true });
+    expect(second).toMatchObject({ ok: true });
+    expect((first as { providerEmailId: string }).providerEmailId).not.toBe(
+      (second as { providerEmailId: string }).providerEmailId,
+    );
   });
 
   it('can simulate a provider failure', async () => {

--- a/tests/worker/admin.test.ts
+++ b/tests/worker/admin.test.ts
@@ -1,0 +1,784 @@
+import { env, exports } from 'cloudflare:workers';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { PaymentInput, Repository } from '../../src/worker/db';
+import { createMockEmailProvider } from '../../src/worker/providers/mock/email';
+import {
+  ACCESS_JWT_COOKIE,
+  ACCESS_JWT_HEADER,
+  resetAccessCertCache,
+} from '../../src/worker/security/access';
+import { CSRF_COOKIE_NAME, CSRF_HEADER_NAME } from '../../src/worker/security/csrf';
+import { createAuditLog } from '../../src/worker/services/audit';
+import { createEmailService } from '../../src/worker/services/email';
+import { createNbtcCompletion } from '../../src/worker/services/nbtc-completion';
+import { createNumberingService } from '../../src/worker/services/numbering';
+import { createReceiptService } from '../../src/worker/services/receipt';
+import { createStateMachine } from '../../src/worker/services/state-machine';
+import {
+  createAccessKeyPair,
+  createAccessToken,
+  serveCerts,
+  TEST_AUDIENCE,
+  TEST_ISSUER,
+} from '../support/access';
+import type { AccessKeyPair } from '../support/access';
+import { ANNUAL_SATANG, TEST_CITIZEN_ID, repository, seedApplication } from '../support/fixtures';
+
+/**
+ * Admin endpoints end to end, with **real** Cloudflare Access verification.
+ *
+ * The tests mint genuine RS256 tokens and serve a genuine JWKS, so the signature
+ * check, the claim checks and the certificate fetch all run for real. Only the
+ * network call to Cloudflare is intercepted. A mock verifier here would leave the
+ * single control between the internet and the manager's data untested, which is
+ * the opposite of what a high-risk change needs.
+ */
+
+const APPLICANT_EMAIL = 'applicant@example.test';
+const MANAGER = 'manager@example.test';
+const ORIGIN = 'http://localhost:8787';
+const CSRF = 'a'.repeat(64);
+
+let keys: AccessKeyPair;
+let restoreFetch: () => void;
+
+beforeEach(async () => {
+  resetAccessCertCache();
+  keys = await createAccessKeyPair();
+  restoreFetch = serveCerts(keys);
+});
+
+afterEach(() => {
+  restoreFetch();
+});
+
+interface CallOptions {
+  method?: string;
+  token?: string | null;
+  /** Sends the token in the cookie instead of the header. */
+  inCookie?: boolean;
+  csrf?: { cookie?: string; header?: string } | null;
+  origin?: string | null;
+}
+
+async function call(path: string, options: CallOptions = {}): Promise<Response> {
+  const headers = new Headers();
+  const cookies: string[] = [];
+
+  const token = options.token === undefined ? await createAccessToken(keys) : options.token;
+  if (token !== null) {
+    if (options.inCookie) cookies.push(`${ACCESS_JWT_COOKIE}=${token}`);
+    else headers.set(ACCESS_JWT_HEADER, token);
+  }
+
+  const method = options.method ?? 'GET';
+  if (method !== 'GET') {
+    const csrf = options.csrf === undefined ? { cookie: CSRF, header: CSRF } : options.csrf;
+    if (csrf?.cookie) cookies.push(`${CSRF_COOKIE_NAME}=${csrf.cookie}`);
+    if (csrf?.header) headers.set(CSRF_HEADER_NAME, csrf.header);
+    const origin = options.origin === undefined ? ORIGIN : options.origin;
+    if (origin !== null) headers.set('origin', origin);
+  }
+
+  if (cookies.length > 0) headers.set('cookie', cookies.join('; '));
+
+  return exports.default.fetch(new Request(`http://localhost${path}`, { method, headers }));
+}
+
+function paymentInput(applicationId: string): PaymentInput {
+  return {
+    applicationId,
+    provider: 'slipok',
+    transactionRef: `TXN-${crypto.randomUUID()}`,
+    amountSatang: ANNUAL_SATANG,
+    sendingBank: '002',
+    receivingBank: 'ธนาคารตัวอย่าง',
+    receiverAccountDigits: '1234',
+    transactionAt: new Date().toISOString(),
+    receiverMatched: true,
+    amountMatched: true,
+    verificationStatus: 'VERIFIED',
+    verifiedAt: new Date().toISOString(),
+  };
+}
+
+/** An application the manager has been notified about, which is the usual case. */
+async function notifiedApplication(repo: Repository, citizenId?: string): Promise<string> {
+  const id = await seedApplication(repo, citizenId);
+  await repo.applications.updateContact(id, { email: APPLICANT_EMAIL, phone: '0800000000' });
+  await repo.addresses.upsert(id, {
+    idAddress: '99/9',
+    idSubdistrict: 'ตำบลทดสอบ',
+    idDistrict: 'อำเภอทดสอบ',
+    idProvince: 'จังหวัดทดสอบ',
+    mailSameAsId: true,
+    mailRecipient: null,
+    mailAddress: null,
+    mailSubdistrict: null,
+    mailDistrict: null,
+    mailProvince: null,
+    mailPostcode: null,
+    mailPhone: null,
+  });
+  await repo.applications.setMembership(id, 'ANNUAL', ANNUAL_SATANG);
+  await repo.applications.setReferenceNo(id, `VRA-2569-${crypto.randomUUID().slice(0, 6)}`);
+  await repo.payments.create(paymentInput(id));
+
+  const machine = createStateMachine(repo);
+  await machine.transition(id, 'AWAITING_PAYMENT');
+  await machine.transition(id, 'PAYMENT_VERIFIED');
+  await machine.transition(id, 'SUBMITTED');
+  await machine.transition(id, 'MANAGER_NOTIFIED');
+  return id;
+}
+
+describe('Access authentication', () => {
+  it('accepts a correctly signed token in the header', async () => {
+    const repo = repository();
+    await notifiedApplication(repo);
+
+    const response = await call('/api/admin/applications');
+
+    expect(response.status).toBe(200);
+  });
+
+  it('accepts the token in the CF_Authorization cookie', async () => {
+    const response = await call('/api/admin/applications', { inCookie: true });
+
+    expect(response.status).toBe(200);
+  });
+
+  it('refuses a request with no token', async () => {
+    const response = await call('/api/admin/applications', { token: null });
+
+    expect(response.status).toBe(403);
+  });
+
+  it('refuses a token signed by a different key', async () => {
+    const other = await createAccessKeyPair('test-key-1');
+    const forged = await createAccessToken(keys, { signWith: other });
+
+    const response = await call('/api/admin/applications', { token: forged });
+
+    expect(response.status).toBe(403);
+  });
+
+  it('refuses a token minted for another Access application', async () => {
+    // Without the `aud` check any token from the same account would work here.
+    const token = await createAccessToken(keys, { audience: ['some-other-application'] });
+
+    const response = await call('/api/admin/applications', { token });
+
+    expect(response.status).toBe(403);
+  });
+
+  it('refuses a token from another team', async () => {
+    const token = await createAccessToken(keys, {
+      issuer: 'https://someone-else.cloudflareaccess.com',
+    });
+
+    const response = await call('/api/admin/applications', { token });
+
+    expect(response.status).toBe(403);
+  });
+
+  it('refuses an expired token', async () => {
+    const token = await createAccessToken(keys, { expiresInSeconds: -3600 });
+
+    const response = await call('/api/admin/applications', { token });
+
+    expect(response.status).toBe(403);
+  });
+
+  it('refuses a token that is not valid yet', async () => {
+    const token = await createAccessToken(keys, { notBeforeSeconds: 3600 });
+
+    const response = await call('/api/admin/applications', { token });
+
+    expect(response.status).toBe(403);
+  });
+
+  it('refuses an unsigned token', async () => {
+    // `alg: none` with an empty signature is the classic JWT bypass. The
+    // algorithm is fixed rather than read from the token for this reason.
+    const token = await createAccessToken(keys, { algorithm: 'none' });
+
+    const response = await call('/api/admin/applications', { token });
+
+    expect(response.status).toBe(403);
+  });
+
+  it('refuses a token whose payload was edited after signing', async () => {
+    const token = await createAccessToken(keys);
+    const [header, , signature] = token.split('.');
+    const tampered = btoa(JSON.stringify({ aud: [TEST_AUDIENCE], iss: TEST_ISSUER, exp: 9e9 }))
+      .replaceAll('+', '-')
+      .replaceAll('/', '_')
+      .replace(/=+$/, '');
+
+    const response = await call('/api/admin/applications', {
+      token: `${header}.${tampered}.${signature}`,
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it('refuses a token with no subject', async () => {
+    const token = await createAccessToken(keys, { subject: null });
+
+    const response = await call('/api/admin/applications', { token });
+
+    expect(response.status).toBe(403);
+  });
+
+  it('says nothing about which check refused it', async () => {
+    const expired = await call('/api/admin/applications', {
+      token: await createAccessToken(keys, { expiresInSeconds: -3600 }),
+    });
+    const wrongAudience = await call('/api/admin/applications', {
+      token: await createAccessToken(keys, { audience: ['other'] }),
+    });
+
+    // Distinguishable failures would tell someone probing the endpoint which
+    // part of their token to fix. The request id differs by design and is not
+    // part of what the response says about the token.
+    const first = await expired.json<{ error: { code: string; message: string } }>();
+    const second = await wrongAudience.json<{ error: { code: string; message: string } }>();
+    expect(expired.status).toBe(wrongAudience.status);
+    expect(first.error.code).toBe(second.error.code);
+    expect(first.error.message).toBe(second.error.message);
+  });
+
+  it('refuses everything when the certificate endpoint is unreachable', async () => {
+    const token = await createAccessToken(keys);
+    restoreFetch();
+    resetAccessCertCache();
+    const original = globalThis.fetch;
+    globalThis.fetch = () => Promise.reject(new Error('network down'));
+
+    try {
+      const response = await call('/api/admin/applications', { token });
+
+      // Failing open here would make the admin API public during an outage.
+      expect(response.status).toBe(403);
+    } finally {
+      globalThis.fetch = original;
+      restoreFetch = serveCerts(keys);
+    }
+  });
+});
+
+describe('every admin endpoint requires Access', () => {
+  const paths = [
+    { method: 'GET', path: '/api/admin/session' },
+    { method: 'GET', path: '/api/admin/applications' },
+    { method: 'GET', path: `/api/admin/applications/${crypto.randomUUID()}` },
+    { method: 'POST', path: `/api/admin/applications/${crypto.randomUUID()}/acknowledge` },
+    { method: 'POST', path: `/api/admin/applications/${crypto.randomUUID()}/nbtc-complete` },
+    { method: 'POST', path: `/api/admin/applications/${crypto.randomUUID()}/finalize` },
+    { method: 'GET', path: `/api/admin/applications/${crypto.randomUUID()}/photo` },
+    { method: 'GET', path: `/api/admin/applications/${crypto.randomUUID()}/receipt` },
+  ];
+
+  for (const route of paths) {
+    it(`refuses ${route.method} ${route.path.replace(/[0-9a-f-]{36}/, ':id')} without a token`, async () => {
+      const response = await call(route.path, { method: route.method, token: null });
+
+      expect(response.status).toBe(403);
+    });
+  }
+});
+
+describe('CSRF on state changes', () => {
+  it('refuses a POST with no origin header', async () => {
+    const repo = repository();
+    const id = await notifiedApplication(repo);
+
+    const response = await call(`/api/admin/applications/${id}/acknowledge`, {
+      method: 'POST',
+      origin: null,
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it('refuses a POST from another origin', async () => {
+    const repo = repository();
+    const id = await notifiedApplication(repo);
+
+    // Access authenticates with a cookie, and a cookie is sent cross-site too.
+    const response = await call(`/api/admin/applications/${id}/acknowledge`, {
+      method: 'POST',
+      origin: 'https://attacker.example.test',
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it('refuses a POST with no CSRF token', async () => {
+    const repo = repository();
+    const id = await notifiedApplication(repo);
+
+    const response = await call(`/api/admin/applications/${id}/acknowledge`, {
+      method: 'POST',
+      csrf: null,
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it('refuses a POST whose header and cookie tokens disagree', async () => {
+    const repo = repository();
+    const id = await notifiedApplication(repo);
+
+    const response = await call(`/api/admin/applications/${id}/acknowledge`, {
+      method: 'POST',
+      csrf: { cookie: CSRF, header: 'b'.repeat(64) },
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it('changes nothing when CSRF fails', async () => {
+    const repo = repository();
+    const id = await notifiedApplication(repo);
+
+    await call(`/api/admin/applications/${id}/nbtc-complete`, { method: 'POST', csrf: null });
+
+    await expect(repo.applications.findById(id)).resolves.toMatchObject({
+      status: 'MANAGER_NOTIFIED',
+    });
+  });
+
+  it('issues a token from the session endpoint', async () => {
+    const response = await call('/api/admin/session');
+    const body = await response.json<{
+      manager: { email: string };
+      csrf: { header: string; token: string };
+    }>();
+
+    expect(response.status).toBe(200);
+    expect(body.manager.email).toBe(MANAGER);
+    expect(body.csrf.header).toBe(CSRF_HEADER_NAME);
+    expect(body.csrf.token).toMatch(/^[0-9a-f]{64}$/);
+    expect(response.headers.get('set-cookie')).toContain(CSRF_COOKIE_NAME);
+  });
+});
+
+describe('GET never changes state', () => {
+  it('leaves the status untouched on every read', async () => {
+    const repo = repository();
+    const id = await notifiedApplication(repo);
+
+    // An email security scanner opens links in messages. A GET that advanced
+    // the application would let an anti-virus gateway act for the manager
+    // (Issue #1 section 37).
+    for (const path of [
+      '/api/admin/applications',
+      `/api/admin/applications/${id}`,
+      `/api/admin/applications/${id}/receipt`,
+      `/api/admin/applications/${id}/photo`,
+    ]) {
+      await call(path);
+    }
+
+    await expect(repo.applications.findById(id)).resolves.toMatchObject({
+      status: 'MANAGER_NOTIFIED',
+    });
+  });
+});
+
+describe('the application list', () => {
+  it('returns applications without their personal details', async () => {
+    const repo = repository();
+    await notifiedApplication(repo);
+
+    const response = await call('/api/admin/applications');
+    const body = await response.json<{ applications: Record<string, unknown>[] }>();
+
+    expect(body.applications).toHaveLength(1);
+    const item = body.applications[0]!;
+    expect(item['referenceNo']).toMatch(/^VRA-2569-/);
+    // A queue view needs a name, not an address, a phone number or a card.
+    const serialised = JSON.stringify(item);
+    expect(serialised).not.toContain(TEST_CITIZEN_ID);
+    expect(serialised).not.toContain(APPLICANT_EMAIL);
+    expect(serialised).not.toContain('จังหวัดทดสอบ');
+  });
+
+  it('filters by status', async () => {
+    const repo = repository();
+    await notifiedApplication(repo, '1234567890121');
+    const draft = await seedApplication(repo, '1234567890139');
+
+    const notified = await call('/api/admin/applications?status=MANAGER_NOTIFIED');
+    const drafts = await call('/api/admin/applications?status=DRAFT');
+
+    const notifiedBody = await notified.json<{ applications: { id: string }[] }>();
+    const draftBody = await drafts.json<{ applications: { id: string }[] }>();
+    expect(notifiedBody.applications).toHaveLength(1);
+    expect(draftBody.applications).toHaveLength(1);
+    expect(draftBody.applications[0]!.id).toBe(draft);
+  });
+
+  it('rejects an unknown status rather than ignoring the filter', async () => {
+    const response = await call('/api/admin/applications?status=NOT_A_STATUS');
+
+    // Ignoring it would turn a typo into a full listing of personal data.
+    expect(response.status).toBeGreaterThanOrEqual(400);
+  });
+});
+
+describe('the application detail', () => {
+  it('returns the full citizen ID and records that it was read', async () => {
+    const repo = repository();
+    const id = await notifiedApplication(repo);
+
+    const response = await call(`/api/admin/applications/${id}`);
+    const body = await response.json<{ detail: { application: { citizenId: string } } }>();
+
+    expect(response.status).toBe(200);
+    expect(body.detail.application.citizenId).toBe(TEST_CITIZEN_ID);
+
+    const events = await repo.events.listByApplicationId(id);
+    const access = events.find((event) => event.eventType === 'CITIZEN_ID_ACCESSED');
+    expect(access).toBeDefined();
+    expect(access?.actorType).toBe('MANAGER');
+    expect(access?.actorId).toBe(MANAGER);
+  });
+
+  it('records one access event per read, so the trail counts them', async () => {
+    const repo = repository();
+    const id = await notifiedApplication(repo);
+
+    await call(`/api/admin/applications/${id}`);
+    await call(`/api/admin/applications/${id}`);
+
+    const events = await repo.events.listByApplicationId(id);
+    expect(events.filter((event) => event.eventType === 'CITIZEN_ID_ACCESSED')).toHaveLength(2);
+  });
+
+  it('includes what the manager needs to do the registration', async () => {
+    const repo = repository();
+    const id = await notifiedApplication(repo);
+
+    const response = await call(`/api/admin/applications/${id}`);
+    const body = await response.json<{
+      detail: {
+        application: { email: string; phone: string; membershipLabel: string };
+        address: { idProvince: string } | null;
+        payment: { transactionRef: string } | null;
+        workflow: { complete: boolean };
+        events: unknown[];
+      };
+    }>();
+
+    expect(body.detail.application.email).toBe(APPLICANT_EMAIL);
+    expect(body.detail.application.membershipLabel).toBe('สมาชิกสามัญรายปี');
+    expect(body.detail.address?.idProvince).toBe('จังหวัดทดสอบ');
+    expect(body.detail.payment?.transactionRef).toMatch(/^TXN-/);
+    expect(body.detail.events.length).toBeGreaterThan(0);
+  });
+
+  it('reports which post-payment steps stalled without retrying them', async () => {
+    const repo = repository();
+    const id = await notifiedApplication(repo);
+
+    const response = await call(`/api/admin/applications/${id}`);
+    const body = await response.json<{ detail: { workflow: { steps: Record<string, string> } } }>();
+
+    // No receipt was issued in this fixture, so the manager can see exactly
+    // that - and loading the page must not have issued one.
+    expect(body.detail.workflow.steps['RECEIPT']).toBe('SKIPPED');
+    expect(await repo.receipts.findByApplicationId(id)).toBeNull();
+  });
+
+  it('returns 404 for an application that does not exist', async () => {
+    const response = await call(`/api/admin/applications/${crypto.randomUUID()}`);
+
+    expect(response.status).toBe(404);
+  });
+});
+
+describe('acknowledge', () => {
+  it('moves the application into processing and notifies the member once', async () => {
+    const repo = repository();
+    const id = await notifiedApplication(repo);
+
+    const first = await call(`/api/admin/applications/${id}/acknowledge`, { method: 'POST' });
+    const second = await call(`/api/admin/applications/${id}/acknowledge`, { method: 'POST' });
+
+    expect(first.status).toBe(200);
+    expect(await first.json<{ processingEmailSent: boolean }>()).toMatchObject({
+      processingEmailSent: true,
+    });
+    expect(await second.json<{ processingEmailSent: boolean }>()).toMatchObject({
+      processingEmailSent: false,
+    });
+    expect(await repo.emails.findByApplicationIdAndType(id, 'MEMBER_PROCESSING')).toHaveLength(1);
+    await expect(repo.applications.findById(id)).resolves.toMatchObject({
+      status: 'NBTC_PROCESSING',
+    });
+  });
+});
+
+describe('nbtc-complete', () => {
+  async function acknowledged(repo: Repository): Promise<string> {
+    const id = await notifiedApplication(repo);
+    await call(`/api/admin/applications/${id}/acknowledge`, { method: 'POST' });
+    return id;
+  }
+
+  it('records the registration, tells the member and completes the application', async () => {
+    const repo = repository();
+    const id = await acknowledged(repo);
+
+    const response = await call(`/api/admin/applications/${id}/nbtc-complete`, { method: 'POST' });
+    const body = await response.json<{ completion: Record<string, unknown> }>();
+
+    expect(response.status).toBe(200);
+    expect(body.completion).toMatchObject({
+      recorded: 'DONE',
+      completionEmail: 'DONE',
+      completed: 'DONE',
+      complete: true,
+      status: 'COMPLETED',
+    });
+  });
+
+  it('attributes the registration to the manager who confirmed it', async () => {
+    const repo = repository();
+    const id = await acknowledged(repo);
+
+    await call(`/api/admin/applications/${id}/nbtc-complete`, { method: 'POST' });
+
+    const application = await repo.applications.findById(id);
+    expect(application?.nbtcRecordedBy).toBe(MANAGER);
+    expect(application?.nbtcRecordedAt).not.toBeNull();
+
+    const events = await repo.events.listByApplicationId(id);
+    const confirmed = events.find((event) => event.eventType === 'MANAGER_CONFIRMED_NBTC_RECORD');
+    expect(confirmed?.actorId).toBe(MANAGER);
+  });
+
+  it('records the documented trail for the second half of the process', async () => {
+    const repo = repository();
+    const id = await acknowledged(repo);
+
+    await call(`/api/admin/applications/${id}/nbtc-complete`, { method: 'POST' });
+
+    // Issue #1 section 50.
+    const types = (await repo.events.listByApplicationId(id)).map((event) => event.eventType);
+    const expected = [
+      'MANAGER_ACKNOWLEDGED',
+      'MEMBER_PROCESSING_EMAIL_SENT',
+      'MANAGER_CONFIRMED_NBTC_RECORD',
+      'MEMBER_COMPLETION_EMAIL_SENT',
+    ];
+    const positions = expected.map((event) => types.indexOf(event));
+    expect(positions.every((position) => position >= 0)).toBe(true);
+    expect([...positions].sort((a, b) => a - b)).toEqual(positions);
+  });
+
+  it('is a no-op when called again, with no second email', async () => {
+    const repo = repository();
+    const id = await acknowledged(repo);
+    await call(`/api/admin/applications/${id}/nbtc-complete`, { method: 'POST' });
+
+    const response = await call(`/api/admin/applications/${id}/nbtc-complete`, { method: 'POST' });
+    const body = await response.json<{ completion: Record<string, unknown> }>();
+
+    expect(body.completion).toMatchObject({
+      recorded: 'ALREADY_DONE',
+      completionEmail: 'ALREADY_DONE',
+      complete: true,
+    });
+    expect(await repo.emails.findByApplicationIdAndType(id, 'MEMBER_NBTC_COMPLETED')).toHaveLength(
+      1,
+    );
+  });
+
+  it('refuses an application that is not ready for it', async () => {
+    const repo = repository();
+    const id = await notifiedApplication(repo);
+
+    const response = await call(`/api/admin/applications/${id}/nbtc-complete`, { method: 'POST' });
+    const body = await response.json<{ completion: { recorded: string; status: string } }>();
+
+    // `MANAGER_NOTIFIED` cannot jump to `NBTC_RECORDED`; the manager has to
+    // acknowledge first, and the state machine refuses rather than inventing a
+    // path.
+    expect(body.completion.recorded).toBe('FAILED');
+    expect(body.completion.status).toBe('MANAGER_NOTIFIED');
+  });
+});
+
+describe('nbtc completion when the provider is down', () => {
+  it('keeps the registration and does not claim completion', async () => {
+    const repo = repository();
+    const id = await notifiedApplication(repo);
+    await call(`/api/admin/applications/${id}/acknowledge`, { method: 'POST' });
+
+    const audit = createAuditLog(repo);
+    const failing = createNbtcCompletion(
+      repo,
+      createStateMachine(repo),
+      createEmailService(
+        repo,
+        createMockEmailProvider({ failWith: 'PROVIDER_ERROR' }),
+        createReceiptService(repo, createNumberingService(repo), audit),
+        audit,
+        { managerEmail: MANAGER, appBaseUrl: ORIGIN },
+      ),
+    );
+
+    const report = await failing.confirm(id, MANAGER);
+
+    // The registration really happened; only the notice failed.
+    expect(report.recorded).toBe('DONE');
+    expect(report.completionEmail).toBe('FAILED');
+    expect(report.completed).toBe('SKIPPED');
+    expect(report.status).toBe('NBTC_RECORDED');
+    expect(report.complete).toBe(false);
+  });
+
+  it('finishes when the provider comes back, without a second record', async () => {
+    const repo = repository();
+    const id = await notifiedApplication(repo);
+    await call(`/api/admin/applications/${id}/acknowledge`, { method: 'POST' });
+    const audit = createAuditLog(repo);
+    const receipts = createReceiptService(repo, createNumberingService(repo), audit);
+
+    await createNbtcCompletion(
+      repo,
+      createStateMachine(repo),
+      createEmailService(
+        repo,
+        createMockEmailProvider({ failWith: 'PROVIDER_ERROR' }),
+        receipts,
+        audit,
+        { managerEmail: MANAGER, appBaseUrl: ORIGIN },
+      ),
+    ).confirm(id, MANAGER);
+    const recordedAt = (await repo.applications.findById(id))?.nbtcRecordedAt;
+
+    const report = await call(`/api/admin/applications/${id}/nbtc-complete`, { method: 'POST' });
+    const body = await report.json<{ completion: Record<string, unknown> }>();
+
+    expect(body.completion).toMatchObject({
+      recorded: 'ALREADY_DONE',
+      completionEmail: 'DONE',
+      completed: 'DONE',
+      status: 'COMPLETED',
+    });
+    expect((await repo.applications.findById(id))?.nbtcRecordedAt).toBe(recordedAt);
+    expect(await repo.emails.findByApplicationIdAndType(id, 'MEMBER_NBTC_COMPLETED')).toHaveLength(
+      1,
+    );
+  });
+});
+
+describe('the member photo', () => {
+  it('is served through the authenticated endpoint', async () => {
+    const repo = repository();
+    const id = await notifiedApplication(repo);
+    const key = `member-photos/${crypto.randomUUID()}.jpg`;
+    await env.MEMBER_PHOTOS.put(key, new Uint8Array([0xff, 0xd8, 0xff, 0x00]), {
+      httpMetadata: { contentType: 'image/jpeg' },
+    });
+    await repo.applications.setPhoto(id, { key, source: 'UPLOAD' });
+
+    const response = await call(`/api/admin/applications/${id}/photo`);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toBe('image/jpeg');
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(new Uint8Array(await response.arrayBuffer())).toHaveLength(4);
+  });
+
+  it('reports a missing photo rather than an empty body', async () => {
+    const repo = repository();
+    const id = await notifiedApplication(repo);
+
+    const response = await call(`/api/admin/applications/${id}/photo`);
+
+    expect(response.status).toBe(404);
+  });
+});
+
+describe('the receipt', () => {
+  it('is regenerated and its download recorded', async () => {
+    const repo = repository();
+    const id = await notifiedApplication(repo);
+    const audit = createAuditLog(repo);
+    const { receipt } = await createReceiptService(repo, createNumberingService(repo), audit).issue(
+      id,
+    );
+
+    const response = await call(`/api/admin/applications/${id}/receipt`);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toBe('application/pdf');
+    expect(response.headers.get('content-disposition')).toContain(`${receipt.receiptNo}.pdf`);
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    expect(new TextDecoder('latin1').decode(bytes.slice(0, 5))).toBe('%PDF-');
+
+    const events = await repo.events.listByApplicationId(id);
+    const download = events.find((event) => event.eventType === 'RECEIPT_DOWNLOADED');
+    expect(download?.actorId).toBe(MANAGER);
+  });
+
+  it('reports a missing receipt', async () => {
+    const repo = repository();
+    const id = await notifiedApplication(repo);
+
+    const response = await call(`/api/admin/applications/${id}/receipt`);
+
+    expect(response.status).toBe(404);
+  });
+});
+
+describe('admin finalize', () => {
+  it('finishes a stalled post-payment flow without the applicant', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+    await repo.applications.updateContact(id, { email: APPLICANT_EMAIL });
+    await repo.applications.setMembership(id, 'ANNUAL', ANNUAL_SATANG);
+    await repo.payments.create(paymentInput(id));
+    const machine = createStateMachine(repo);
+    await machine.transition(id, 'AWAITING_PAYMENT');
+    await machine.transition(id, 'PAYMENT_VERIFIED');
+
+    const response = await call(`/api/admin/applications/${id}/finalize`, { method: 'POST' });
+    const body = await response.json<{ confirmation: { complete: boolean; status: string } }>();
+
+    expect(response.status).toBe(200);
+    expect(body.confirmation.complete).toBe(true);
+    expect(body.confirmation.status).toBe('MANAGER_NOTIFIED');
+  });
+});
+
+describe('logging', () => {
+  it('never logs the manager identity or applicant details', async () => {
+    const repo = repository();
+    const id = await notifiedApplication(repo);
+    const lines: string[] = [];
+    const original = console.log;
+    console.log = (...args: unknown[]) => {
+      lines.push(args.map((arg) => String(arg)).join(' '));
+    };
+
+    try {
+      await call(`/api/admin/applications/${id}`);
+      await call(`/api/admin/applications/${id}/acknowledge`, { method: 'POST' });
+    } finally {
+      console.log = original;
+    }
+
+    const output = lines.join('\n');
+    expect(output).not.toContain(MANAGER);
+    expect(output).not.toContain(APPLICANT_EMAIL);
+    expect(output).not.toContain(TEST_CITIZEN_ID);
+    expect(output).not.toContain('ทดสอบ');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -37,6 +37,10 @@ export default defineConfig(async () => {
             // Invented account details. `receiverAccountDigits` from the mock
             // slip provider is `1234`, which has to appear in order inside the
             // configured account for the receiver check to pass.
+            // Access team and audience for the admin tests, which mint real
+            // RS256 tokens against a JWKS the test itself serves.
+            CF_ACCESS_TEAM_DOMAIN: 'vra-test',
+            CF_ACCESS_AUD: 'test-only-access-audience-tag',
             VRA_BANK_ACCOUNT: '001234567890',
             VRA_BANK_NAME: 'ธนาคารตัวอย่าง',
             VRA_BANK_ACCOUNT_NAME: 'สมาคมนักวิทยุอาสาสมัคร (ตัวอย่าง)',


### PR DESCRIPTION
Closes #16

## What this does

The manager's API: list, detail, acknowledge, NBTC completion, photo, receipt, and a finalize that does not need the applicant's token. Plus the three handoffs recorded on this issue from #12, #14 and #15.

## Access is verified in the Worker, not only at the edge

Access sits in front of `/admin*` and `/api/admin/*` and will not let an unauthenticated request through. Every route here verifies the JWT anyway, because that edge configuration is **one setting in a dashboard**: remove it, attach it to the wrong hostname, or write a path that does not match, and every endpoint becomes public. Verifying again means a dashboard mistake costs an outage rather than a data breach.

With `CF_ACCESS_TEAM_DOMAIN` and `CF_ACCESS_AUD` unset, every admin request is refused. There is no "not configured yet, so open" state.

What the verification checks, and why each one is there:

- **Signature**, against the team's published certificates, refetched once on an unknown `kid` so a key rotation does not lock the manager out for an hour.
- **`aud`** must be *this* application's tag. This is the one that matters most: without it, a token minted for any other Access application in the same account would be accepted here.
- **`alg` is fixed at RS256**, not read from the token. Reading it is what allows `alg: none` and using the public key as an HMAC shared secret.
- **`iss`** must be this team.
- **Validity window.** Clock tolerance applies to `nbf` and `iat`, where skew makes a freshly minted token look future-dated — and deliberately **not** to `exp`, where tolerance would extend the life of an expired token. Access tokens last hours; nothing needs it.
- **An unreachable certificate endpoint refuses everything.** Failing open during a Cloudflare outage would publish the admin API.

Every failure returns the identical message. The difference between "wrong audience" and "expired" is precisely what someone probing the endpoint would want to learn.

## GET never changes state

Email security scanners open links in messages. A `GET` that advanced an application would let an anti-virus gateway acknowledge it, or mark it registered, on the manager's behalf (Issue #1 section 37). So every read here is a read, and every state change is a `POST` that also passes the origin and double-submit CSRF checks built in #8 — needed on top of authentication because Access authenticates with a cookie, and cookies are sent on cross-site requests.

The links in the manager's email point at portal pages, not at these endpoints. The page shows what is about to happen and posts from there. `GET /api/admin/session` issues the CSRF token the portal echoes back.

## The citizen ID has exactly one reader

`admin-view.ts` is the only place in the admin flow that decrypts a citizen ID, and it records `CITIZEN_ID_ACCESSED` on the same call. There is no way to add a second reader later that forgets to record it. Each detail read is counted, so the trail answers who looked and how often — not just whether anyone did.

The list view carries no personal data beyond a name. A manager scanning a queue does not need addresses or phone numbers, and a list endpoint is the one most likely to be logged, cached or screenshotted. An unknown status in the filter is rejected rather than ignored, because ignoring it would turn a typo into a full listing.

The member photo is streamed through the authenticated Worker. There is no signed-URL path: a URL that works without Access would outlive the manager's session and could be forwarded (section 14).

## NBTC completion

`nbtc-completion.ts` mirrors the post-payment workflow deliberately:

```
NBTC_RECORDED → MEMBER_COMPLETION_EMAIL_SENT → COMPLETED
```

`COMPLETED` waits for the email, because that is what the status claims. If the provider is down the registration still stands as `NBTC_RECORDED`, and a second confirmation does only the part that is missing — verified by test, including that `nbtc_recorded_at` does not move on the second call.

The manager's identity goes on `nbtc_recorded_by` and on the audit event. It is the only place this system persists a staff member's identity, and it is required: a filing with the regulator has to be attributable to the person who made it.

An application that has not been acknowledged yet is refused rather than jumped forward — the state machine has no `MANAGER_NOTIFIED → NBTC_RECORDED` edge and does not invent one.

## Two defects found while testing

**The mock email provider produced colliding ids.** It numbered from a per-instance counter, and there is one provider instance per request, so the second request's first email collided with the first request's on `UNIQUE(provider_email_id)` and the endpoint returned 500. A real provider's ids are globally unique, so the stand-in was failing in a way the real thing cannot. Now random, with a test that two instances never agree.

**An unknown application id was a 500, not a 404.** `WorkflowApplicationNotFoundError` (from #15) and the two new equivalents were bespoke error classes that nothing mapped. They are `ApiError('NOT_FOUND')` now, which the entrypoint already handles. This was reachable through `POST /api/admin/applications/:id/finalize`, where there is no capability-token check to 404 first.

## Tests

50 new tests; 655 pass in total.

**Access verification is real, not mocked.** The tests generate an RSA key pair, serve a genuine JWKS, and mint genuine RS256 tokens, so the signature check, the claim checks and the certificate fetch all run for real — only the network call to Cloudflare is intercepted, and any other URL still falls through so a stray provider call would fail loudly. A mock verifier would have left the single control between the internet and the manager's data untested, which is the wrong choice on a change labelled high risk.

- accepted: valid token in the header, and in the `CF_Authorization` cookie
- refused: no token, wrong signing key, another application's `aud`, another team's `iss`, expired, not-yet-valid, `alg: none`, a payload edited after signing, no `sub`, and an unreachable certificate endpoint
- the refusal body is identical for two different causes
- all eight endpoints refuse without a token, enumerated rather than assumed
- CSRF: missing origin, foreign origin, missing token, mismatched token — and the status is unchanged after a CSRF failure
- reads leave the status untouched across all four `GET` routes
- list: no citizen ID, no email, no address in the payload; status filter works; an unknown status is rejected
- detail: full citizen ID returned, `CITIZEN_ID_ACCESSED` recorded with the manager's identity, counted per read, workflow steps reported without being run, 404 for an unknown id
- acknowledge: moves to `NBTC_PROCESSING` and emails the member once across two calls
- nbtc-complete: records, emails, completes; attributes to the manager; the section 50 trail in order; a repeat is a no-op with no second email; refused when not acknowledged
- with the provider down: registration kept, completion not claimed, and a later call finishes it without a second record
- photo: served with `no-store`, 404 when absent
- receipt: regenerated, `RECEIPT_DOWNLOADED` recorded with the manager's identity
- logging: neither the manager's identity, the applicant's address, the citizen ID nor the applicant's name appears in any log line

## Security / privacy impact

High risk, as the issue states — and the reason this one deserves your eye more than the others.

- Authentication is verified twice: at the edge by Access, and in the Worker. The Worker's check fails closed on missing configuration and on an unreachable certificate endpoint
- Authorization is per-application-audience, so a token from elsewhere in the account is useless here
- No `GET` mutates. Every mutation needs Access **and** origin **and** a double-submit token
- The citizen ID decrypt is single-path and audited per read
- The photo and the receipt are streamed through the authenticated Worker with `no-store`; no signed or durable URL exists
- The manager's identity is persisted only where attribution requires it, and never logged — asserted by test
- Automated tests reach no external service

## Owner actions added

`CF_ACCESS_TEAM_DOMAIN` and `CF_ACCESS_AUD` are now in `docs/owner-actions.md`, with the note that leaving them unset refuses all admin requests rather than allowing them.

## Bundle size

3209.74 KiB, 860.76 KiB gzipped — up 22.78 KiB, inside the compressed limit on either plan.

## Gate

`format:check`, `lint`, `typecheck`, `test` (655), `build`, `check:worker:production` and `validate-repository.ps1` (153 tracked files) all pass locally.
