### PR TITLE
feat: apply security headers and a strict CSP to every response

### DIFF
--- a/docs/security-privacy.md
+++ b/docs/security-privacy.md
@@ -21,6 +21,35 @@
 - R2 เป็น private; object keys เป็น random identifiers และไม่มี PII
 - Logs ใช้ allowlist ของ technical metadata ไม่ dump object/request/provider response
 - Receipt PDF สร้างใน memory และไม่เขียนลง storage; สิทธิ์ regenerate ต้องผ่าน admin authentication
+- ทุก response มี Content-Security-Policy ที่ `default-src 'none'` และ **ไม่มี `unsafe-inline`/`unsafe-eval`** ที่ `script-src` — ดูหัวข้อ Response headers ด้านล่าง
 - Retention และ deletion ต้องกำหนดก่อน production พร้อม audit trail ที่ไม่เก็บ payload ลับ
 
 ทุก PR ต้องระบุ security/privacy impact แม้คำตอบคือ “ไม่มี” พร้อมเหตุผลสั้น ๆ
+
+## Response headers
+
+`src/worker/security/headers.ts` ตั้ง header บนทุก response และ middleware อยู่ชั้นนอกสุดใน `src/worker/index.ts` จึงครอบทั้ง API, error และ static asset — policy ที่ครอบเฉพาะ path ที่มีคนจำได้ ไม่ใช่ policy
+
+Worker รันก่อน asset binding ทุก request (`run_worker_first: true`) เพื่อให้ตั้ง header บน HTML และ bundle ได้ ถ้าไม่ทำ เอกสารที่โหลด script จะเป็น response เดียวที่ไม่มี CSP
+
+### ทำไม CSP สำคัญกับระบบนี้เป็นพิเศษ
+
+CSRF protection ใน #8 (origin check + double-submit token) กัน cross-site request ได้ แต่ **ไม่กัน XSS** script ที่รันบน origin ของเราเองอ่าน cookie แล้วสร้าง header เองได้ ทำให้ทั้งสองด่านไม่มีผล และหน้าผู้จัดการแสดงเลขบัตรประชาชน ที่อยู่ และรูปสมาชิก XSS จึงเป็นทางเดียวที่เหลือไปถึงข้อมูลนั้น `script-src` ที่ไม่มี `unsafe-inline` และไม่มี `unsafe-eval` คือสิ่งที่ปิดทางนี้
+
+### จุดที่ต้องรู้ก่อนแก้ policy
+
+**inline style ของ React ไม่ถูกกระทบ** `style={{...}}` ถูกใช้ผ่าน CSSOM (`node.style.width = …`) และ CSP ควบคุม style _attribute_ กับ `<style>` ที่ parse จาก markup ไม่ใช่การเปลี่ยน style ด้วยโปรแกรม จึงใช้ `style-src 'self'` ได้โดยไม่ต้องยกเว้นให้ progress bar หรือกรอบ crop (ยืนยันในเบราว์เซอร์จริงแล้ว: `style.width` เป็น `11%` และไม่มี CSP violation)
+
+**Turnstile ต้องการแค่สองอย่าง** `script-src` และ `frame-src` ของ `https://challenges.cloudflare.com` ตามเอกสาร Cloudflare ไม่ต้องมี inline allowance
+
+**`camera=()` ปิดสนิท** ทั้งที่ wizard ถ่ายภาพ เพราะใช้ `<input type="file" capture>` ซึ่งส่งต่อให้แอปกล้องของระบบปฏิบัติการและไม่ต้องขอ permission ของเว็บ ต่างจาก `getUserMedia` ที่ระบบนี้ไม่ใช้เลย การเปิด feature นี้จะอนุญาตสิ่งที่ไม่มีใครต้องใช้
+
+**`blob:` ใน `img-src`** จำเป็น เพราะภาพบัตร ภาพใบหน้า และภาพสลิปถูกแสดงจาก blob URL — ก็เพราะมันไม่ออกจากเครื่องผู้ใช้
+
+### Cache-Control
+
+`no-store` เป็นค่าตั้งต้นเมื่อ response ไม่ได้เลือกค่าของตัวเอง ทุก API route ที่คืนข้อมูลส่วนบุคคลตั้งไว้ชัดเจนอยู่แล้ว และตัวนี้เป็นตัวรับท้าย: route ที่เพิ่มมาภายหลังแล้วลืมตั้ง จะเป็น private โดยปริยาย ไม่ใช่ cacheable โดยปริยาย static asset มี `Cache-Control` ของตัวเองจาก asset binding จึงไม่ถูกทับ
+
+### HSTS
+
+`max-age=63072000; includeSubDomains; preload` ส่งเฉพาะบน HTTPS การส่งบน plain HTTP เบราว์เซอร์ไม่สนใจ และจะปรากฏเฉพาะใน local development ซึ่งจะ pin `localhost` เป็น HTTPS ในเบราว์เซอร์ของผู้พัฒนาไปสองปี

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -7,6 +7,7 @@ import { ApiError, errorBody, statusForErrorCode } from './lib/http';
 import { createLogger } from './lib/logger';
 import { createProviders } from './providers';
 import { ValidationError, createSecurityServices, validationErrorBody } from './security';
+import { withSecurityHeaders } from './security/headers';
 import { PaymentRejectedError } from './services/payment';
 import { healthRoutes } from './routes/health';
 import { adminRoutes } from './routes/admin';
@@ -30,6 +31,21 @@ function resolveRequestId(header: string | undefined): string {
 }
 
 const app = new Hono<AppContext>();
+
+/**
+ * Security headers on every response.
+ *
+ * Outermost, so it covers an error response, an asset and an API answer alike -
+ * a policy that only applies to the paths someone remembered is not a policy.
+ * The Worker runs before the asset binding for every request (`run_worker_first`
+ * in `wrangler.jsonc`) precisely so this can wrap the HTML and the bundle too;
+ * without that, the document that loads the scripts would be the one response
+ * with no Content-Security-Policy on it.
+ */
+app.use('*', async (c, next) => {
+  await next();
+  c.res = withSecurityHeaders(c.res, c.req.raw);
+});
 
 /**
  * Per-request setup: correlation id, validated config, allowlisted logger and
@@ -72,12 +88,28 @@ app.route('/api', paymentRoutes);
 app.route('/api', webhookRoutes);
 app.route('/api', adminRoutes);
 
-/** API 404s must be JSON so the SPA fallback never masks a routing mistake. */
-app.notFound((c) => {
-  if (new URL(c.req.url).pathname.startsWith('/api/')) {
+/**
+ * Everything that is not an API route is the client application.
+ *
+ * The asset binding does the serving, including the single-page fallback, so a
+ * deep link like `/admin/applications/<id>` - which is what the manager's email
+ * contains - returns the document rather than a 404.
+ */
+app.all('*', async (c) => {
+  const path = new URL(c.req.url).pathname;
+
+  // An unknown API path must not fall through to the SPA: an HTML body with a
+  // 200 in place of a JSON 404 turns a routing mistake into a silent one.
+  if (path.startsWith('/api/')) {
     return c.json(errorBody('NOT_FOUND', 'ไม่พบปลายทางที่ร้องขอ', c.var.requestId), 404);
   }
-  return c.text('Not Found', 404);
+
+  return c.env.ASSETS.fetch(c.req.raw);
+});
+
+/** Reached only if the catch-all above is ever removed. */
+app.notFound((c) => {
+  return c.json(errorBody('NOT_FOUND', 'ไม่พบปลายทางที่ร้องขอ', c.var.requestId), 404);
 });
 
 app.onError((error, c) => {

--- a/src/worker/security/headers.ts
+++ b/src/worker/security/headers.ts
@@ -1,0 +1,167 @@
+/**
+ * Response headers applied to everything the Worker serves.
+ *
+ * The one that matters is the Content-Security-Policy, and the reason is
+ * specific rather than general. #8 protects the manager's actions with an origin
+ * check and a double-submit CSRF token, and both are defeated by script running
+ * on our own origin: injected script can read the cookie and set the header
+ * itself. So XSS is the single remaining path to the manager's actions and to the
+ * personal data on their screen, and a policy with no `unsafe-inline` and no
+ * `unsafe-eval` in `script-src` is what closes it.
+ *
+ * **React's inline styles are not affected.** `style={{...}}` is applied through
+ * the CSSOM (`node.style.width = …`), and CSP governs style *attributes* and
+ * `<style>` elements parsed from markup, not programmatic style changes. So
+ * `style-src 'self'` holds with no exception for the progress bar or the crop
+ * frame - which is why neither needed rewriting for this.
+ *
+ * The `camera` permission is denied outright, even though the wizard takes
+ * photographs. It uses `<input type="file" capture>`, which hands off to the
+ * operating system's own camera app and needs no web permission - unlike
+ * `getUserMedia`, which this deliberately does not use.
+ */
+
+export const TURNSTILE_ORIGIN = 'https://challenges.cloudflare.com';
+
+/**
+ * Two years, and `preload`. Long because the alternative is a window in which a
+ * first visit over plain HTTP can be intercepted, and this site handles an ID
+ * card. `includeSubDomains` because the Access-protected admin host is a
+ * subdomain of the same zone.
+ */
+const HSTS = 'max-age=63072000; includeSubDomains; preload';
+
+/**
+ * The policy, as directives.
+ *
+ * Each entry says why it is as wide as it is; anything not listed falls to
+ * `default-src 'none'`, so a resource type nobody thought about is denied rather
+ * than inherited from a permissive default.
+ */
+const CSP_DIRECTIVES: readonly string[] = [
+  // Deny by default. Every allowance below is deliberate.
+  "default-src 'none'",
+
+  // Our own bundle, plus the Turnstile challenge script. No `unsafe-inline` and
+  // no `unsafe-eval`: this is the directive the whole file exists for.
+  `script-src 'self' ${TURNSTILE_ORIGIN}`,
+
+  // The built stylesheet is a file, so `'self'` is enough. React's inline styles
+  // go through the CSSOM and are not covered by this.
+  "style-src 'self'",
+
+  // `blob:` for the previews the wizard makes of a card, a face crop and a slip -
+  // those never leave the device, so they can only be shown from a blob URL.
+  // `data:` for the favicon. `'self'` covers the member photo, which is streamed
+  // by the Worker rather than served from R2 directly.
+  "img-src 'self' blob: data:",
+
+  // Fonts are inside the bundle; nothing is fetched from a font service.
+  "font-src 'self'",
+
+  // The API, and Turnstile's own verification calls.
+  `connect-src 'self' ${TURNSTILE_ORIGIN}`,
+
+  // The Turnstile challenge renders in an iframe.
+  `frame-src ${TURNSTILE_ORIGIN}`,
+
+  // Nothing may frame this site. The NBTC confirmation page is one button that
+  // tells a member their registration is complete, and clickjacking it is
+  // exactly the attack `X-Frame-Options` was invented for.
+  "frame-ancestors 'none'",
+
+  // No `<base>` rewriting, and no plugins.
+  "base-uri 'none'",
+  "object-src 'none'",
+
+  // Forms post to the API only.
+  "form-action 'self'",
+
+  // Any mixed-content subresource is upgraded rather than silently blocked.
+  'upgrade-insecure-requests',
+];
+
+export const CONTENT_SECURITY_POLICY = CSP_DIRECTIVES.join('; ');
+
+/**
+ * Features denied outright.
+ *
+ * `camera` included: the wizard photographs a card and a face through
+ * `<input type="file" capture>`, which is the operating system's camera app and
+ * needs no web permission. Granting the feature would allow `getUserMedia`,
+ * which nothing here uses.
+ */
+export const PERMISSIONS_POLICY = [
+  'accelerometer=()',
+  'autoplay=()',
+  'camera=()',
+  'display-capture=()',
+  'encrypted-media=()',
+  'fullscreen=()',
+  'geolocation=()',
+  'gyroscope=()',
+  'magnetometer=()',
+  'microphone=()',
+  'midi=()',
+  'payment=()',
+  'publickey-credentials-get=()',
+  'screen-wake-lock=()',
+  'usb=()',
+  'xr-spatial-tracking=()',
+].join(', ');
+
+/** Headers every response carries, whatever it is. */
+export const BASE_SECURITY_HEADERS: Readonly<Record<string, string>> = {
+  'Content-Security-Policy': CONTENT_SECURITY_POLICY,
+  'X-Content-Type-Options': 'nosniff',
+  // `X-Frame-Options` as well as `frame-ancestors`, for the browsers that
+  // implement one and not the other.
+  'X-Frame-Options': 'DENY',
+  // Sends the origin but not the path cross-site. Application ids and reference
+  // numbers are in our paths, and a `Referer` carrying one to a third party
+  // would leak which application a person is looking at.
+  'Referrer-Policy': 'strict-origin-when-cross-origin',
+  'Permissions-Policy': PERMISSIONS_POLICY,
+  'Cross-Origin-Opener-Policy': 'same-origin',
+  'Cross-Origin-Resource-Policy': 'same-origin',
+  // Removes any hint about what runs this.
+  'X-Powered-By': '',
+};
+
+/**
+ * Applies the headers to a response, returning a new one.
+ *
+ * `Cache-Control` is set to `no-store` unless the response already chose its own
+ * value. Every API route that returns personal data sets it explicitly, and this
+ * is the backstop: a route added later that forgets is private by default rather
+ * than cacheable by default. Static assets opt out by carrying their own
+ * `Cache-Control`, which the asset binding sets.
+ *
+ * HSTS is only sent over HTTPS. Sending it on a plain-HTTP response is ignored
+ * by browsers and would only appear in local development, where it would then
+ * pin `localhost` to HTTPS in the developer's browser for two years.
+ */
+export function withSecurityHeaders(response: Response, request: Request): Response {
+  const headers = new Headers(response.headers);
+
+  for (const [name, value] of Object.entries(BASE_SECURITY_HEADERS)) {
+    if (value === '') headers.delete(name);
+    else headers.set(name, value);
+  }
+
+  if (new URL(request.url).protocol === 'https:') {
+    headers.set('Strict-Transport-Security', HSTS);
+  }
+
+  if (!headers.has('Cache-Control')) {
+    headers.set('Cache-Control', 'no-store');
+  }
+
+  // A new `Response` rather than mutating: a response from the asset binding has
+  // immutable headers, and assigning to them silently does nothing.
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}

--- a/src/worker/security/index.ts
+++ b/src/worker/security/index.ts
@@ -1,6 +1,7 @@
 export * from './access';
 export * from './context';
 export * from './csrf';
+export * from './headers';
 export * from './rate-limit';
 export * from './turnstile';
 export * from './validation';

--- a/tests/worker/security-headers.test.ts
+++ b/tests/worker/security-headers.test.ts
@@ -158,13 +158,19 @@ describe('routing', () => {
     expect(body.error.code).toBe('NOT_FOUND');
   });
 
-  it('serves the client application for a deep admin link', async () => {
-    // This is the shape of URL the manager notification email contains, so the
-    // single-page fallback has to answer it.
+  it('hands a deep admin link to the asset binding rather than answering it', async () => {
+    // This is the shape of URL the manager notification email contains, and the
+    // Worker's job is to delegate it so the single-page fallback resolves.
+    //
+    // Asserting a 200 would be asserting that `dist/client` was built, which is
+    // not what this change controls - and in CI the tests run before the build,
+    // so it would pass only on a machine that happened to have the artifacts.
+    // What is checked instead is that the Worker did not answer it itself.
     const response = await get('/admin/applications/11111111-2222-4333-8444-555555555555');
 
-    expect(response.status).toBe(200);
-    expect(response.headers.get('content-type')).toContain('text/html');
+    expect(response.headers.get('content-type') ?? '').not.toContain('application/json');
+    // The headers are applied to whatever the binding returns, built or not.
+    expect(response.headers.get('content-security-policy')).toBe(CONTENT_SECURITY_POLICY);
   });
 
   it('still serves the API through the Worker', async () => {

--- a/tests/worker/security-headers.test.ts
+++ b/tests/worker/security-headers.test.ts
@@ -1,0 +1,176 @@
+import { exports } from 'cloudflare:workers';
+import { describe, expect, it } from 'vitest';
+import { CONTENT_SECURITY_POLICY, TURNSTILE_ORIGIN } from '../../src/worker/security/headers';
+
+/**
+ * Security headers on real responses.
+ *
+ * Asserted on what the Worker actually returns rather than on the constants,
+ * because the whole point of the change is that the headers reach every kind of
+ * response - an API answer, an error, and the document that loads the scripts.
+ * A test that read the module and agreed with itself would pass with the
+ * middleware unwired.
+ */
+
+const ORIGIN = 'https://membership.example.test';
+
+async function get(path: string): Promise<Response> {
+  return exports.default.fetch(new Request(`${ORIGIN}${path}`));
+}
+
+/** Splits the policy into directives, so each can be checked on its own. */
+function directives(policy: string): Map<string, string[]> {
+  const parsed = new Map<string, string[]>();
+  for (const entry of policy.split(';')) {
+    const parts = entry.trim().split(/\s+/).filter(Boolean);
+    const name = parts.shift();
+    if (name) parsed.set(name, parts);
+  }
+  return parsed;
+}
+
+describe('every response', () => {
+  const paths = ['/api/health', '/api/config', '/api/does-not-exist', '/', '/admin'];
+
+  for (const path of paths) {
+    it(`carries the headers on ${path}`, async () => {
+      const response = await get(path);
+
+      expect(response.headers.get('content-security-policy')).toBe(CONTENT_SECURITY_POLICY);
+      expect(response.headers.get('x-content-type-options')).toBe('nosniff');
+      expect(response.headers.get('x-frame-options')).toBe('DENY');
+      expect(response.headers.get('referrer-policy')).toBe('strict-origin-when-cross-origin');
+      expect(response.headers.get('permissions-policy')).toContain('camera=()');
+      expect(response.headers.get('cross-origin-opener-policy')).toBe('same-origin');
+    });
+  }
+
+  it('sends HSTS over HTTPS', async () => {
+    const response = await get('/api/health');
+    const hsts = response.headers.get('strict-transport-security') ?? '';
+
+    expect(hsts).toContain('max-age=63072000');
+    expect(hsts).toContain('includeSubDomains');
+    expect(hsts).toContain('preload');
+  });
+
+  it('does not send HSTS over plain HTTP', async () => {
+    // Only reachable in local development, where it would pin `localhost` to
+    // HTTPS in the developer's browser for two years.
+    const response = await exports.default.fetch(new Request('http://localhost:8787/api/health'));
+
+    expect(response.headers.get('strict-transport-security')).toBeNull();
+  });
+
+  it('advertises nothing about what runs it', async () => {
+    const response = await get('/api/health');
+
+    expect(response.headers.get('x-powered-by')).toBeNull();
+  });
+});
+
+describe('the content security policy', () => {
+  const parsed = directives(CONTENT_SECURITY_POLICY);
+
+  it('denies by default', () => {
+    // Anything nobody thought about is denied rather than inheriting a
+    // permissive default.
+    expect(parsed.get('default-src')).toEqual(["'none'"]);
+  });
+
+  it('allows no inline or evaluated script', () => {
+    const scriptSrc = parsed.get('script-src') ?? [];
+
+    // This is the directive the whole file exists for: injected script on our
+    // own origin can read the CSRF cookie and set the header itself, which is
+    // the one way past the protection in #8.
+    expect(scriptSrc).not.toContain("'unsafe-inline'");
+    expect(scriptSrc).not.toContain("'unsafe-eval'");
+    expect(scriptSrc).toContain("'self'");
+  });
+
+  it('allows no inline style either', () => {
+    // React applies `style={{...}}` through the CSSOM, which CSP does not
+    // govern, so nothing in the interface needs this allowance.
+    const styleSrc = parsed.get('style-src') ?? [];
+
+    expect(styleSrc).toEqual(["'self'"]);
+    expect(CONTENT_SECURITY_POLICY).not.toContain('unsafe-inline');
+    expect(CONTENT_SECURITY_POLICY).not.toContain('unsafe-eval');
+  });
+
+  it('lets Turnstile load its script and its challenge frame', () => {
+    // Cloudflare documents exactly these two, and no inline allowance.
+    expect(parsed.get('script-src')).toContain(TURNSTILE_ORIGIN);
+    expect(parsed.get('frame-src')).toContain(TURNSTILE_ORIGIN);
+    expect(parsed.get('connect-src')).toContain(TURNSTILE_ORIGIN);
+  });
+
+  it('allows the blob previews the wizard makes without uploading them', () => {
+    // The card, the face crop and the slip are shown from blob URLs precisely
+    // because they never leave the device.
+    expect(parsed.get('img-src')).toContain('blob:');
+    expect(parsed.get('img-src')).toContain("'self'");
+  });
+
+  it('refuses to be framed', () => {
+    // The NBTC confirmation page is one button that tells a member their
+    // registration is complete.
+    expect(parsed.get('frame-ancestors')).toEqual(["'none'"]);
+  });
+
+  it('blocks plugins, base rewriting and foreign form targets', () => {
+    expect(parsed.get('object-src')).toEqual(["'none'"]);
+    expect(parsed.get('base-uri')).toEqual(["'none'"]);
+    expect(parsed.get('form-action')).toEqual(["'self'"]);
+  });
+
+  it('does not allow a script host beyond our own and Turnstile', () => {
+    const scriptSrc = parsed.get('script-src') ?? [];
+
+    expect(scriptSrc).toHaveLength(2);
+  });
+});
+
+describe('caching', () => {
+  it('marks an API response no-store', async () => {
+    const response = await get('/api/health');
+
+    expect(response.headers.get('cache-control')).toBe('no-store');
+  });
+
+  it('marks an unknown API path no-store as well', async () => {
+    // The backstop: a route added later that forgets to set it is private by
+    // default rather than cacheable by default.
+    const response = await get('/api/does-not-exist');
+
+    expect(response.headers.get('cache-control')).toBe('no-store');
+  });
+});
+
+describe('routing', () => {
+  it('answers an unknown API path with JSON, not the client application', async () => {
+    const response = await get('/api/nope');
+    const body = await response.json<{ error: { code: string } }>();
+
+    // An HTML body with a 200 would turn a routing mistake into a silent one.
+    expect(response.status).toBe(404);
+    expect(body.error.code).toBe('NOT_FOUND');
+  });
+
+  it('serves the client application for a deep admin link', async () => {
+    // This is the shape of URL the manager notification email contains, so the
+    // single-page fallback has to answer it.
+    const response = await get('/admin/applications/11111111-2222-4333-8444-555555555555');
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/html');
+  });
+
+  it('still serves the API through the Worker', async () => {
+    const response = await get('/api/health');
+    const body = await response.json<{ status: string }>();
+
+    expect(body.status).toBe('ok');
+  });
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -29,7 +29,7 @@
     "directory": "./dist/client",
     "binding": "ASSETS",
     "not_found_handling": "single-page-application",
-    "run_worker_first": ["/api/*"]
+    "run_worker_first": true
   },
   "vars": {
     "ENVIRONMENT": "development",


### PR DESCRIPTION
Closes #25

## Why this policy, specifically

#8 protects the manager's actions with an origin check and a double-submit CSRF token. Both are defeated by script running on our own origin: it reads the cookie and sets the header itself. So XSS was the one remaining path to the manager's actions and to the citizen ID, address and member photo on their screen — which is exactly what the issue says. A `script-src` with no `unsafe-inline` and no `unsafe-eval` is what closes it, and everything else here is the rest of the standard set.

`default-src 'none'` so that a resource type nobody thought about is denied rather than inheriting something permissive. Every allowance is annotated in `src/worker/security/headers.ts` with why it is as wide as it is.

## Three decisions worth reviewing

**`run_worker_first` is now `true`, not `["/api/*"]`.** Previously the Worker never saw a request for the HTML or the bundle — the asset binding answered them directly, so **the document that loads the scripts would have been the one response with no policy on it**. The Worker now sees every request and delegates non-API paths to `env.ASSETS`, which keeps the single-page fallback that makes a deep admin link from the manager's email resolve. The cost is a Worker invocation per asset request, which for one or two applications a day is not a consideration.

**`camera=()` denies the permission outright, even though the wizard photographs a card and a face.** It uses `<input type="file" capture>`, which hands off to the operating system's camera app and needs no web permission — unlike `getUserMedia`, which nothing here uses. Granting the feature would allow something no code asks for.

**`img-src` includes `blob:`.** The card, the face crop and the slip are previewed from blob URLs, which is a direct consequence of their never leaving the device. Without it the wizard would show broken images at exactly the steps where the applicant needs to check what they are about to submit.

## React's inline styles needed no exception, and I verified it rather than assuming

`style-src 'self'` with no `unsafe-inline` would normally break `style={{ width: '44%' }}` on the progress bar and the crop frame. It does not: React applies styles through the CSSOM (`node.style.width = …`), and CSP governs style *attributes* and `<style>` elements parsed from markup, not programmatic style changes.

I checked this in a real browser against the real policy rather than trusting the reasoning — `wrangler dev` with the built client, then reading the live document:

| | |
| --- | --- |
| progress bar `style.width` | `11%` |
| computed width | `56.9688px` |
| `<style>` elements in the document | 0 |
| stylesheets loaded | 1 (external, under `style-src 'self'`) |
| `blob:` image load | loaded |
| canvas encode (crop/downscale path) | works |
| console messages | none — no CSP violation |

Also confirmed live that the headers reach the HTML, the JS bundle, a deep admin link and an API response, that `Cache-Control` is `no-store` on the API and the binding's own value on assets, and that HSTS is absent over plain HTTP.

**What I could not verify: the Turnstile widget itself**, because there is no site key configured. The policy carries exactly the two sources Cloudflare documents (`script-src` and `frame-src` for `https://challenges.cloudflare.com`) plus `connect-src` for its verification calls, and their documentation states no inline allowance is required. This is the one acceptance criterion resting on documentation rather than on an observation, and it is worth a look on the first deploy with a real key.

## `Cache-Control: no-store` as a default, not a rule

Every API route returning personal data already sets it. This is the backstop: a route added later that forgets is private by default rather than cacheable by default. A response that chose its own value keeps it, which is how static assets retain the binding's `public, max-age=0, must-revalidate`.

## HSTS only over HTTPS

`max-age=63072000; includeSubDomains; preload`. Sent only when the request was HTTPS — on plain HTTP browsers ignore it, and the only place it would ever appear is local development, where it would pin `localhost` to HTTPS in a developer's browser for two years.

## A test that was asserting the wrong thing

My first version of the deep-link test expected a 200 from `/admin/applications/<id>`, which is really an assertion that `dist/client` had been built. CI runs the tests before the build, so it passed only on a machine that already had the artifacts — the same shape of failure as #17, and caught the same way, by cloning the branch and running the gate. It now asserts what the Worker actually controls: that a non-API path is delegated rather than answered with the API's JSON error, and that the headers are applied to whatever comes back. That holds with or without a build.

## Tests

21 new tests; 767 pass in total.

- the full header set on an API response, an API 404, the document, `/admin`, and `/api/config`
- HSTS present over HTTPS and absent over HTTP
- `X-Powered-By` removed
- the policy parsed into directives: `default-src 'none'`; `script-src` free of `unsafe-inline` and `unsafe-eval` and limited to exactly two sources; `style-src` exactly `'self'`; no `unsafe-*` anywhere in the whole policy; Turnstile's script, frame and connect sources present; `blob:` in `img-src`; `frame-ancestors 'none'`; `object-src`, `base-uri` and `form-action` locked down
- `no-store` on an API response and on an unknown API path
- an unknown API path answered with JSON rather than the SPA, and a non-API path delegated to the binding

Verified by mutation: disabling the middleware fails 8 of them.

## Security / privacy impact

High risk, as the issue states — this is the control that keeps the CSRF protection and the access controls meaningful.

- No `unsafe-inline` and no `unsafe-eval` anywhere in the policy, not only in `script-src`
- The policy is applied by the outermost middleware, so it covers errors, assets and API answers alike
- `frame-ancestors 'none'` and `X-Frame-Options: DENY` both set, for the browsers that implement one and not the other
- `Referrer-Policy: strict-origin-when-cross-origin`, because application ids and reference numbers are in our paths
- `no-store` as the default for anything that did not choose otherwise
- No CSP reporting endpoint, per the issue's non-goals

## Bundle size

3214.48 KiB, 862.20 KiB gzipped — up 3.78 KiB.

## Gate

`format:check`, `lint`, `typecheck`, `test` (767), `build`, `check:worker:production` and `validate-repository.ps1` (195 tracked files) pass locally, and the whole gate passes in a clean `git clone` + `npm ci`.
