### PR TITLE
feat: build the manager portal

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -82,6 +82,12 @@ src/web/               React client, built to dist/client
   lib/turnstile.ts     the one third-party script, loaded lazily
   components/          Field, Button, Alert, CropBox, QrCode, StepFrame
   steps/               one component per wizard step
+  lib/datetime.ts      Bangkok time and the Buddhist era, everywhere
+  admin/AdminApp.tsx   manager portal; path routing, no router dependency
+  admin/api.ts         admin API; Access cookie plus the CSRF token
+  admin/QueuePage.tsx  the queue, carrying no detail beyond a name
+  admin/DetailPage.tsx one application; the citizen ID is a separate request
+  admin/ConfirmPage.tsx  the page an email link lands on; acts only on a POST
 migrations/            append-only D1 migrations
 tests/                 Vitest suites, all running inside workerd
 ```
@@ -386,6 +392,34 @@ checklist ยืนยันเป็นสามข้อ ไม่ใช่ข
 ทุก input ผ่าน component `Field` เดียว จึงทำให้ "ทุกช่องมี label" เป็นคุณสมบัติของโค้ด ไม่ใช่ความเคยชิน — error ผูกด้วย `aria-describedby` + `aria-invalid` + `role="alert"` และ required ทำเครื่องหมายทั้งด้วยสายตาและด้วย attribute เพราะดอกจันสีแดงมองไม่เห็นสำหรับ screen reader และสำหรับคนที่แยกสีไม่ได้
 
 heading ของแต่ละขั้นถูก focus เมื่อเปลี่ยนขั้น เพราะใน wizard หน้าเดียวไม่มีอะไรประกาศการเปลี่ยนขั้น ผู้ใช้ screen reader ที่กด "ถัดไป" จะได้ยินความเงียบและต้องไปหาเองว่าอะไรเปลี่ยน
+
+## Admin portal
+
+หน้าเดียวกับ wizard คนละ path — `/admin*` เป็น portal ผู้จัดการ ที่เหลือเป็น wizard ผู้สมัคร แชร์ bundle เพราะแชร์ component กับ stylesheet และการแยก build สองชุดสำหรับระบบที่รับหนึ่งถึงสองใบสมัครต่อวันไม่คุ้ม แต่ไม่แชร์ข้อมูลกันเลย — portal ไม่ render ตอน wizard ทำงาน และ wizard ไม่ถือ state ของ admin
+
+สิ่งแรกที่ portal ทำคือเรียก `GET /api/admin/session` ซึ่งทำสองอย่างพร้อมกัน: พิสูจน์ว่าผู้เรียกผ่าน Access แล้ว และคืน CSRF token ที่ทุกการเปลี่ยนสถานะต้องแนบ **ถ้าเรียกไม่ผ่าน ไม่ render หน้าใดเลย** ไม่มีสถานะ "ใช้ได้บางส่วน" — ไม่มี CSRF token ก็ยืนยันอะไรไม่ได้อยู่แล้ว และ portal ที่ดูเหมือนทำงานได้แต่ทุก action ล้มเหลวแย่กว่าการบอกตรง ๆ
+
+### เลขบัตรประชาชนแยกเป็น request ของตัวเอง
+
+เดิม (#16) หน้า detail ถอดรหัสเลขบัตรตอนโหลด ทำให้ทุกครั้งที่ผู้จัดการเปิดดูใบสมัครเกิด `CITIZEN_ID_ACCESSED` — audit trail จึงแยกไม่ออกระหว่าง "ผู้จัดการเปิดดูเลขบัตร" กับ "ผู้จัดการเปิดหน้า"
+
+ตอนนี้เลขบัตร**ไม่อยู่ใน detail เลย** และมี `GET /api/admin/applications/:id/citizen-id` แยก ผู้จัดการต้องกดปุ่มเพื่อเปิดดู หน้าเว็บบอกด้วยว่าการเปิดดูจะถูกบันทึก ผลคือ entry ใน trail หมายถึงมีคนถามหาเลขจริง ๆ และเลขไม่ค้างอยู่บนจอให้ถูกถ่ายภาพโดยไม่ได้ตั้งใจ
+
+### GET ไม่เปลี่ยนอะไร และหน้ายืนยันรู้สถานะก่อน
+
+link ในอีเมลผู้จัดการชี้มาที่ `/admin/applications/:id/acknowledge` และ `/nbtc-complete` ซึ่งเป็นหน้ายืนยัน ไม่ใช่ endpoint — email security scanner เปิด link เอง ถ้าหน้านั้นทำงานทันที gateway ป้องกันไวรัสจะกดรับเรื่องหรือแจ้งสมาชิกว่าบันทึกทะเบียนเสร็จแทนผู้จัดการ (หัวข้อ 37)
+
+หน้ายืนยันโหลดใบสมัครก่อนแล้ว **ไม่เสนอ action ที่สถานะปัจจุบันทำไม่ได้** ถ้าเปิดอีเมลฉบับเก่าซ้ำ หน้าจะบอกว่าดำเนินการไปแล้ว แทนที่จะแสดงปุ่มที่กดแล้วล้มเหลว ซึ่งจะทำให้ผู้จัดการไม่รู้ว่าครั้งแรกสำเร็จหรือไม่
+
+### รูปสมาชิกและใบเสร็จ
+
+เป็น `<img src>` และ `<a href>` ชี้ไปที่ endpoint ที่ authenticate แล้วโดยตรง เบราว์เซอร์ส่ง Access cookie ให้เอง จึงไม่มี URL ที่เปิดได้โดยไม่ผ่าน Access และไม่มีอะไรให้ forward (หัวข้อ 14)
+
+### เวลาและรายการคิว
+
+ทุกเวลาแสดงเป็น Asia/Bangkok และปีพุทธศักราช ผู้จัดการอ่านมันข้างเอกสารที่พิมพ์ `2569` และวันเกิดที่ผู้สมัครกรอกมาจากบัตรที่พิมพ์แบบเดียวกัน `th-TH-u-ca-buddhist` ระบุปฏิทินไว้ตรง ๆ ไม่พึ่งว่า `th-TH` จะ default เป็นพุทธศักราช ซึ่งจริงใน ICU ปัจจุบันแต่ไม่ใช่การรับประกัน
+
+รายการคิวเปิดที่ "ที่ต้องดำเนินการ" ไม่ใช่ทั้งหมด และแต่ละแถวมีแค่ชื่อ เลขที่ใบสมัคร ยอด และสถานะ — ไม่มีที่อยู่ ไม่มีเบอร์โทร ไม่มีเลขบัตร นี่เป็นหน้าที่มีโอกาสถูกเปิดค้างบนจอที่ใช้ร่วมกันหรือถูกถ่ายภาพมากที่สุด และข้อมูลเหล่านั้นไม่จำเป็นต่อการเลือกว่าจะเปิดใบไหน
 
 ## Decision records
 

--- a/src/web/admin/AdminApp.tsx
+++ b/src/web/admin/AdminApp.tsx
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Alert } from '../components/Alert';
+import { adminApi } from './api';
+import type { AdminSession } from './api';
+import { ConfirmPage } from './ConfirmPage';
+import { DetailPage } from './DetailPage';
+import { QueuePage } from './QueuePage';
+import { parseAdminRoute, queuePath } from './route';
+import type { AdminRoute } from './route';
+
+/**
+ * The manager's portal.
+ *
+ * Everything here sits behind Cloudflare Access, and the Worker verifies the
+ * token again on every request (see `src/worker/security/access.ts`). The first
+ * thing this does is call `GET /api/admin/session`, which both proves the caller
+ * is authenticated and hands back the CSRF token every state change has to carry
+ * - Access authenticates with a cookie, and a cookie travels on cross-site
+ * requests too.
+ *
+ * If that call fails, no page renders. There is no partly-usable state: without
+ * a CSRF token nothing can be confirmed anyway, and rendering a portal that
+ * looks working while every action fails is worse than saying so.
+ *
+ * Routing is `history.pushState` over a handful of paths, with no router
+ * dependency. The three action paths are the ones the manager notification email
+ * links to, so they have to be real URLs that survive being opened from a mail
+ * client - and the pages they land on must do nothing on their own.
+ */
+
+export function AdminApp() {
+  const [route, setRoute] = useState<AdminRoute>(() => parseAdminRoute(window.location.pathname));
+  const [session, setSession] = useState<AdminSession | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    adminApi
+      .session()
+      .then(setSession)
+      .catch((caught: unknown) => {
+        setError(
+          caught instanceof Error ? caught.message : 'ไม่สามารถยืนยันสิทธิ์เข้าถึงระบบผู้จัดการได้',
+        );
+      });
+  }, []);
+
+  // The back button has to work: a manager moves between the queue and a detail
+  // constantly, and a portal where back leaves the app is one they will stop
+  // using.
+  useEffect(() => {
+    const onPopState = () => setRoute(parseAdminRoute(window.location.pathname));
+    window.addEventListener('popstate', onPopState);
+    return () => window.removeEventListener('popstate', onPopState);
+  }, []);
+
+  const navigate = useCallback((path: string) => {
+    window.history.pushState(null, '', path);
+    setRoute(parseAdminRoute(path));
+    window.scrollTo({ top: 0 });
+  }, []);
+
+  const toQueue = useCallback(() => navigate(queuePath()), [navigate]);
+
+  if (error) {
+    return (
+      <main className="vra-admin">
+        <Alert tone="error" title="เข้าถึงระบบผู้จัดการไม่ได้">
+          <p>{error}</p>
+          <p>
+            หากเพิ่งเข้าสู่ระบบ กรุณาโหลดหน้านี้อีกครั้ง หากยังเข้าไม่ได้
+            กรุณาตรวจสอบว่าบัญชีของท่านได้รับสิทธิ์ในระบบ Cloudflare Access แล้ว
+          </p>
+        </Alert>
+      </main>
+    );
+  }
+
+  if (!session) {
+    return (
+      <main className="vra-admin">
+        <p className="vra-muted">กำลังตรวจสอบสิทธิ์...</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="vra-admin">
+      <header className="vra-admin__header">
+        <p className="vra-admin__brand">ระบบผู้จัดการ · สมาคมนักวิทยุอาสาสมัคร</p>
+        <p className="vra-admin__manager">{session.manager.email}</p>
+      </header>
+
+      {route.kind === 'queue' ? <QueuePage onOpen={navigate} /> : null}
+
+      {route.kind === 'detail' ? (
+        <DetailPage
+          applicationId={route.applicationId}
+          csrf={session.csrf}
+          onOpen={navigate}
+          onBack={toQueue}
+        />
+      ) : null}
+
+      {route.kind === 'acknowledge' || route.kind === 'nbtc-complete' ? (
+        <ConfirmPage
+          action={route.kind}
+          applicationId={route.applicationId}
+          csrf={session.csrf}
+          onDone={navigate}
+          onCancel={() => navigate(`/admin/applications/${route.applicationId}`)}
+        />
+      ) : null}
+
+      {route.kind === 'unknown' ? (
+        <Alert tone="error" title="ไม่พบหน้านี้">
+          <p>ที่อยู่ที่เปิดไม่ตรงกับหน้าใดในระบบผู้จัดการ</p>
+          <button type="button" className="vra-back" onClick={toQueue}>
+            ← ไปรายการใบสมัคร
+          </button>
+        </Alert>
+      ) : null}
+    </main>
+  );
+}

--- a/src/web/admin/ConfirmPage.tsx
+++ b/src/web/admin/ConfirmPage.tsx
@@ -1,0 +1,199 @@
+import { useEffect, useState } from 'react';
+import { Alert } from '../components/Alert';
+import { Button } from '../components/Button';
+import { adminApi } from './api';
+import type { AdminDetail, Csrf } from './api';
+import { StatusBadge } from './StatusBadge';
+
+/**
+ * The confirmation screen for the two irreversible actions (Issue #1 sections
+ * 37-38).
+ *
+ * This page exists because the manager's email contains links, and email
+ * security scanners open links. A `GET` that acted would let an anti-virus
+ * gateway acknowledge an application or tell a member their registration is
+ * complete. So the link lands here, the page shows who and what, and **nothing
+ * happens until the manager presses the button**, which is a `POST` carrying the
+ * CSRF token.
+ *
+ * The page loads the application first and refuses to offer the action when the
+ * status does not allow it. Otherwise a stale link - the same email opened twice,
+ * a week apart - would present a button that fails, and the manager would have no
+ * idea whether their first press had worked.
+ */
+
+export type ConfirmAction = 'acknowledge' | 'nbtc-complete';
+
+const COPY: Readonly<
+  Record<
+    ConfirmAction,
+    {
+      title: string;
+      question: string;
+      detail: string;
+      button: string;
+      busy: string;
+      /** Statuses from which the action is meaningful. */
+      allowed: readonly string[];
+      /** Statuses that mean it has already been done. */
+      alreadyDone: readonly string[];
+    }
+  >
+> = {
+  acknowledge: {
+    title: 'ยืนยันการรับเรื่อง',
+    question: 'ยืนยันว่าท่านได้รับเรื่องและเริ่มดำเนินการใบสมัครนี้',
+    detail: 'ระบบจะแจ้งสมาชิกทางอีเมลว่าใบสมัครอยู่ระหว่างการดำเนินการ',
+    button: 'ยืนยันว่ารับเรื่องแล้ว',
+    busy: 'กำลังบันทึก...',
+    allowed: ['MANAGER_NOTIFIED'],
+    alreadyDone: ['NBTC_PROCESSING', 'NBTC_RECORDED', 'COMPLETED'],
+  },
+  'nbtc-complete': {
+    title: 'ยืนยันการบันทึกทะเบียน กสทช.',
+    question: 'กรุณายืนยันว่าได้บันทึกข้อมูลทะเบียนสมาชิกในระบบของสำนักงาน กสทช. เรียบร้อยแล้ว',
+    detail: 'ระบบจะแจ้งสมาชิกทางอีเมลว่าการบันทึกทะเบียนเรียบร้อย และปิดใบสมัครนี้เป็นเสร็จสมบูรณ์',
+    button: 'ยืนยันว่าบันทึกเรียบร้อยแล้ว',
+    busy: 'กำลังบันทึก...',
+    allowed: ['NBTC_PROCESSING'],
+    alreadyDone: ['NBTC_RECORDED', 'COMPLETED'],
+  },
+};
+
+export interface ConfirmPageProps {
+  action: ConfirmAction;
+  applicationId: string;
+  csrf: Csrf;
+  onDone: (path: string) => void;
+  onCancel: () => void;
+}
+
+export function ConfirmPage({ action, applicationId, csrf, onDone, onCancel }: ConfirmPageProps) {
+  const copy = COPY[action];
+  const [detail, setDetail] = useState<AdminDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [outcome, setOutcome] = useState<string | null>(null);
+
+  const [attempt, setAttempt] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    adminApi
+      .detail(applicationId)
+      .then((response) => {
+        if (!cancelled) setDetail(response.detail);
+      })
+      .catch((caught: unknown) => {
+        if (!cancelled) {
+          setError(caught instanceof Error ? caught.message : 'ไม่สามารถโหลดใบสมัครนี้ได้');
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [applicationId, attempt]);
+
+  const confirm = () => {
+    // The guard is a ref-free early return plus the disabled button: the request
+    // itself is idempotent on the server, so the worst a second press could do
+    // is a wasted round trip - but the manager should not see two spinners.
+    if (busy) return;
+    setBusy(true);
+    setError(null);
+
+    const request =
+      action === 'acknowledge'
+        ? adminApi.acknowledge(applicationId, csrf).then(() => 'บันทึกการรับเรื่องแล้ว')
+        : adminApi
+            .completeNbtc(applicationId, csrf)
+            .then((response) =>
+              response.completion.complete
+                ? 'บันทึกทะเบียนและแจ้งสมาชิกเรียบร้อยแล้ว'
+                : 'บันทึกทะเบียนแล้ว แต่การแจ้งสมาชิกยังไม่สำเร็จ ระบบจะลองใหม่ได้จากหน้ารายละเอียด',
+            );
+
+    request
+      .then((message) => {
+        setOutcome(message);
+        // Re-reads the application so the status shown after the action is the
+        // one the server now holds, not the one the page loaded with.
+        setAttempt((previous) => previous + 1);
+      })
+      .catch((caught: unknown) => {
+        setError(caught instanceof Error ? caught.message : 'ไม่สามารถบันทึกได้');
+      })
+      .finally(() => setBusy(false));
+  };
+
+  if (!detail) {
+    return (
+      <>
+        <h1 className="vra-admin__title">{copy.title}</h1>
+        {error ? <Alert tone="error">{error}</Alert> : <p className="vra-muted">กำลังโหลด...</p>}
+      </>
+    );
+  }
+
+  const { application } = detail;
+  const name = [application.title, application.firstName, application.lastName]
+    .filter((part) => part && part.trim().length > 0)
+    .join(' ');
+
+  const already = copy.alreadyDone.includes(application.status);
+  const allowed = copy.allowed.includes(application.status);
+
+  return (
+    <>
+      <h1 className="vra-admin__title">{copy.title}</h1>
+
+      <div className="vra-confirm">
+        <p className="vra-confirm__reference">
+          {application.referenceNo ?? 'ยังไม่ออกเลขที่ใบสมัคร'}
+        </p>
+        <p className="vra-confirm__name">{name.length > 0 ? name : 'ไม่ระบุชื่อ'}</p>
+        <p>
+          <StatusBadge status={application.status} />
+        </p>
+      </div>
+
+      {outcome ? <Alert tone="success">{outcome}</Alert> : null}
+      {error ? <Alert tone="error">{error}</Alert> : null}
+
+      {already && !outcome ? (
+        <Alert tone="info" title="ดำเนินการนี้ไปแล้ว">
+          <p>
+            ใบสมัครนี้ผ่านขั้นตอนนี้ไปแล้ว ไม่ต้องทำซ้ำ — หากเปิดจากอีเมลฉบับเก่า
+            สถานะปัจจุบันคือสิ่งที่ถูกต้อง
+          </p>
+        </Alert>
+      ) : null}
+
+      {!allowed && !already && !outcome ? (
+        <Alert tone="info" title="ยังไม่ถึงขั้นตอนนี้">
+          <p>สถานะปัจจุบันของใบสมัครยังทำขั้นตอนนี้ไม่ได้ กรุณาตรวจสอบในหน้ารายละเอียด</p>
+        </Alert>
+      ) : null}
+
+      {allowed && !outcome ? (
+        <>
+          <p className="vra-confirm__question">{copy.question}</p>
+          <p className="vra-muted">{copy.detail}</p>
+          <Button onClick={confirm} busy={busy} busyLabel={copy.busy}>
+            {copy.button}
+          </Button>
+        </>
+      ) : null}
+
+      <Button
+        variant="quiet"
+        onClick={() => (outcome ? onDone(`/admin/applications/${applicationId}`) : onCancel())}
+        disabled={busy}
+      >
+        {outcome ? 'ไปหน้ารายละเอียดใบสมัคร' : 'ยกเลิก'}
+      </Button>
+    </>
+  );
+}

--- a/src/web/admin/DetailPage.tsx
+++ b/src/web/admin/DetailPage.tsx
@@ -1,0 +1,351 @@
+import { useEffect, useState } from 'react';
+import { Alert } from '../components/Alert';
+import { Button } from '../components/Button';
+import { formatCalendarDate, formatDateTime } from '../lib/datetime';
+import { adminApi } from './api';
+import type { AdminDetail, Csrf, WorkflowStepName } from './api';
+import { StatusBadge } from './StatusBadge';
+import { Timeline } from './Timeline';
+
+/**
+ * One application, in full (Issue #1 section 53).
+ *
+ * The citizen ID is **not** loaded with the page. It is fetched by a button, and
+ * the server records that read in the audit trail - so an entry there means the
+ * manager looked the number up, not merely that they opened the page. It also
+ * keeps the number off screen unless it is being used, which matters on a shared
+ * or photographed display.
+ *
+ * The photo is an `<img>` pointing at the authenticated endpoint. The browser
+ * sends the Access cookie itself, so there is no URL that works without it and
+ * nothing to forward.
+ */
+
+const STEP_LABELS: Readonly<Record<WorkflowStepName, string>> = {
+  APPLICATION_NUMBER: 'ออกเลขที่ใบสมัคร',
+  RECEIPT: 'ออกใบสำคัญรับเงิน',
+  RECEIPT_EMAIL: 'ส่งใบสำคัญรับเงินให้สมาชิก',
+  SUBMISSION: 'ส่งใบสมัครเข้าระบบ',
+  MANAGER_EMAIL: 'แจ้งผู้จัดการ',
+};
+
+const STEP_ORDER: readonly WorkflowStepName[] = [
+  'APPLICATION_NUMBER',
+  'RECEIPT',
+  'RECEIPT_EMAIL',
+  'SUBMISSION',
+  'MANAGER_EMAIL',
+];
+
+function Row({ label, value }: { label: string; value: string | null }) {
+  return (
+    <div className="vra-details__row">
+      <dt>{label}</dt>
+      <dd>{value && value.trim().length > 0 ? value : '—'}</dd>
+    </div>
+  );
+}
+
+function addressLine(parts: readonly (string | null)[]): string | null {
+  const joined = parts
+    .map((part) => part?.trim() ?? '')
+    .filter((part) => part.length > 0)
+    .join(' ');
+  return joined.length > 0 ? joined : null;
+}
+
+export interface DetailPageProps {
+  applicationId: string;
+  csrf: Csrf;
+  onOpen: (path: string) => void;
+  onBack: () => void;
+}
+
+export function DetailPage({ applicationId, csrf, onOpen, onBack }: DetailPageProps) {
+  const [detail, setDetail] = useState<AdminDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [citizenId, setCitizenId] = useState<string | null>(null);
+  const [citizenIdError, setCitizenIdError] = useState<string | null>(null);
+  const [revealing, setRevealing] = useState(false);
+  const [finalizing, setFinalizing] = useState(false);
+
+  const [attempt, setAttempt] = useState(0);
+  const reload = () => setAttempt((previous) => previous + 1);
+
+  // State is set only when the response arrives. `attempt` is what re-runs this
+  // after an action, rather than calling a loader that sets state synchronously.
+  useEffect(() => {
+    let cancelled = false;
+
+    adminApi
+      .detail(applicationId)
+      .then((response) => {
+        if (!cancelled) setDetail(response.detail);
+      })
+      .catch((caught: unknown) => {
+        if (!cancelled) {
+          setError(caught instanceof Error ? caught.message : 'ไม่สามารถโหลดใบสมัครนี้ได้');
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [applicationId, attempt]);
+
+  const reveal = () => {
+    if (revealing) return;
+    setRevealing(true);
+    setCitizenIdError(null);
+
+    adminApi
+      .citizenId(applicationId)
+      .then((response) => {
+        if (response.citizenId) setCitizenId(response.citizenId);
+        else setCitizenIdError('ไม่สามารถอ่านเลขบัตรประชาชนของใบสมัครนี้ได้');
+      })
+      .catch((caught: unknown) => {
+        setCitizenIdError(caught instanceof Error ? caught.message : 'ไม่สามารถอ่านเลขบัตรได้');
+      })
+      .finally(() => setRevealing(false));
+  };
+
+  const finalize = () => {
+    if (finalizing) return;
+    setFinalizing(true);
+
+    adminApi
+      .finalize(applicationId, csrf)
+      .then(() => reload())
+      .catch((caught: unknown) => {
+        setError(caught instanceof Error ? caught.message : 'ไม่สามารถดำเนินการต่อได้');
+      })
+      .finally(() => setFinalizing(false));
+  };
+
+  if (error && !detail) {
+    return (
+      <>
+        <Alert tone="error">{error}</Alert>
+        <Button variant="secondary" onClick={onBack}>
+          กลับไปรายการใบสมัคร
+        </Button>
+      </>
+    );
+  }
+
+  if (!detail) return <p className="vra-muted">กำลังโหลด...</p>;
+
+  const { application, address, payment, receipt, workflow, events } = detail;
+  const outstanding = STEP_ORDER.filter(
+    (step) => workflow.steps[step] !== 'DONE' && workflow.steps[step] !== 'ALREADY_DONE',
+  );
+
+  return (
+    <>
+      <button type="button" className="vra-back" onClick={onBack}>
+        ← รายการใบสมัคร
+      </button>
+
+      <h1 className="vra-admin__title">{application.referenceNo ?? 'ยังไม่ออกเลขที่ใบสมัคร'}</h1>
+      <p className="vra-admin__subtitle">
+        <StatusBadge status={application.status} />
+      </p>
+
+      {error ? <Alert tone="error">{error}</Alert> : null}
+
+      <section className="vra-panel">
+        <h2 className="vra-panel__title">การดำเนินการ</h2>
+
+        {application.status === 'MANAGER_NOTIFIED' ? (
+          <>
+            <p>
+              เมื่อพร้อมเริ่มดำเนินการ กดปุ่มด้านล่างเพื่อไปยังหน้ายืนยันการรับเรื่อง
+              ระบบจะแจ้งสมาชิกว่ากำลังดำเนินการ
+            </p>
+            <Button onClick={() => onOpen(`/admin/applications/${applicationId}/acknowledge`)}>
+              รับเรื่อง / เริ่มดำเนินการ
+            </Button>
+          </>
+        ) : null}
+
+        {application.status === 'NBTC_PROCESSING' ? (
+          <>
+            <p>
+              เมื่อบันทึกข้อมูลทะเบียนสมาชิกในระบบของสำนักงาน กสทช. เรียบร้อยแล้ว
+              กดปุ่มด้านล่างเพื่อไปยังหน้ายืนยัน
+            </p>
+            <Button onClick={() => onOpen(`/admin/applications/${applicationId}/nbtc-complete`)}>
+              บันทึกในระบบ กสทช. เรียบร้อยแล้ว
+            </Button>
+          </>
+        ) : null}
+
+        {application.status === 'COMPLETED' ? (
+          <Alert tone="success">
+            <p>ใบสมัครนี้ดำเนินการครบถ้วนแล้ว ไม่มีขั้นตอนที่ต้องทำเพิ่ม</p>
+          </Alert>
+        ) : null}
+
+        {outstanding.length > 0 ? (
+          <>
+            <Alert tone="info" title="มีขั้นตอนหลังการชำระเงินที่ยังไม่สำเร็จ">
+              <ul>
+                {outstanding.map((step) => (
+                  <li key={step}>{STEP_LABELS[step]}</li>
+                ))}
+              </ul>
+              <p>
+                การชำระเงินและใบสำคัญรับเงินไม่หายไป ขั้นตอนที่ค้างมักเป็นการส่งอีเมลที่ล้มชั่วคราว
+              </p>
+            </Alert>
+            <Button
+              variant="secondary"
+              onClick={finalize}
+              busy={finalizing}
+              busyLabel="กำลังดำเนินการ..."
+            >
+              ลองดำเนินการขั้นตอนที่ค้างอีกครั้ง
+            </Button>
+          </>
+        ) : null}
+      </section>
+
+      <section className="vra-panel">
+        <h2 className="vra-panel__title">ผู้สมัคร</h2>
+        <dl className="vra-details">
+          <Row
+            label="ชื่อ-นามสกุล"
+            value={addressLine([application.title, application.firstName, application.lastName])}
+          />
+          <Row
+            label="ชื่อภาษาอังกฤษ"
+            value={addressLine([application.firstNameEn, application.lastNameEn])}
+          />
+          <Row label="วันเกิด" value={formatCalendarDate(application.birthDate)} />
+          <Row label="วันหมดอายุบัตร" value={formatCalendarDate(application.cardExpiryDate)} />
+          <Row label="อีเมล" value={application.email} />
+          <Row label="โทรศัพท์" value={application.phone} />
+          <Row label="สัญญาณเรียกขาน" value={application.callsign} />
+        </dl>
+
+        <div className="vra-reveal">
+          <h3 className="vra-reveal__title">เลขบัตรประชาชน</h3>
+          {citizenId ? (
+            <p className="vra-reveal__value">{citizenId}</p>
+          ) : (
+            <>
+              <p className="vra-muted">
+                เลขบัตรประชาชนไม่ถูกโหลดมาพร้อมหน้านี้ กดเพื่อเปิดดูเมื่อจำเป็นต้องใช้
+                <strong> การเปิดดูจะถูกบันทึกไว้ในประวัติการดำเนินการ</strong>
+              </p>
+              <Button
+                variant="secondary"
+                onClick={reveal}
+                busy={revealing}
+                busyLabel="กำลังเปิดดู..."
+              >
+                แสดงเลขบัตรประชาชน
+              </Button>
+            </>
+          )}
+          {citizenIdError ? <Alert tone="error">{citizenIdError}</Alert> : null}
+        </div>
+      </section>
+
+      <section className="vra-panel">
+        <h2 className="vra-panel__title">ที่อยู่</h2>
+        <dl className="vra-details">
+          <Row
+            label="ที่อยู่ตามบัตร"
+            value={addressLine([
+              address?.idAddress ?? null,
+              address?.idSubdistrict ?? null,
+              address?.idDistrict ?? null,
+              address?.idProvince ?? null,
+            ])}
+          />
+          <Row
+            label="ที่อยู่จัดส่ง"
+            value={
+              address?.mailSameAsId
+                ? `ใช้ที่อยู่เดียวกับบัตร · รหัสไปรษณีย์ ${address.mailPostcode ?? '—'}`
+                : addressLine([
+                    address?.mailRecipient ?? null,
+                    address?.mailAddress ?? null,
+                    address?.mailSubdistrict ?? null,
+                    address?.mailDistrict ?? null,
+                    address?.mailProvince ?? null,
+                    address?.mailPostcode ?? null,
+                  ])
+            }
+          />
+          <Row label="โทรศัพท์สำหรับจัดส่ง" value={address?.mailPhone ?? null} />
+        </dl>
+      </section>
+
+      <section className="vra-panel">
+        <h2 className="vra-panel__title">รูปสมาชิก</h2>
+        {application.hasPhoto ? (
+          <>
+            <img
+              className="vra-member-photo"
+              src={adminApi.photoUrl(applicationId)}
+              alt="รูปสำหรับบัตรสมาชิกของผู้สมัคร"
+            />
+            <p className="vra-muted">
+              ที่มา: {application.photoSource === 'ID_CARD' ? 'ภาพใบหน้าจากบัตร' : 'รูปที่อัปโหลด'}
+            </p>
+            <p className="vra-field__hint">
+              รูปนี้เข้าถึงได้เฉพาะผ่านระบบผู้จัดการ ไม่มีลิงก์ที่เปิดได้โดยไม่เข้าสู่ระบบ
+            </p>
+          </>
+        ) : (
+          <p className="vra-muted">ยังไม่มีรูปสมาชิก</p>
+        )}
+      </section>
+
+      <section className="vra-panel">
+        <h2 className="vra-panel__title">การชำระเงินและใบสำคัญรับเงิน</h2>
+        <dl className="vra-details">
+          <Row label="ประเภทสมาชิก" value={application.membershipLabel} />
+          <Row
+            label="ยอดค่าบำรุง"
+            value={application.amountBaht ? `${application.amountBaht} บาท` : null}
+          />
+          <Row label="อ้างอิงรายการโอน" value={payment?.transactionRef ?? null} />
+          <Row label="ธนาคารผู้รับเงิน" value={payment?.receivingBank ?? null} />
+          <Row label="เวลาที่โอน" value={formatDateTime(payment?.transactionAt)} />
+          <Row label="เวลาที่ตรวจสอบผ่าน" value={formatDateTime(payment?.verifiedAt)} />
+          <Row label="เลขที่ใบสำคัญรับเงิน" value={receipt?.receiptNo ?? null} />
+          <Row label="วันที่ออกใบสำคัญรับเงิน" value={formatDateTime(receipt?.issuedAt)} />
+        </dl>
+
+        {receipt ? (
+          <p>
+            <a className="vra-link" href={adminApi.receiptUrl(applicationId)}>
+              ดาวน์โหลดใบสำคัญรับเงิน (PDF)
+            </a>
+          </p>
+        ) : null}
+      </section>
+
+      <section className="vra-panel">
+        <h2 className="vra-panel__title">การดำเนินการกับสำนักงาน กสทช.</h2>
+        <dl className="vra-details">
+          <Row
+            label="ผู้จัดการรับเรื่องเมื่อ"
+            value={formatDateTime(application.managerAcknowledgedAt)}
+          />
+          <Row label="บันทึกทะเบียนเมื่อ" value={formatDateTime(application.nbtcRecordedAt)} />
+          <Row label="บันทึกโดย" value={application.nbtcRecordedBy} />
+        </dl>
+      </section>
+
+      <section className="vra-panel">
+        <h2 className="vra-panel__title">ประวัติการดำเนินการ</h2>
+        <Timeline events={events} />
+      </section>
+    </>
+  );
+}

--- a/src/web/admin/QueuePage.tsx
+++ b/src/web/admin/QueuePage.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useState } from 'react';
+import { Alert } from '../components/Alert';
+import { Button } from '../components/Button';
+import { formatDateTime } from '../lib/datetime';
+import { adminApi } from './api';
+import type { AdminListItem, ApplicationStatus } from './api';
+import { StatusBadge } from './StatusBadge';
+import { detailPath } from './route';
+
+/**
+ * The application queue (Issue #1 section 52).
+ *
+ * The default filter is the two statuses that need the manager - waiting to be
+ * picked up, and picked up but not yet recorded. A dashboard that opens on
+ * everything makes the manager do the filtering, and this queue is one or two
+ * applications a day: what matters is what is outstanding.
+ *
+ * Rows carry a name, a reference number, an amount and a status, and nothing
+ * else. No address, no phone number, no card. This is the view most likely to be
+ * left open on a shared screen or photographed, and none of that is needed to
+ * decide which application to open.
+ */
+
+const OUTSTANDING: readonly ApplicationStatus[] = ['MANAGER_NOTIFIED', 'NBTC_PROCESSING'];
+
+interface FilterOption {
+  id: string;
+  label: string;
+  statuses: readonly ApplicationStatus[];
+}
+
+const FILTERS: readonly FilterOption[] = [
+  { id: 'outstanding', label: 'ที่ต้องดำเนินการ', statuses: OUTSTANDING },
+  { id: 'done', label: 'เสร็จสมบูรณ์', statuses: ['COMPLETED', 'NBTC_RECORDED'] },
+  { id: 'paying', label: 'รอชำระเงิน', statuses: ['DRAFT', 'AWAITING_PAYMENT'] },
+  {
+    id: 'attention',
+    label: 'ต้องตรวจสอบ',
+    statuses: ['REJECTED', 'REFUND_REQUIRED', 'PAYMENT_VERIFIED', 'SUBMITTED'],
+  },
+  { id: 'all', label: 'ทั้งหมด', statuses: [] },
+];
+
+export interface QueuePageProps {
+  onOpen: (path: string) => void;
+}
+
+/** Result of one request, tagged with the filter and attempt it belongs to. */
+interface Loaded {
+  items: AdminListItem[];
+  filterId: string;
+  attempt: number;
+}
+
+export function QueuePage({ onOpen }: QueuePageProps) {
+  const [filterId, setFilterId] = useState('outstanding');
+  const [attempt, setAttempt] = useState(0);
+  const [loaded, setLoaded] = useState<Loaded | null>(null);
+  const [failure, setFailure] = useState<{ message: string; attempt: number } | null>(null);
+
+  // State is set only when a response arrives, never synchronously here, and the
+  // result carries the filter it was for - so switching filters quickly cannot
+  // leave the slower response on screen under the newer label.
+  useEffect(() => {
+    let cancelled = false;
+    const filter = FILTERS.find((candidate) => candidate.id === filterId) ?? FILTERS[0]!;
+
+    adminApi
+      .list(filter.statuses)
+      .then((response) => {
+        if (!cancelled) setLoaded({ items: response.applications, filterId, attempt });
+      })
+      .catch((caught: unknown) => {
+        if (cancelled) return;
+        setFailure({
+          message: caught instanceof Error ? caught.message : 'ไม่สามารถโหลดรายการได้',
+          attempt,
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [filterId, attempt]);
+
+  const fresh = loaded?.filterId === filterId && loaded.attempt === attempt;
+  const items = fresh ? loaded.items : null;
+  const error = failure?.attempt === attempt ? failure.message : null;
+  const busy = items === null && error === null;
+  const reload = () => setAttempt((previous) => previous + 1);
+
+  return (
+    <>
+      <h1 className="vra-admin__title">ใบสมัครสมาชิก</h1>
+
+      <div className="vra-filters" role="group" aria-label="กรองตามสถานะ">
+        {FILTERS.map((filter) => (
+          <button
+            key={filter.id}
+            type="button"
+            className={filter.id === filterId ? 'vra-chip vra-chip--active' : 'vra-chip'}
+            aria-pressed={filter.id === filterId}
+            onClick={() => setFilterId(filter.id)}
+          >
+            {filter.label}
+          </button>
+        ))}
+      </div>
+
+      {error ? (
+        <>
+          <Alert tone="error">{error}</Alert>
+          <Button variant="secondary" onClick={reload}>
+            ลองโหลดอีกครั้ง
+          </Button>
+        </>
+      ) : null}
+
+      {busy ? <p className="vra-muted">กำลังโหลด...</p> : null}
+
+      {items !== null && items.length === 0 ? (
+        <Alert tone="info">
+          <p>ไม่มีใบสมัครในสถานะนี้</p>
+        </Alert>
+      ) : null}
+
+      {items !== null && items.length > 0 ? (
+        <ul className="vra-queue">
+          {items.map((item) => (
+            <li className="vra-queue__item" key={item.id}>
+              {/*
+                A real link, so it can be opened in a new tab, copied, or
+                bookmarked - all of which a manager working through a queue does.
+                The click is intercepted for in-app navigation, but a middle
+                click or a modifier still does the browser's own thing.
+              */}
+              <a
+                className="vra-queue__link"
+                href={detailPath(item.id)}
+                onClick={(event) => {
+                  if (event.metaKey || event.ctrlKey || event.shiftKey || event.button !== 0)
+                    return;
+                  event.preventDefault();
+                  onOpen(detailPath(item.id));
+                }}
+              >
+                <span className="vra-queue__reference">
+                  {item.referenceNo ?? 'ยังไม่ออกเลขที่ใบสมัคร'}
+                </span>
+                <span className="vra-queue__name">{item.name ?? 'ไม่ระบุชื่อ'}</span>
+              </a>
+
+              <div className="vra-queue__meta">
+                <StatusBadge status={item.status} />
+                {item.amountBaht ? <span>{item.amountBaht} บาท</span> : null}
+                <span className="vra-muted">
+                  {item.submittedAt
+                    ? `ส่งเมื่อ ${formatDateTime(item.submittedAt)}`
+                    : `สร้างเมื่อ ${formatDateTime(item.createdAt)}`}
+                </span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </>
+  );
+}

--- a/src/web/admin/StatusBadge.tsx
+++ b/src/web/admin/StatusBadge.tsx
@@ -1,0 +1,50 @@
+import type { ApplicationStatus } from './api';
+
+/**
+ * The application status, in Thai.
+ *
+ * A word as well as a colour. A colour-only badge is unreadable to a screen
+ * reader and ambiguous to anyone who cannot distinguish the two greens - and
+ * these statuses are the thing the manager scans the queue by.
+ */
+
+const LABELS: Readonly<Record<ApplicationStatus, string>> = {
+  DRAFT: 'ยังไม่ชำระเงิน',
+  AWAITING_PAYMENT: 'รอชำระเงิน',
+  PAYMENT_VERIFIED: 'ตรวจสอบการชำระเงินแล้ว',
+  SUBMITTED: 'ส่งใบสมัครแล้ว',
+  MANAGER_NOTIFIED: 'รอผู้จัดการรับเรื่อง',
+  NBTC_PROCESSING: 'อยู่ระหว่างบันทึกทะเบียน',
+  NBTC_RECORDED: 'บันทึกทะเบียนแล้ว',
+  COMPLETED: 'เสร็จสมบูรณ์',
+  REJECTED: 'ปฏิเสธใบสมัคร',
+  CANCELLED: 'ยกเลิกใบสมัคร',
+  REFUND_REQUIRED: 'ต้องคืนเงิน',
+  REFUNDED: 'คืนเงินแล้ว',
+};
+
+/** Grouped by what the manager should do about it, not by position in the flow. */
+const TONES: Readonly<Record<ApplicationStatus, string>> = {
+  DRAFT: 'idle',
+  AWAITING_PAYMENT: 'idle',
+  PAYMENT_VERIFIED: 'busy',
+  SUBMITTED: 'busy',
+  MANAGER_NOTIFIED: 'action',
+  NBTC_PROCESSING: 'action',
+  NBTC_RECORDED: 'busy',
+  COMPLETED: 'done',
+  REJECTED: 'stop',
+  CANCELLED: 'idle',
+  REFUND_REQUIRED: 'stop',
+  REFUNDED: 'done',
+};
+
+function statusLabel(status: ApplicationStatus): string {
+  return LABELS[status] ?? status;
+}
+
+export function StatusBadge({ status }: { status: ApplicationStatus }) {
+  return (
+    <span className={`vra-badge vra-badge--${TONES[status] ?? 'idle'}`}>{statusLabel(status)}</span>
+  );
+}

--- a/src/web/admin/Timeline.tsx
+++ b/src/web/admin/Timeline.tsx
@@ -1,0 +1,94 @@
+import { formatDateTime } from '../lib/datetime';
+import type { AdminEvent } from './api';
+
+/**
+ * The audit trail for one application (Issue #1 sections 49-50).
+ *
+ * Event types are translated because the trail is something the manager reads
+ * when a member phones to ask what happened, not a debugging log. An untranslated
+ * `MEMBER_PROCESSING_EMAIL_SENT` is answerable only by someone who wrote the
+ * system.
+ *
+ * Anything not in the table below is shown as-is rather than hidden. A trail that
+ * silently drops what it does not recognise is worse than one with an odd row in
+ * it: the manager would have no way to know something happened.
+ */
+
+const EVENT_LABELS: Readonly<Record<string, string>> = {
+  APPLICATION_CREATED: 'สร้างใบสมัคร',
+  ID_OCR_COMPLETED: 'อ่านข้อมูลจากบัตรประชาชน',
+  PHOTO_SELECTED: 'เลือกรูปสำหรับบัตรสมาชิก',
+  PHOTO_REPLACED: 'เปลี่ยนรูปสำหรับบัตรสมาชิก',
+  STATUS_CHANGED: 'เปลี่ยนสถานะ',
+  PAYMENT_VERIFIED: 'ตรวจสอบการชำระเงินผ่าน',
+  PAYMENT_REJECTED: 'การชำระเงินไม่ผ่านการตรวจสอบ',
+  PAYMENT_PRESENTED_WHEN_NOT_EXPECTED: 'ส่งหลักฐานการชำระเงินซ้ำ',
+  RECEIPT_ISSUED: 'ออกใบสำคัญรับเงิน',
+  RECEIPT_EMAIL_SENT: 'ส่งใบสำคัญรับเงินทางอีเมล',
+  RECEIPT_DOWNLOADED: 'ดาวน์โหลดใบสำคัญรับเงิน',
+  APPLICATION_SUBMITTED: 'ส่งใบสมัครเข้าระบบ',
+  MANAGER_EMAIL_SENT: 'แจ้งผู้จัดการทางอีเมล',
+  MANAGER_EMAIL_OPENED: 'ผู้จัดการเปิดอีเมล',
+  MANAGER_ACKNOWLEDGED: 'ผู้จัดการรับเรื่อง',
+  MEMBER_PROCESSING_EMAIL_SENT: 'แจ้งสมาชิกว่าอยู่ระหว่างดำเนินการ',
+  MANAGER_CONFIRMED_NBTC_RECORD: 'ผู้จัดการยืนยันการบันทึกทะเบียน กสทช.',
+  MEMBER_COMPLETION_EMAIL_SENT: 'แจ้งสมาชิกว่าบันทึกทะเบียนเรียบร้อย',
+  CITIZEN_ID_ACCESSED: 'มีการเปิดดูเลขบัตรประชาชน',
+  CITIZEN_ID_MASKED_FOR_EMAIL: 'ใช้เลขบัตรประชาชนบางส่วนในอีเมลผู้จัดการ',
+  EMAIL_SEND_FAILED: 'ส่งอีเมลไม่สำเร็จ',
+  EMAIL_SKIPPED: 'ไม่ได้ส่งอีเมล',
+  EMAIL_BOUNCED: 'อีเมลตีกลับ',
+};
+
+const ACTOR_LABELS: Readonly<Record<string, string>> = {
+  APPLICANT: 'ผู้สมัคร',
+  MANAGER: 'ผู้จัดการ',
+  SYSTEM: 'ระบบ',
+  PROVIDER: 'ผู้ให้บริการ',
+};
+
+/** Metadata keys the manager can act on; the rest is machinery. */
+const METADATA_LABELS: Readonly<Record<string, string>> = {
+  from: 'จาก',
+  to: 'เป็น',
+  reason: 'เหตุผล',
+  emailType: 'ชนิดอีเมล',
+  receiptNo: 'เลขที่ใบสำคัญรับเงิน',
+  referenceNo: 'เลขที่ใบสมัคร',
+  amountSatang: 'ยอด (สตางค์)',
+  provider: 'ผู้ให้บริการ',
+  source: 'ที่มา',
+};
+
+function describe(event: AdminEvent): string | null {
+  if (!event.metadata) return null;
+  const parts = Object.entries(event.metadata)
+    .filter(([key]) => key in METADATA_LABELS)
+    .map(([key, value]) => `${METADATA_LABELS[key]!}: ${String(value)}`);
+  return parts.length > 0 ? parts.join(' · ') : null;
+}
+
+export function Timeline({ events }: { events: readonly AdminEvent[] }) {
+  if (events.length === 0) {
+    return <p className="vra-muted">ยังไม่มีเหตุการณ์</p>;
+  }
+
+  return (
+    <ol className="vra-timeline">
+      {events.map((event) => {
+        const detail = describe(event);
+        return (
+          <li className="vra-timeline__item" key={event.id}>
+            <p className="vra-timeline__when">{formatDateTime(event.createdAt)}</p>
+            <p className="vra-timeline__what">{EVENT_LABELS[event.eventType] ?? event.eventType}</p>
+            <p className="vra-timeline__who">
+              {ACTOR_LABELS[event.actorType] ?? event.actorType}
+              {event.actorId ? ` · ${event.actorId}` : ''}
+            </p>
+            {detail ? <p className="vra-timeline__meta">{detail}</p> : null}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/src/web/admin/api.ts
+++ b/src/web/admin/api.ts
@@ -1,0 +1,230 @@
+/**
+ * The admin API from the browser.
+ *
+ * Separate from `src/web/api/client.ts` because the two halves authenticate
+ * completely differently and share nothing useful. The applicant carries a
+ * capability token in a header; the manager is authenticated by the Cloudflare
+ * Access cookie the browser sends on its own, and every state change has to
+ * carry the CSRF token issued by `GET /api/admin/session` - because a cookie is
+ * sent on cross-site requests too.
+ *
+ * Nothing here is stored. The CSRF token lives in React state for the life of
+ * the tab, and the Access cookie is the browser's business.
+ */
+
+const GENERIC_MESSAGE = 'ไม่สามารถติดต่อระบบได้ กรุณาโหลดหน้าใหม่แล้วลองอีกครั้ง';
+
+export class AdminRequestError extends Error {
+  readonly code: string;
+  readonly status: number;
+
+  constructor(code: string, message: string, status: number) {
+    super(message);
+    this.name = 'AdminRequestError';
+    this.code = code;
+    this.status = status;
+  }
+}
+
+/* ------------------------------------------------------------ wire types --- */
+
+export type ApplicationStatus =
+  | 'DRAFT'
+  | 'AWAITING_PAYMENT'
+  | 'PAYMENT_VERIFIED'
+  | 'SUBMITTED'
+  | 'MANAGER_NOTIFIED'
+  | 'NBTC_PROCESSING'
+  | 'NBTC_RECORDED'
+  | 'COMPLETED'
+  | 'REJECTED'
+  | 'CANCELLED'
+  | 'REFUND_REQUIRED'
+  | 'REFUNDED';
+
+export interface AdminSession {
+  manager: { email: string };
+  csrf: { header: string; token: string };
+}
+
+export interface AdminListItem {
+  id: string;
+  referenceNo: string | null;
+  status: ApplicationStatus;
+  name: string | null;
+  membershipType: 'ANNUAL' | 'LIFETIME' | null;
+  amountBaht: string | null;
+  submittedAt: string | null;
+  createdAt: string;
+}
+
+export interface AdminEvent {
+  id: string;
+  eventType: string;
+  actorType: string;
+  actorId: string | null;
+  metadata: Record<string, string | number | boolean> | null;
+  createdAt: string;
+}
+
+export interface AdminAddress {
+  idAddress: string | null;
+  idSubdistrict: string | null;
+  idDistrict: string | null;
+  idProvince: string | null;
+  mailSameAsId: boolean;
+  mailRecipient: string | null;
+  mailAddress: string | null;
+  mailSubdistrict: string | null;
+  mailDistrict: string | null;
+  mailProvince: string | null;
+  mailPostcode: string | null;
+  mailPhone: string | null;
+}
+
+export type WorkflowStepName =
+  'APPLICATION_NUMBER' | 'RECEIPT' | 'RECEIPT_EMAIL' | 'SUBMISSION' | 'MANAGER_EMAIL';
+
+export interface AdminDetail {
+  application: {
+    id: string;
+    referenceNo: string | null;
+    status: ApplicationStatus;
+    title: string | null;
+    firstName: string | null;
+    lastName: string | null;
+    firstNameEn: string | null;
+    lastNameEn: string | null;
+    birthDate: string | null;
+    cardExpiryDate: string | null;
+    phone: string | null;
+    email: string | null;
+    callsign: string | null;
+    membershipType: 'ANNUAL' | 'LIFETIME' | null;
+    membershipLabel: string | null;
+    amountBaht: string | null;
+    hasPhoto: boolean;
+    photoSource: string | null;
+    submittedAt: string | null;
+    managerAcknowledgedAt: string | null;
+    nbtcRecordedAt: string | null;
+    nbtcRecordedBy: string | null;
+    createdAt: string;
+    updatedAt: string;
+  };
+  address: AdminAddress | null;
+  payment: {
+    transactionRef: string;
+    amountBaht: string;
+    sendingBank: string | null;
+    receivingBank: string | null;
+    transactionAt: string | null;
+    verifiedAt: string | null;
+  } | null;
+  receipt: { receiptNo: string; amountBaht: string; issuedAt: string } | null;
+  workflow: {
+    referenceNo: string | null;
+    receiptNo: string | null;
+    status: string;
+    steps: Record<WorkflowStepName, 'DONE' | 'ALREADY_DONE' | 'FAILED' | 'SKIPPED'>;
+    complete: boolean;
+  };
+  events: AdminEvent[];
+}
+
+export interface AcknowledgeResult {
+  transition: string;
+  processingEmailSent: boolean;
+}
+
+export interface CompletionResult {
+  applicationId: string;
+  status: ApplicationStatus;
+  recorded: string;
+  completionEmail: string;
+  completed: string;
+  complete: boolean;
+}
+
+/* ---------------------------------------------------------------- client --- */
+
+interface ErrorBody {
+  error?: { code?: unknown; message?: unknown };
+}
+
+async function toError(response: Response): Promise<AdminRequestError> {
+  let body: ErrorBody | null;
+  try {
+    body = (await response.json()) as ErrorBody;
+  } catch {
+    body = null;
+  }
+
+  const code = typeof body?.error?.code === 'string' ? body.error.code : 'HTTP_ERROR';
+  const message = typeof body?.error?.message === 'string' ? body.error.message : GENERIC_MESSAGE;
+  return new AdminRequestError(code, message, response.status);
+}
+
+async function send<T>(path: string, init: RequestInit = {}): Promise<T> {
+  let response: Response;
+  try {
+    // `same-origin` credentials so the Access cookie goes with the request; it
+    // is the only thing authenticating it.
+    response = await fetch(path, { credentials: 'same-origin', ...init });
+  } catch {
+    throw new AdminRequestError('NETWORK', GENERIC_MESSAGE, 0);
+  }
+
+  if (!response.ok) throw await toError(response);
+  return (await response.json()) as T;
+}
+
+export interface Csrf {
+  header: string;
+  token: string;
+}
+
+function post<T>(path: string, csrf: Csrf): Promise<T> {
+  return send<T>(path, { method: 'POST', headers: { [csrf.header]: csrf.token } });
+}
+
+export const adminApi = {
+  session(): Promise<AdminSession> {
+    return send<AdminSession>('/api/admin/session');
+  },
+
+  list(statuses: readonly ApplicationStatus[]): Promise<{ applications: AdminListItem[] }> {
+    const query = statuses.length > 0 ? `?status=${statuses.join(',')}` : '';
+    return send(`/api/admin/applications${query}`);
+  },
+
+  detail(applicationId: string): Promise<{ detail: AdminDetail }> {
+    return send(`/api/admin/applications/${applicationId}`);
+  },
+
+  /** Asks for the full citizen ID. The server records that this happened. */
+  citizenId(applicationId: string): Promise<{ citizenId: string | null }> {
+    return send(`/api/admin/applications/${applicationId}/citizen-id`);
+  },
+
+  acknowledge(applicationId: string, csrf: Csrf): Promise<AcknowledgeResult> {
+    return post(`/api/admin/applications/${applicationId}/acknowledge`, csrf);
+  },
+
+  completeNbtc(applicationId: string, csrf: Csrf): Promise<{ completion: CompletionResult }> {
+    return post(`/api/admin/applications/${applicationId}/nbtc-complete`, csrf);
+  },
+
+  finalize(applicationId: string, csrf: Csrf): Promise<unknown> {
+    return post(`/api/admin/applications/${applicationId}/finalize`, csrf);
+  },
+
+  /** Paths the browser loads directly, with the Access cookie attached. */
+  photoUrl(applicationId: string): string {
+    return `/api/admin/applications/${applicationId}/photo`;
+  },
+
+  receiptUrl(applicationId: string): string {
+    return `/api/admin/applications/${applicationId}/receipt`;
+  },
+};

--- a/src/web/admin/route.ts
+++ b/src/web/admin/route.ts
@@ -1,0 +1,48 @@
+/**
+ * Where in the portal we are, derived from the URL.
+ *
+ * A handful of paths and no router dependency. The three action paths are the
+ * ones the manager notification email links to (Issue #1 sections 32 and 37), so
+ * they have to be real URLs that survive being opened from a mail client - which
+ * also means the page they land on must not do anything by itself.
+ */
+
+export type AdminRoute =
+  | { kind: 'queue' }
+  | { kind: 'detail'; applicationId: string }
+  | { kind: 'acknowledge'; applicationId: string }
+  | { kind: 'nbtc-complete'; applicationId: string }
+  | { kind: 'unknown'; path: string };
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function parseAdminRoute(pathname: string): AdminRoute {
+  const segments = pathname.replace(/^\/+|\/+$/g, '').split('/');
+  if (segments[0] !== 'admin') return { kind: 'unknown', path: pathname };
+
+  if (segments.length === 1) return { kind: 'queue' };
+  if (segments[1] !== 'applications') return { kind: 'unknown', path: pathname };
+
+  const applicationId = segments[2];
+  // An id that is not a UUID is not a typo worth guessing at - it would produce
+  // a request the API will refuse anyway.
+  if (!applicationId || !UUID.test(applicationId)) return { kind: 'unknown', path: pathname };
+
+  if (segments.length === 3) return { kind: 'detail', applicationId };
+  if (segments[3] === 'acknowledge' && segments.length === 4) {
+    return { kind: 'acknowledge', applicationId };
+  }
+  if (segments[3] === 'nbtc-complete' && segments.length === 4) {
+    return { kind: 'nbtc-complete', applicationId };
+  }
+
+  return { kind: 'unknown', path: pathname };
+}
+
+export function queuePath(): string {
+  return '/admin';
+}
+
+export function detailPath(applicationId: string): string {
+  return `/admin/applications/${applicationId}`;
+}

--- a/src/web/lib/datetime.ts
+++ b/src/web/lib/datetime.ts
@@ -1,0 +1,69 @@
+/**
+ * Dates and times, always in Bangkok and always in the Buddhist era.
+ *
+ * The manager reads these next to documents that print `2569`, and the applicant
+ * gave a birth date from a card printed the same way. Rendering an ISO instant in
+ * the browser's own zone would show a different day either side of midnight, and
+ * a Gregorian year would not match anything else the association handles
+ * (Issue #1 section 69).
+ *
+ * `th-TH-u-ca-buddhist` fixes the calendar explicitly rather than relying on
+ * `th-TH` defaulting to it, which is true in current ICU but is not a guarantee.
+ */
+
+const TIME_ZONE = 'Asia/Bangkok';
+const LOCALE = 'th-TH-u-ca-buddhist';
+
+const dateFormatter = new Intl.DateTimeFormat(LOCALE, {
+  timeZone: TIME_ZONE,
+  day: 'numeric',
+  month: 'long',
+  year: 'numeric',
+});
+
+const dateTimeFormatter = new Intl.DateTimeFormat(LOCALE, {
+  timeZone: TIME_ZONE,
+  day: 'numeric',
+  month: 'long',
+  year: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+});
+
+function parse(value: string | null | undefined): Date | null {
+  if (!value) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+/** An instant as a Bangkok date, or a dash when there is none. */
+export function formatDate(value: string | null | undefined): string {
+  const parsed = parse(value);
+  return parsed ? dateFormatter.format(parsed) : '—';
+}
+
+/**
+ * An instant as a Bangkok date and time, or a dash when there is none.
+ *
+ * The formatter's own output already reads `20 สิงหาคม 2569 เวลา 09:30`, so
+ * nothing is appended - adding `น.` after the locale's `เวลา` reads wrong.
+ */
+export function formatDateTime(value: string | null | undefined): string {
+  const parsed = parse(value);
+  return parsed ? dateTimeFormatter.format(parsed) : '—';
+}
+
+/**
+ * A stored `YYYY-MM-DD`, which is a Bangkok calendar date rather than an
+ * instant.
+ *
+ * Parsed with the offset written in, because `new Date('1990-01-15')` is
+ * midnight UTC - which is the previous evening in Bangkok, and would show the
+ * wrong day for every birth date in the database.
+ */
+export function formatCalendarDate(value: string | null | undefined): string {
+  if (!value) return '—';
+  const parsed = new Date(`${value}T00:00:00+07:00`);
+  return Number.isNaN(parsed.getTime()) ? '—' : dateFormatter.format(parsed);
+}

--- a/src/web/main.tsx
+++ b/src/web/main.tsx
@@ -1,16 +1,32 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
+import { AdminApp } from './admin/AdminApp';
 import './styles/global.css';
 import './styles/wizard.css';
+import './styles/admin.css';
 
+/**
+ * One bundle, two applications, chosen by path.
+ *
+ * `/admin*` is the manager's portal and everything else is the applicant wizard.
+ * They share a bundle because they share the components and the stylesheet, and
+ * because splitting them would mean a second build for a site that serves one or
+ * two applications a day. They share no data: the portal never renders while the
+ * wizard does, and the wizard holds no admin state.
+ *
+ * The portal is only reachable through Cloudflare Access, which sits in front of
+ * `/admin*`, and every request it makes is verified again by the Worker. Shipping
+ * its code to a browser that has not passed Access is harmless - the code can
+ * read nothing without a token.
+ */
 const container = document.getElementById('root');
 if (!container) {
   throw new Error('Root container is missing from index.html');
 }
 
-createRoot(container).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-);
+const isAdmin =
+  window.location.pathname.replace(/\/+$/, '') === '/admin' ||
+  window.location.pathname.startsWith('/admin/');
+
+createRoot(container).render(<StrictMode>{isAdmin ? <AdminApp /> : <App />}</StrictMode>);

--- a/src/web/styles/admin.css
+++ b/src/web/styles/admin.css
@@ -1,0 +1,347 @@
+/*
+ * Manager portal.
+ *
+ * Wider than the wizard because the detail page is a lot of fields and a
+ * timeline, and the manager is usually at a desk - but still one column, because
+ * the same person opens this from a phone after reading the notification email,
+ * and a two-column layout that collapses badly is worse than one that never
+ * needed to.
+ *
+ * Reuses the wizard's buttons, alerts and detail rows. The manager and the
+ * applicant see the same kind of controls, and a second set of primitives would
+ * drift.
+ */
+
+.vra-admin {
+  margin: 0 auto;
+  max-width: 52rem;
+  padding: 1rem 1rem 4rem;
+}
+
+.vra-admin__header {
+  align-items: baseline;
+  border-bottom: 1px solid var(--vra-border);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  justify-content: space-between;
+  padding-bottom: 0.75rem;
+}
+
+.vra-admin__brand {
+  font-weight: 700;
+  margin: 0;
+}
+
+.vra-admin__manager {
+  color: var(--vra-text-muted);
+  font-size: 0.875rem;
+  margin: 0;
+}
+
+.vra-admin__title {
+  font-size: 1.375rem;
+  margin: 1.25rem 0 0.25rem;
+}
+
+.vra-admin__subtitle {
+  margin: 0 0 1rem;
+}
+
+.vra-panel {
+  background: var(--vra-surface);
+  border: 1px solid var(--vra-border);
+  border-radius: var(--vra-radius);
+  margin-top: 1rem;
+  padding: 1rem 1.125rem 1.25rem;
+}
+
+.vra-panel__title {
+  font-size: 1.0625rem;
+  margin: 0 0 0.5rem;
+}
+
+.vra-panel ul {
+  margin: 0.5rem 0;
+  padding-left: 1.25rem;
+}
+
+/* ---------------------------------------------------------------- filters --- */
+
+.vra-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.vra-chip {
+  background: var(--vra-surface);
+  border: 1px solid var(--vra-border);
+  border-radius: 999px;
+  color: var(--vra-text);
+  cursor: pointer;
+  font: inherit;
+  min-height: 2.25rem;
+  padding: 0.375rem 0.875rem;
+}
+
+.vra-chip--active {
+  background: var(--vra-navy);
+  border-color: var(--vra-navy);
+  color: #ffffff;
+  font-weight: 600;
+}
+
+.vra-chip:focus-visible {
+  outline: 3px solid var(--vra-navy);
+  outline-offset: 2px;
+}
+
+/* ------------------------------------------------------------------ queue --- */
+
+.vra-queue {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.vra-queue__item {
+  background: var(--vra-surface);
+  border: 1px solid var(--vra-border);
+  border-radius: var(--vra-radius);
+  margin-bottom: 0.625rem;
+  padding: 0.875rem 1rem;
+}
+
+.vra-queue__link {
+  color: inherit;
+  display: block;
+  text-decoration: none;
+}
+
+.vra-queue__link:focus-visible {
+  outline: 3px solid var(--vra-navy);
+  outline-offset: 3px;
+}
+
+.vra-queue__reference {
+  display: block;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.vra-queue__name {
+  color: var(--vra-navy);
+  display: block;
+  text-decoration: underline;
+}
+
+.vra-queue__meta {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.75rem;
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+}
+
+/* ------------------------------------------------------------------ badge --- */
+
+.vra-badge {
+  border: 1px solid transparent;
+  border-radius: 999px;
+  display: inline-block;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  padding: 0.125rem 0.625rem;
+}
+
+.vra-badge--idle {
+  background: var(--vra-surface-muted);
+  border-color: var(--vra-border);
+  color: var(--vra-text-muted);
+}
+
+.vra-badge--busy {
+  background: #e8f0f9;
+  border-color: #b7cfe6;
+  color: #1a4a77;
+}
+
+.vra-badge--action {
+  background: #fff3d6;
+  border-color: #e5c777;
+  color: #6b4a06;
+}
+
+.vra-badge--done {
+  background: #e4f4ea;
+  border-color: #9fd3b3;
+  color: #14603a;
+}
+
+.vra-badge--stop {
+  background: #fbe6e5;
+  border-color: #e3a7a3;
+  color: #8a201b;
+}
+
+@media (prefers-color-scheme: dark) {
+  .vra-badge--busy {
+    background: #14283a;
+    border-color: #2c4b6b;
+    color: #a8cbe9;
+  }
+
+  .vra-badge--action {
+    background: #362c11;
+    border-color: #6b5720;
+    color: #f0d69a;
+  }
+
+  .vra-badge--done {
+    background: #14301f;
+    border-color: #2c5b3f;
+    color: #a5d8bb;
+  }
+
+  .vra-badge--stop {
+    background: #351a19;
+    border-color: #6b302c;
+    color: #eaa9a4;
+  }
+}
+
+/* --------------------------------------------------------------- controls --- */
+
+.vra-back {
+  background: none;
+  border: 0;
+  color: var(--vra-navy);
+  cursor: pointer;
+  font: inherit;
+  margin: 0.5rem 0 0;
+  padding: 0.5rem 0;
+}
+
+.vra-back:focus-visible {
+  outline: 3px solid var(--vra-navy);
+  outline-offset: 2px;
+}
+
+.vra-link {
+  color: var(--vra-navy);
+  font-weight: 600;
+}
+
+/* -------------------------------------------------------------- reveal --- */
+
+.vra-reveal {
+  border: 1px dashed var(--vra-border);
+  border-radius: 10px;
+  margin-top: 1rem;
+  padding: 0.875rem 1rem;
+}
+
+.vra-reveal__title {
+  font-size: 0.9375rem;
+  margin: 0 0 0.25rem;
+}
+
+.vra-reveal__value {
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  margin: 0.25rem 0 0;
+}
+
+.vra-member-photo {
+  border: 1px solid var(--vra-border);
+  border-radius: 10px;
+  display: block;
+  max-width: 11rem;
+  width: 100%;
+}
+
+/* -------------------------------------------------------------- confirm --- */
+
+.vra-confirm {
+  background: var(--vra-surface-muted);
+  border-radius: var(--vra-radius);
+  margin-top: 1rem;
+  padding: 1rem;
+  text-align: center;
+}
+
+.vra-confirm__reference {
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  margin: 0;
+}
+
+.vra-confirm__name {
+  font-size: 1.125rem;
+  margin: 0.25rem 0 0.5rem;
+}
+
+.vra-confirm__question {
+  font-size: 1.0625rem;
+  font-weight: 600;
+  margin-top: 1.25rem;
+}
+
+/* ------------------------------------------------------------- timeline --- */
+
+.vra-timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.vra-timeline__item {
+  border-left: 2px solid var(--vra-border);
+  padding: 0 0 0.875rem 0.875rem;
+  position: relative;
+}
+
+.vra-timeline__item::before {
+  background: var(--vra-navy);
+  border-radius: 50%;
+  content: '';
+  height: 0.5rem;
+  left: -0.3125rem;
+  position: absolute;
+  top: 0.4375rem;
+  width: 0.5rem;
+}
+
+.vra-timeline__when {
+  color: var(--vra-text-muted);
+  font-size: 0.8125rem;
+  margin: 0;
+}
+
+.vra-timeline__what {
+  font-weight: 600;
+  margin: 0.125rem 0 0;
+}
+
+.vra-timeline__who,
+.vra-timeline__meta {
+  color: var(--vra-text-muted);
+  font-size: 0.8125rem;
+  margin: 0.125rem 0 0;
+  word-break: break-word;
+}
+
+@media (min-width: 48rem) {
+  .vra-details__row {
+    display: grid;
+    grid-template-columns: 14rem 1fr;
+  }
+
+  .vra-details dd {
+    text-align: left;
+  }
+}

--- a/src/worker/routes/admin.ts
+++ b/src/worker/routes/admin.ts
@@ -127,16 +127,37 @@ export const adminRoutes: Hono<AppContext> = new Hono<AppContext>()
   })
 
   .get('/admin/applications/:id', async (c) => {
-    const identity = await authenticate(c);
+    await authenticate(c);
     const applicationId = idSchema.parse(c.req.param('id'));
 
     const view = await buildAdminView(c);
-    const detail = await view.detail(applicationId, identity.email);
+    const detail = await view.detail(applicationId);
 
     c.var.logger.info({ event: 'admin.detail_read', applicationId });
 
     c.header('Cache-Control', 'no-store');
     return c.json({ detail });
+  })
+
+  /**
+   * The full citizen ID, on request only.
+   *
+   * A separate endpoint rather than a field on the detail, so an entry in the
+   * audit trail means the manager asked for the number - not merely that they
+   * opened the page. A `GET` because it changes no application state; the audit
+   * event it writes is a record of the read, which is the point of it.
+   */
+  .get('/admin/applications/:id/citizen-id', async (c) => {
+    const identity = await authenticate(c);
+    const applicationId = idSchema.parse(c.req.param('id'));
+
+    const view = await buildAdminView(c);
+    const citizenId = await view.revealCitizenId(applicationId, identity.email);
+
+    c.var.logger.info({ event: 'admin.citizen_id_revealed', applicationId });
+
+    c.header('Cache-Control', 'no-store');
+    return c.json({ citizenId });
   })
 
   /**

--- a/src/worker/services/admin-view.ts
+++ b/src/worker/services/admin-view.ts
@@ -18,11 +18,17 @@ import { formatBaht, membershipPlan } from './membership';
 /**
  * What the manager sees (Issue #1 sections 52-53).
  *
- * This module exists so that reading an application's full details is one code
- * path with the audit event attached to it. The citizen ID is decrypted here and
- * nowhere else in the admin flow, and `CITIZEN_ID_ACCESSED` is recorded on the
- * same call - so there is no way to add a second reader later that forgets to
- * record it.
+ * The citizen ID is **not** part of the detail. `revealCitizenId` is a separate
+ * call, and it is the only place in the admin flow that decrypts, recording
+ * `CITIZEN_ID_ACCESSED` on the same call - so there is no way to add a second
+ * reader later that forgets to record it.
+ *
+ * Splitting it out is what makes the audit trail mean something. When the detail
+ * page decrypted on load, every glance at an application produced an access
+ * event, so the trail could not distinguish "the manager looked up the number"
+ * from "the manager opened the page". Now an entry exists only when someone
+ * actually asked for the number, which is also what stops it sitting on screen
+ * for a screenshot nobody intended.
  *
  * The list view carries no personal data beyond a name. A manager scanning a
  * queue does not need addresses or contact details, and a list endpoint is the
@@ -65,8 +71,6 @@ export interface AdminDetail {
     lastNameEn: string | null;
     birthDate: string | null;
     cardExpiryDate: string | null;
-    /** Full number. Decrypted for this call only, and audited. */
-    citizenId: string | null;
     phone: string | null;
     email: string | null;
     callsign: string | null;
@@ -99,12 +103,16 @@ export interface AdminDetail {
 
 export interface AdminViewService {
   list(query?: ApplicationListQuery): Promise<AdminListItem[]>;
+  /** Everything except the citizen ID, and nothing is decrypted. */
+  detail(applicationId: string): Promise<AdminDetail>;
   /**
-   * The full record, decrypting the citizen ID and recording that it was read.
+   * Decrypts the citizen ID and records that it was read.
    *
    * `actor` is the manager's Access identity, so the trail says who looked.
+   * Returns null when the envelope cannot be read, which is reported to the
+   * manager rather than failing the page.
    */
-  detail(applicationId: string, actor: string): Promise<AdminDetail>;
+  revealCitizenId(applicationId: string, actor: string): Promise<string | null>;
 }
 
 function fullName(record: ApplicationRecord): string | null {
@@ -150,7 +158,7 @@ export function createAdminView(
       }));
     },
 
-    async detail(applicationId, actor) {
+    async detail(applicationId) {
       const application = await db.applications.findById(applicationId);
       if (!application) throw adminApplicationNotFound();
 
@@ -161,22 +169,6 @@ export function createAdminView(
         db.events.listByApplicationId(applicationId),
         workflow.inspect(applicationId),
       ]);
-
-      // Decrypting is the sensitive act, so it is recorded before the value is
-      // used. An envelope that cannot be read leaves the field null rather than
-      // failing the page: the manager still needs everything else.
-      let plainCitizenId: string | null;
-      try {
-        plainCitizenId = await citizenId.decrypt(application.citizenIdCiphertext);
-        await audit.record({
-          applicationId,
-          eventType: CITIZEN_ID_ACCESSED_EVENT,
-          actorType: 'MANAGER',
-          actorId: actor,
-        });
-      } catch {
-        plainCitizenId = null;
-      }
 
       const payment = latestVerified(payments);
       const plan = application.membershipType ? membershipPlan(application.membershipType) : null;
@@ -193,7 +185,6 @@ export function createAdminView(
           lastNameEn: application.lastNameEn,
           birthDate: application.birthDate,
           cardExpiryDate: application.cardExpiryDate,
-          citizenId: plainCitizenId,
           phone: application.phone,
           email: application.email,
           callsign: application.callsign,
@@ -227,6 +218,29 @@ export function createAdminView(
         workflow: report,
         events,
       };
+    },
+
+    async revealCitizenId(applicationId, actor) {
+      const application = await db.applications.findById(applicationId);
+      if (!application) throw adminApplicationNotFound();
+
+      // The event is recorded before the value is returned, so a failure after
+      // the decrypt cannot leave a read unrecorded.
+      let plain: string;
+      try {
+        plain = await citizenId.decrypt(application.citizenIdCiphertext);
+      } catch {
+        return null;
+      }
+
+      await audit.record({
+        applicationId,
+        eventType: CITIZEN_ID_ACCESSED_EVENT,
+        actorType: 'MANAGER',
+        actorId: actor,
+      });
+
+      return plain;
     },
   };
 }

--- a/tests/web/admin-portal.test.tsx
+++ b/tests/web/admin-portal.test.tsx
@@ -1,0 +1,602 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AdminApp } from '../../src/web/admin/AdminApp';
+import type { AdminDetail, AdminListItem } from '../../src/web/admin/api';
+
+/**
+ * The manager portal, driven the way a manager drives it.
+ *
+ * `fetch` is stubbed per test. Every value is synthetic: the citizen ID is a
+ * sequential pattern with a valid check digit, names are the Thai words for
+ * "test", and addresses use the reserved `.test` TLD.
+ */
+
+const MANAGER = 'manager@example.test';
+const CSRF = { header: 'x-vra-csrf', token: 'c'.repeat(64) };
+const APPLICATION_ID = '11111111-2222-4333-8444-555555555555';
+const CITIZEN_ID = '1234567890121';
+
+interface Recorded {
+  url: string;
+  method: string;
+  headers: Headers;
+}
+
+let calls: Recorded[] = [];
+let routes: Map<string, { status?: number; body?: unknown }>;
+
+function detailBody(overrides: Partial<AdminDetail['application']> = {}): AdminDetail {
+  return {
+    application: {
+      id: APPLICATION_ID,
+      referenceNo: 'VRA-2569-000123',
+      status: 'MANAGER_NOTIFIED',
+      title: 'นาย',
+      firstName: 'ทดสอบ',
+      lastName: 'ระบบสมัคร',
+      firstNameEn: 'Thodsob',
+      lastNameEn: 'Rabobsamak',
+      birthDate: '1990-01-15',
+      cardExpiryDate: '2032-01-14',
+      phone: '0812345678',
+      email: 'applicant@example.test',
+      callsign: 'HS0TEST',
+      membershipType: 'ANNUAL',
+      membershipLabel: 'สมาชิกสามัญรายปี',
+      amountBaht: '500.00',
+      hasPhoto: true,
+      photoSource: 'UPLOAD',
+      submittedAt: '2026-08-20T03:00:00.000Z',
+      managerAcknowledgedAt: null,
+      nbtcRecordedAt: null,
+      nbtcRecordedBy: null,
+      createdAt: '2026-08-20T02:00:00.000Z',
+      updatedAt: '2026-08-20T03:00:00.000Z',
+      ...overrides,
+    },
+    address: {
+      idAddress: '99/9 หมู่ 9',
+      idSubdistrict: 'ตำบลทดสอบ',
+      idDistrict: 'อำเภอทดสอบ',
+      idProvince: 'จังหวัดทดสอบ',
+      mailSameAsId: true,
+      mailRecipient: null,
+      mailAddress: null,
+      mailSubdistrict: null,
+      mailDistrict: null,
+      mailProvince: null,
+      mailPostcode: '10200',
+      mailPhone: null,
+    },
+    payment: {
+      transactionRef: 'TXN0000000000001',
+      amountBaht: '500.00',
+      sendingBank: '002',
+      receivingBank: 'ธนาคารตัวอย่าง',
+      transactionAt: '2026-08-20T02:30:00.000Z',
+      verifiedAt: '2026-08-20T02:31:00.000Z',
+    },
+    receipt: {
+      receiptNo: 'VRA-RC-2569-000001',
+      amountBaht: '500.00',
+      issuedAt: '2026-08-20T02:31:00.000Z',
+    },
+    workflow: {
+      referenceNo: 'VRA-2569-000123',
+      receiptNo: 'VRA-RC-2569-000001',
+      status: 'MANAGER_NOTIFIED',
+      steps: {
+        APPLICATION_NUMBER: 'DONE',
+        RECEIPT: 'DONE',
+        RECEIPT_EMAIL: 'DONE',
+        SUBMISSION: 'DONE',
+        MANAGER_EMAIL: 'DONE',
+      },
+      complete: true,
+    },
+    events: [
+      {
+        id: 'event-1',
+        eventType: 'PAYMENT_VERIFIED',
+        actorType: 'SYSTEM',
+        actorId: null,
+        metadata: { amountSatang: 50000 },
+        createdAt: '2026-08-20T02:31:00.000Z',
+      },
+      {
+        id: 'event-2',
+        eventType: 'MANAGER_EMAIL_SENT',
+        actorType: 'SYSTEM',
+        actorId: null,
+        metadata: { emailType: 'MANAGER_NEW_APPLICATION' },
+        createdAt: '2026-08-20T03:00:00.000Z',
+      },
+    ],
+  };
+}
+
+const QUEUE: AdminListItem[] = [
+  {
+    id: APPLICATION_ID,
+    referenceNo: 'VRA-2569-000123',
+    status: 'MANAGER_NOTIFIED',
+    name: 'นาย ทดสอบ ระบบสมัคร',
+    membershipType: 'ANNUAL',
+    amountBaht: '500.00',
+    submittedAt: '2026-08-20T03:00:00.000Z',
+    createdAt: '2026-08-20T02:00:00.000Z',
+  },
+];
+
+function route(path: string, body: unknown, status = 200): void {
+  routes.set(path, { body, status });
+}
+
+function stubFetch(): void {
+  globalThis.fetch = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+    calls.push({ url, method: init?.method ?? 'GET', headers: new Headers(init?.headers) });
+
+    const key = [...routes.keys()]
+      .sort((a, b) => b.length - a.length)
+      .find((candidate) => url.startsWith(candidate));
+    const entry = key ? routes.get(key)! : undefined;
+
+    if (!entry) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ error: { code: 'NOT_FOUND', message: 'ไม่พบ' } }), {
+          status: 404,
+        }),
+      );
+    }
+
+    return Promise.resolve(
+      new Response(JSON.stringify(entry.body ?? {}), {
+        status: entry.status ?? 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+  });
+}
+
+function visit(path: string): void {
+  window.history.pushState(null, '', path);
+}
+
+beforeEach(() => {
+  calls = [];
+  routes = new Map();
+  route('/api/admin/session', { manager: { email: MANAGER }, csrf: CSRF });
+  route('/api/admin/applications', { applications: QUEUE });
+  route(`/api/admin/applications/${APPLICATION_ID}`, { detail: detailBody() });
+  stubFetch();
+  visit('/admin');
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  visit('/');
+});
+
+describe('the session', () => {
+  it('renders nothing until Access is confirmed', async () => {
+    render(<AdminApp />);
+
+    expect(screen.getByText('กำลังตรวจสอบสิทธิ์...')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText(MANAGER)).toBeInTheDocument());
+  });
+
+  it('shows no portal at all when the session call is refused', async () => {
+    route(
+      '/api/admin/session',
+      { error: { code: 'FORBIDDEN', message: 'ไม่มีสิทธิ์เข้าถึงส่วนผู้จัดการ' } },
+      403,
+    );
+    render(<AdminApp />);
+
+    // A portal that renders while every action fails is worse than saying so.
+    await waitFor(() => {
+      expect(screen.getByText('ไม่มีสิทธิ์เข้าถึงส่วนผู้จัดการ')).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('heading', { name: 'ใบสมัครสมาชิก' })).not.toBeInTheDocument();
+  });
+});
+
+describe('the queue', () => {
+  it('opens on the applications that need the manager', async () => {
+    render(<AdminApp />);
+
+    await waitFor(() => expect(screen.getByText('VRA-2569-000123')).toBeInTheDocument());
+    // The default filter is the outstanding work, not everything.
+    const listCall = calls.find((call) => call.url.includes('/api/admin/applications?'));
+    expect(listCall?.url).toContain('status=MANAGER_NOTIFIED,NBTC_PROCESSING');
+  });
+
+  it('shows a status in words, not only a colour', async () => {
+    render(<AdminApp />);
+
+    await waitFor(() => {
+      expect(screen.getByText('รอผู้จัดการรับเรื่อง')).toBeInTheDocument();
+    });
+  });
+
+  it('carries no personal detail beyond a name', async () => {
+    render(<AdminApp />);
+    await waitFor(() => expect(screen.getByText('VRA-2569-000123')).toBeInTheDocument());
+
+    // This is the view most likely to be left open on a shared screen.
+    const body = document.body.textContent ?? '';
+    expect(body).not.toContain(CITIZEN_ID);
+    expect(body).not.toContain('applicant@example.test');
+    expect(body).not.toContain('จังหวัดทดสอบ');
+  });
+
+  it('changes the filter and asks the server again', async () => {
+    const user = userEvent.setup();
+    render(<AdminApp />);
+    await waitFor(() => expect(screen.getByText('VRA-2569-000123')).toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: 'เสร็จสมบูรณ์' }));
+
+    await waitFor(() => {
+      expect(calls.some((call) => call.url.includes('status=COMPLETED,NBTC_RECORDED'))).toBe(true);
+    });
+  });
+
+  it('offers a retry when the list cannot be loaded', async () => {
+    route(
+      '/api/admin/applications',
+      { error: { code: 'INTERNAL_ERROR', message: 'เกิดข้อผิดพลาดภายในระบบ' } },
+      500,
+    );
+    const user = userEvent.setup();
+    render(<AdminApp />);
+
+    await waitFor(() => expect(screen.getByText('เกิดข้อผิดพลาดภายในระบบ')).toBeInTheDocument());
+    const before = calls.length;
+    await user.click(screen.getByRole('button', { name: 'ลองโหลดอีกครั้ง' }));
+
+    await waitFor(() => expect(calls.length).toBeGreaterThan(before));
+  });
+
+  it('links to a detail with a real href, so it can be opened in a new tab', async () => {
+    render(<AdminApp />);
+
+    await waitFor(() => {
+      const link = screen.getByRole('link', { name: /ทดสอบ/ });
+      expect(link).toHaveAttribute('href', `/admin/applications/${APPLICATION_ID}`);
+    });
+  });
+});
+
+describe('the detail', () => {
+  beforeEach(() => visit(`/admin/applications/${APPLICATION_ID}`));
+
+  it('shows the application without asking for the citizen ID', async () => {
+    render(<AdminApp />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'VRA-2569-000123' })).toBeInTheDocument();
+    });
+
+    // Opening a page must not produce an access event for the number.
+    expect(calls.some((call) => call.url.endsWith('/citizen-id'))).toBe(false);
+    expect(document.body.textContent).not.toContain(CITIZEN_ID);
+  });
+
+  it('fetches the citizen ID only when asked, and says the read is recorded', async () => {
+    route(`/api/admin/applications/${APPLICATION_ID}/citizen-id`, { citizenId: CITIZEN_ID });
+    const user = userEvent.setup();
+    render(<AdminApp />);
+    await waitFor(() => expect(screen.getByText('เลขบัตรประชาชน')).toBeInTheDocument());
+
+    expect(screen.getByText(/การเปิดดูจะถูกบันทึกไว้/)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'แสดงเลขบัตรประชาชน' }));
+
+    await waitFor(() => expect(screen.getByText(CITIZEN_ID)).toBeInTheDocument());
+    expect(calls.filter((call) => call.url.endsWith('/citizen-id'))).toHaveLength(1);
+  });
+
+  it('reports a citizen ID that cannot be decrypted', async () => {
+    route(`/api/admin/applications/${APPLICATION_ID}/citizen-id`, { citizenId: null });
+    const user = userEvent.setup();
+    render(<AdminApp />);
+    await waitFor(() => expect(screen.getByText('เลขบัตรประชาชน')).toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: 'แสดงเลขบัตรประชาชน' }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/ไม่สามารถอ่านเลขบัตรประชาชน/)).toBeInTheDocument();
+    });
+  });
+
+  it('shows dates in Bangkok time and the Buddhist era', async () => {
+    render(<AdminApp />);
+
+    await waitFor(() => {
+      // 1990-01-15 is 2533 in the Buddhist era.
+      expect(screen.getByText('15 มกราคม 2533')).toBeInTheDocument();
+    });
+    // 02:30Z is 09:30 in Bangkok, on the same day.
+    expect(screen.getByText(/20 สิงหาคม 2569 เวลา 09:30/)).toBeInTheDocument();
+  });
+
+  it('loads the photo from the authenticated endpoint', async () => {
+    render(<AdminApp />);
+
+    await waitFor(() => {
+      const photo = screen.getByAltText('รูปสำหรับบัตรสมาชิกของผู้สมัคร');
+      // No signed or durable URL: the browser sends the Access cookie itself.
+      expect(photo).toHaveAttribute('src', `/api/admin/applications/${APPLICATION_ID}/photo`);
+    });
+  });
+
+  it('links to the receipt', async () => {
+    render(<AdminApp />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: /ดาวน์โหลดใบสำคัญรับเงิน/ })).toHaveAttribute(
+        'href',
+        `/api/admin/applications/${APPLICATION_ID}/receipt`,
+      );
+    });
+  });
+
+  it('translates the audit trail rather than showing raw event names', async () => {
+    render(<AdminApp />);
+
+    await waitFor(() => {
+      expect(screen.getByText('ตรวจสอบการชำระเงินผ่าน')).toBeInTheDocument();
+      expect(screen.getByText('แจ้งผู้จัดการทางอีเมล')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('PAYMENT_VERIFIED')).not.toBeInTheDocument();
+  });
+
+  it('offers the action the current status allows, and no other', async () => {
+    render(<AdminApp />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'รับเรื่อง / เริ่มดำเนินการ' }),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole('button', { name: 'บันทึกในระบบ กสทช. เรียบร้อยแล้ว' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('offers the NBTC action once the application is in processing', async () => {
+    route(`/api/admin/applications/${APPLICATION_ID}`, {
+      detail: detailBody({ status: 'NBTC_PROCESSING' }),
+    });
+    render(<AdminApp />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'บันทึกในระบบ กสทช. เรียบร้อยแล้ว' }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('surfaces an outstanding post-payment step with a retry', async () => {
+    const detail = detailBody();
+    detail.workflow.steps.RECEIPT_EMAIL = 'FAILED';
+    detail.workflow.complete = false;
+    route(`/api/admin/applications/${APPLICATION_ID}`, { detail });
+    render(<AdminApp />);
+
+    await waitFor(() => {
+      expect(screen.getByText('ส่งใบสำคัญรับเงินให้สมาชิก')).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole('button', { name: 'ลองดำเนินการขั้นตอนที่ค้างอีกครั้ง' }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('the confirmation page reached from the email', () => {
+  it('changes nothing on load', async () => {
+    visit(`/admin/applications/${APPLICATION_ID}/nbtc-complete`);
+    route(`/api/admin/applications/${APPLICATION_ID}`, {
+      detail: detailBody({ status: 'NBTC_PROCESSING' }),
+    });
+    render(<AdminApp />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/กรุณายืนยันว่าได้บันทึกข้อมูลทะเบียนสมาชิก/)).toBeInTheDocument();
+    });
+
+    // An email security scanner opens links. Nothing here may act on its own.
+    expect(calls.every((call) => call.method === 'GET')).toBe(true);
+  });
+
+  it('shows who and what before asking', async () => {
+    visit(`/admin/applications/${APPLICATION_ID}/nbtc-complete`);
+    route(`/api/admin/applications/${APPLICATION_ID}`, {
+      detail: detailBody({ status: 'NBTC_PROCESSING' }),
+    });
+    render(<AdminApp />);
+
+    await waitFor(() => {
+      expect(screen.getByText('VRA-2569-000123')).toBeInTheDocument();
+      expect(screen.getByText('นาย ทดสอบ ระบบสมัคร')).toBeInTheDocument();
+    });
+  });
+
+  it('posts with the CSRF token when confirmed', async () => {
+    visit(`/admin/applications/${APPLICATION_ID}/nbtc-complete`);
+    route(`/api/admin/applications/${APPLICATION_ID}`, {
+      detail: detailBody({ status: 'NBTC_PROCESSING' }),
+    });
+    route(`/api/admin/applications/${APPLICATION_ID}/nbtc-complete`, {
+      completion: {
+        applicationId: APPLICATION_ID,
+        status: 'COMPLETED',
+        recorded: 'DONE',
+        completionEmail: 'DONE',
+        completed: 'DONE',
+        complete: true,
+      },
+    });
+    const user = userEvent.setup();
+    render(<AdminApp />);
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'ยืนยันว่าบันทึกเรียบร้อยแล้ว' }),
+      ).toBeInTheDocument(),
+    );
+
+    await user.click(screen.getByRole('button', { name: 'ยืนยันว่าบันทึกเรียบร้อยแล้ว' }));
+
+    await waitFor(() => {
+      const post = calls.find((call) => call.method === 'POST');
+      expect(post?.url).toContain('/nbtc-complete');
+      expect(post?.headers.get(CSRF.header)).toBe(CSRF.token);
+    });
+  });
+
+  it('reports a partial result honestly', async () => {
+    visit(`/admin/applications/${APPLICATION_ID}/nbtc-complete`);
+    route(`/api/admin/applications/${APPLICATION_ID}`, {
+      detail: detailBody({ status: 'NBTC_PROCESSING' }),
+    });
+    route(`/api/admin/applications/${APPLICATION_ID}/nbtc-complete`, {
+      completion: {
+        applicationId: APPLICATION_ID,
+        status: 'NBTC_RECORDED',
+        recorded: 'DONE',
+        completionEmail: 'FAILED',
+        completed: 'SKIPPED',
+        complete: false,
+      },
+    });
+    const user = userEvent.setup();
+    render(<AdminApp />);
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'ยืนยันว่าบันทึกเรียบร้อยแล้ว' }),
+      ).toBeInTheDocument(),
+    );
+
+    await user.click(screen.getByRole('button', { name: 'ยืนยันว่าบันทึกเรียบร้อยแล้ว' }));
+
+    // "Done" would be a lie when the member has not been told.
+    await waitFor(() => {
+      expect(screen.getByText(/การแจ้งสมาชิกยังไม่สำเร็จ/)).toBeInTheDocument();
+    });
+  });
+
+  it('sends one request for two presses', async () => {
+    visit(`/admin/applications/${APPLICATION_ID}/acknowledge`);
+    route(`/api/admin/applications/${APPLICATION_ID}/acknowledge`, {
+      transition: 'APPLIED',
+      processingEmailSent: true,
+    });
+    const user = userEvent.setup();
+    render(<AdminApp />);
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'ยืนยันว่ารับเรื่องแล้ว' })).toBeInTheDocument(),
+    );
+
+    const button = screen.getByRole('button', { name: 'ยืนยันว่ารับเรื่องแล้ว' });
+    await user.click(button);
+    await user.click(button);
+
+    await waitFor(() => expect(screen.getByText('บันทึกการรับเรื่องแล้ว')).toBeInTheDocument());
+    expect(calls.filter((call) => call.method === 'POST')).toHaveLength(1);
+  });
+
+  it('says the work is already done when an old email is opened again', async () => {
+    visit(`/admin/applications/${APPLICATION_ID}/acknowledge`);
+    route(`/api/admin/applications/${APPLICATION_ID}`, {
+      detail: detailBody({ status: 'COMPLETED' }),
+    });
+    render(<AdminApp />);
+
+    // A stale link must not present a button that would fail, leaving the
+    // manager unsure whether their first press worked.
+    await waitFor(() => expect(screen.getByText('ดำเนินการนี้ไปแล้ว')).toBeInTheDocument());
+    expect(
+      screen.queryByRole('button', { name: 'ยืนยันว่ารับเรื่องแล้ว' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('refuses to offer an action the status does not allow yet', async () => {
+    visit(`/admin/applications/${APPLICATION_ID}/nbtc-complete`);
+    render(<AdminApp />);
+
+    await waitFor(() => expect(screen.getByText('ยังไม่ถึงขั้นตอนนี้')).toBeInTheDocument());
+    expect(
+      screen.queryByRole('button', { name: 'ยืนยันว่าบันทึกเรียบร้อยแล้ว' }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('navigation', () => {
+  it('walks from the queue to a detail and back', async () => {
+    const user = userEvent.setup();
+    render(<AdminApp />);
+    await waitFor(() => expect(screen.getByText('VRA-2569-000123')).toBeInTheDocument());
+
+    await user.click(screen.getByRole('link', { name: /ทดสอบ/ }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'VRA-2569-000123' })).toBeInTheDocument(),
+    );
+    expect(window.location.pathname).toBe(`/admin/applications/${APPLICATION_ID}`);
+
+    await user.click(screen.getByRole('button', { name: '← รายการใบสมัคร' }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'ใบสมัครสมาชิก' })).toBeInTheDocument(),
+    );
+  });
+
+  it('reports an address that is not a portal page', async () => {
+    visit('/admin/nonsense');
+    render(<AdminApp />);
+
+    await waitFor(() => expect(screen.getByText('ไม่พบหน้านี้')).toBeInTheDocument());
+  });
+
+  it('reports a malformed application id rather than requesting it', async () => {
+    visit('/admin/applications/not-a-uuid');
+    render(<AdminApp />);
+
+    await waitFor(() => expect(screen.getByText('ไม่พบหน้านี้')).toBeInTheDocument());
+    expect(calls.some((call) => call.url.includes('not-a-uuid'))).toBe(false);
+  });
+});
+
+describe('client-side storage', () => {
+  it('writes nothing, including the CSRF token', async () => {
+    route(`/api/admin/applications/${APPLICATION_ID}/citizen-id`, { citizenId: CITIZEN_ID });
+    const user = userEvent.setup();
+    visit(`/admin/applications/${APPLICATION_ID}`);
+    render(<AdminApp />);
+    await waitFor(() => expect(screen.getByText('เลขบัตรประชาชน')).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'แสดงเลขบัตรประชาชน' }));
+    await waitFor(() => expect(screen.getByText(CITIZEN_ID)).toBeInTheDocument());
+
+    expect(localStorage.length).toBe(0);
+    expect(sessionStorage.length).toBe(0);
+  });
+});
+
+describe('the detail layout', () => {
+  it('labels every value it shows', async () => {
+    visit(`/admin/applications/${APPLICATION_ID}`);
+    render(<AdminApp />);
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'VRA-2569-000123' })).toBeInTheDocument(),
+    );
+
+    // A definition list, so each value is announced with the term it belongs to
+    // rather than as a bare string.
+    const applicant = screen.getByRole('heading', { name: 'ผู้สมัคร' }).parentElement!;
+    const terms = within(applicant).getAllByRole('term');
+    expect(terms.length).toBeGreaterThan(0);
+    expect(within(applicant).getAllByRole('definition').length).toBe(terms.length);
+  });
+});

--- a/tests/worker/admin.test.ts
+++ b/tests/worker/admin.test.ts
@@ -278,6 +278,7 @@ describe('every admin endpoint requires Access', () => {
     { method: 'POST', path: `/api/admin/applications/${crypto.randomUUID()}/finalize` },
     { method: 'GET', path: `/api/admin/applications/${crypto.randomUUID()}/photo` },
     { method: 'GET', path: `/api/admin/applications/${crypto.randomUUID()}/receipt` },
+    { method: 'GET', path: `/api/admin/applications/${crypto.randomUUID()}/citizen-id` },
   ];
 
   for (const route of paths) {
@@ -378,6 +379,7 @@ describe('GET never changes state', () => {
       `/api/admin/applications/${id}`,
       `/api/admin/applications/${id}/receipt`,
       `/api/admin/applications/${id}/photo`,
+      `/api/admin/applications/${id}/citizen-id`,
     ]) {
       await call(path);
     }
@@ -429,35 +431,60 @@ describe('the application list', () => {
   });
 });
 
-describe('the application detail', () => {
-  it('returns the full citizen ID and records that it was read', async () => {
+describe('the citizen ID', () => {
+  it('is not part of the detail at all', async () => {
     const repo = repository();
     const id = await notifiedApplication(repo);
 
     const response = await call(`/api/admin/applications/${id}`);
-    const body = await response.json<{ detail: { application: { citizenId: string } } }>();
+    const body = await response.text();
+
+    // Opening the page must not decrypt. Otherwise every glance produces an
+    // access event and the trail cannot tell a lookup from a page load.
+    expect(response.status).toBe(200);
+    expect(body).not.toContain(TEST_CITIZEN_ID);
+    const events = await repo.events.listByApplicationId(id);
+    expect(events.some((event) => event.eventType === 'CITIZEN_ID_ACCESSED')).toBe(false);
+  });
+
+  it('is returned on request, and the read is recorded', async () => {
+    const repo = repository();
+    const id = await notifiedApplication(repo);
+
+    const response = await call(`/api/admin/applications/${id}/citizen-id`);
+    const body = await response.json<{ citizenId: string }>();
 
     expect(response.status).toBe(200);
-    expect(body.detail.application.citizenId).toBe(TEST_CITIZEN_ID);
+    expect(body.citizenId).toBe(TEST_CITIZEN_ID);
 
     const events = await repo.events.listByApplicationId(id);
     const access = events.find((event) => event.eventType === 'CITIZEN_ID_ACCESSED');
-    expect(access).toBeDefined();
     expect(access?.actorType).toBe('MANAGER');
     expect(access?.actorId).toBe(MANAGER);
   });
 
-  it('records one access event per read, so the trail counts them', async () => {
+  it('records one event per request, so the trail counts them', async () => {
     const repo = repository();
     const id = await notifiedApplication(repo);
 
-    await call(`/api/admin/applications/${id}`);
-    await call(`/api/admin/applications/${id}`);
+    await call(`/api/admin/applications/${id}/citizen-id`);
+    await call(`/api/admin/applications/${id}/citizen-id`);
 
     const events = await repo.events.listByApplicationId(id);
     expect(events.filter((event) => event.eventType === 'CITIZEN_ID_ACCESSED')).toHaveLength(2);
   });
 
+  it('needs Access like everything else', async () => {
+    const repo = repository();
+    const id = await notifiedApplication(repo);
+
+    const response = await call(`/api/admin/applications/${id}/citizen-id`, { token: null });
+
+    expect(response.status).toBe(403);
+  });
+});
+
+describe('the application detail', () => {
   it('includes what the manager needs to do the registration', async () => {
     const repo = repository();
     const id = await notifiedApplication(repo);


### PR DESCRIPTION
Closes #18

## What this does

The manager's portal: the application queue, one application in full with its audit trail, and the two confirmation pages the notification email links to. Same bundle as the applicant wizard, chosen by path — they share the components and the stylesheet, and splitting them would mean a second build for a site that takes one or two applications a day. They share no data: the portal never renders while the wizard does.

## The citizen ID is now a request of its own — a change to #16

This is the part most worth reviewing. #16 decrypted the citizen ID when the detail loaded, so **every glance at an application produced a `CITIZEN_ID_ACCESSED` event**, and the audit trail could not tell "the manager looked the number up" from "the manager opened the page". An audit entry that fires on page load says nothing.

So:

- `AdminDetail` no longer carries the number at all, and `detail()` decrypts nothing
- `GET /api/admin/applications/:id/citizen-id` is a separate endpoint, and `revealCitizenId()` is now the only place in the admin flow that decrypts
- the page shows a button, and the copy says plainly that the read will be recorded

Two things follow. An entry in the trail now means someone actually asked for the number. And the number is not sitting on screen for a screenshot nobody intended — which matters for a page a manager may leave open.

Tested both directions: loading the detail returns a body that does not contain the citizen ID and writes no access event; requesting it returns the number and writes exactly one event per request, attributed to the Access identity.

## Confirmation pages know the status before offering anything

The manager email links to `/admin/applications/:id/acknowledge` and `/nbtc-complete`. Email security scanners open links, so these are pages, not endpoints, and nothing happens until the manager presses the button (Issue #1 §37). A test asserts every request made while the page loads is a `GET`.

Beyond that, the page loads the application first and **refuses to offer an action the current status does not allow**. A stale link — the same email opened twice, a week apart — says the work is already done rather than presenting a button that would fail and leave the manager unsure whether their first press worked. Both cases are tested.

The partial outcome is reported honestly too: if the registration is recorded but the member's email fails, the page says so rather than "done", because "done" would be a lie when the member has not been told.

## No URL works without Access

The photo is an `<img src>` and the receipt an `<a href>` pointing straight at the authenticated endpoints. The browser sends the Access cookie itself, so there is nothing signed, nothing durable, and nothing to forward (§14). Asserted on the rendered attributes.

## The queue carries as little as it can

It opens on the two statuses that need the manager rather than on everything, because the manager should not have to do the filtering. Rows carry a name, a reference number, an amount and a status — no address, no phone number, no card. This is the view most likely to be left open on a shared screen or photographed, and none of that is needed to choose which application to open. There is a test that greps the rendered document for a citizen ID, an email address and a province and asserts all three are absent.

## Two things the linter caught, and the code is better for both

`react-hooks/set-state-in-effect` flagged the loaders. Rewriting them so state is only set when a response arrives fixed a real bug alongside it: the queue result now carries the filter it was fetched for, so switching filters quickly can no longer leave a slower response on screen under the newer label. The detail and confirmation pages reload by bumping an attempt counter rather than calling a function that sets state synchronously.

## Times

Everything is Asia/Bangkok in the Buddhist era. The manager reads these next to documents that print `2569`, and the applicant's birth date came from a card printed the same way. `th-TH-u-ca-buddhist` names the calendar explicitly rather than relying on `th-TH` defaulting to it — true in current ICU, not a guarantee. A stored `YYYY-MM-DD` is parsed with `+07:00` written in, because `new Date('1990-01-15')` is midnight UTC, which is the previous evening in Bangkok and would show the wrong day for every birth date in the database.

The date test pins both: `1990-01-15` renders as `15 มกราคม 2533`, and `02:30Z` renders as `09:30` on the same day.

## Tests

30 new web tests and 3 changed worker tests; 746 pass in total.

Portal (`tests/web/admin-portal.test.tsx`): nothing renders until the session resolves, and nothing renders at all if it is refused; the queue opens on the outstanding filter, shows a status in words, contains no personal detail beyond a name, changes filter, offers a retry on failure, and links with a real `href` so a row can be opened in a new tab; the detail asks for no citizen ID on load, fetches it only on request, reports one that cannot be decrypted, renders Bangkok/Buddhist dates, points the photo and receipt at the authenticated endpoints, translates the audit trail rather than showing raw event names, offers only the action the status allows, and surfaces an outstanding post-payment step with a retry; the confirmation page changes nothing on load, shows who and what, posts with the CSRF token, reports a partial result honestly, sends one request for two presses, says the work is already done for a stale link, and refuses an action the status does not allow; navigation walks queue → detail → back and reports both an unknown path and a malformed id without requesting it; storage stays empty including the CSRF token; the detail uses a definition list so each value is announced with its term.

API (`tests/worker/admin.test.ts`): the detail no longer contains the citizen ID and writes no access event; the new endpoint returns it and records one event per request; it requires Access; and it is included in both the "every endpoint requires Access" and "no `GET` changes state" sweeps.

## Security / privacy impact

High risk, as the issue states: this is the surface that shows an applicant's full record.

- Every page is behind Cloudflare Access, and the Worker verifies the token again on every request
- No page renders without a successful session call, so there is no partly-authenticated state
- The citizen ID is fetched only on request and audited per request; nothing else in the admin flow decrypts
- The queue exposes only a name beyond identifiers
- The photo and the receipt have no URL that works without Access
- Every state change is a `POST` carrying the CSRF token; no `GET` mutates
- Nothing is written to client storage, including the CSRF token — asserted

## Bundle size

Client: 420.52 KiB, 134.61 KiB gzipped (up 27.66 KiB for the portal). Worker: 3210.70 KiB / 860.95 KiB gzipped, up 0.52 KiB for the new endpoint.

## Gate

`format:check`, `lint`, `typecheck`, `test` (746), `build`, `check:worker:production` and `validate-repository.ps1` (193 tracked files) pass locally — **and the whole gate passes in a clean `git clone` + `npm ci`**, which is the check that caught the missing directory in #17 and is now part of my routine before pushing.
