### PR TITLE
chore: reduce Worker PDF bundle overhead

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -110,6 +110,12 @@ Pipeline ประกอบด้วยสาม workflow
 
 8. Wrangler ติดตั้ง production Cron `17 19 * * *` UTC สำหรับ retention ตาม `docs/retention-policy.md`
 
+### Worker bundle policy
+
+Wrangler minify Worker bundle และอัปโหลด source map แยกให้ Cloudflare เพื่อให้ production exception ยังวิเคราะห์ได้โดยไม่เพิ่ม source map ใน Worker module หรือเปิดเป็น public asset
+
+ใบสำคัญรับเงินใช้เฉพาะฟอนต์ Sarabun ที่อยู่ใน repository และวาดเฉพาะข้อความกับเส้น จึง alias optional dependency ของ pdf-lib สองรายการออกจาก runtime bundle ได้แก่ built-in Latin font metrics และ PNG decoder ทั้งสอง alias ชี้ไปที่ guard ที่ throw อย่างชัดเจน หากเพิ่ม built-in font หรือรูป PNG ในเอกสารภายหลัง ต้องเอา alias ที่เกี่ยวข้องออก ทบทวนขนาด bundle และรัน receipt tests ก่อน deploy
+
 ## First production deployment
 
 การ deploy production ครั้งแรกจาก repository สำเร็จเมื่อ `2026-08-21T07:53:34Z` โดยมีหลักฐานที่ไม่เปิดเผย secret หรือ PII ดังนี้

--- a/src/worker/lib/pdf/png-disabled.ts
+++ b/src/worker/lib/pdf/png-disabled.ts
@@ -1,0 +1,17 @@
+/**
+ * Runtime guard for pdf-lib's unused PNG support.
+ *
+ * Receipts intentionally contain text and vector rules only. pdf-lib otherwise
+ * bundles a PNG/APNG decoder even though no receipt calls `embedPng`. Keeping a
+ * throwing implementation makes a future image addition fail visibly until
+ * the Wrangler alias is deliberately removed and the bundle cost is reviewed.
+ */
+
+const unsupported = (): never => {
+  throw new Error('PNG embedding is disabled for receipt PDFs');
+};
+
+export default Object.freeze({
+  decode: unsupported,
+  toRGBA8: unsupported,
+});

--- a/src/worker/lib/pdf/standard-fonts-disabled.ts
+++ b/src/worker/lib/pdf/standard-fonts-disabled.ts
@@ -1,0 +1,48 @@
+/**
+ * Runtime guard for pdf-lib's unused standard-font support.
+ *
+ * The receipt always embeds Sarabun because PDF's built-in fonts cannot encode
+ * Thai. pdf-lib imports the metrics for all 14 built-in fonts eagerly even when
+ * none is embedded, so Wrangler aliases that package to this small module.
+ * Keep the names because pdf-lib inspects them while loading; the first actual
+ * attempt to embed one fails explicitly instead of producing a broken receipt.
+ */
+
+export const FontNames = Object.freeze({
+  Courier: 'Courier',
+  CourierBold: 'Courier-Bold',
+  CourierOblique: 'Courier-Oblique',
+  CourierBoldOblique: 'Courier-BoldOblique',
+  Helvetica: 'Helvetica',
+  HelveticaBold: 'Helvetica-Bold',
+  HelveticaOblique: 'Helvetica-Oblique',
+  HelveticaBoldOblique: 'Helvetica-BoldOblique',
+  TimesRoman: 'Times-Roman',
+  TimesRomanBold: 'Times-Bold',
+  TimesRomanItalic: 'Times-Italic',
+  TimesRomanBoldItalic: 'Times-BoldItalic',
+  Symbol: 'Symbol',
+  ZapfDingbats: 'ZapfDingbats',
+});
+
+const unsupported = (): never => {
+  throw new Error('Built-in PDF fonts are disabled; embed a vendored Thai-capable font instead');
+};
+
+const disabledEncoding = Object.freeze({
+  canEncodeUnicodeCodePoint: unsupported,
+  encodeUnicodeCodePoint: unsupported,
+  supportedCodePoints: [] as number[],
+});
+
+export const Encodings = Object.freeze({
+  Symbol: disabledEncoding,
+  ZapfDingbats: disabledEncoding,
+  WinAnsi: disabledEncoding,
+});
+
+export class Font {
+  static load(): never {
+    return unsupported();
+  }
+}

--- a/tests/worker/receipt.test.ts
+++ b/tests/worker/receipt.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from 'vitest';
 import fontkit from '@pdf-lib/fontkit';
 import { PDFDocument } from 'pdf-lib';
 import { THAI_FONT_BYTES } from '../../src/worker/lib/pdf/fonts';
+import disabledPng from '../../src/worker/lib/pdf/png-disabled';
 import { renderReceiptPdf } from '../../src/worker/lib/pdf/receipt';
+import { Font as DisabledStandardFont } from '../../src/worker/lib/pdf/standard-fonts-disabled';
 import { createAuditLog } from '../../src/worker/services/audit';
 import { createNumberingService } from '../../src/worker/services/numbering';
 import { createReceiptService } from '../../src/worker/services/receipt';
@@ -192,6 +194,14 @@ describe('renderReceiptPdf', () => {
     await expect(
       renderReceiptPdf({ ...data, amountBaht: '2,000.00', membershipLabel: 'สมาชิกสามัญตลอดชีพ' }),
     ).resolves.toBeDefined();
+  });
+
+  it('fails closed if a future receipt tries to use a built-in PDF font', () => {
+    expect(() => DisabledStandardFont.load()).toThrow(/built-in PDF fonts/i);
+  });
+
+  it('fails closed if a future receipt tries to embed a PNG', () => {
+    expect(() => disabledPng.decode()).toThrow(/PNG embedding is disabled/i);
   });
 });
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -16,6 +16,20 @@
   "main": "src/worker/index.ts",
   "compatibility_date": "2026-08-01",
   "compatibility_flags": ["nodejs_compat"],
+  // Minification materially reduces cold-start parsing. Upload the source map
+  // separately so production exceptions remain diagnosable without putting
+  // the map in the Worker module or exposing it as a public asset.
+  "minify": true,
+  "upload_source_maps": true,
+  // pdf-lib imports its built-in Latin font metrics and PNG decoder even
+  // though the receipt uses only vendored Sarabun TTF fonts and no images.
+  // Replace those optional paths with fail-closed guards so they do not add
+  // cold-start weight. Receipt tests prove both guards and the supported Thai
+  // path; remove an alias before adding the corresponding feature.
+  "alias": {
+    "@pdf-lib/standard-fonts": "./src/worker/lib/pdf/standard-fonts-disabled.ts",
+    "@pdf-lib/upng": "./src/worker/lib/pdf/png-disabled.ts"
+  },
   // The receipt PDF embeds a Thai font, which has to reach the Worker as bytes.
   // Without this rule the .ttf import is treated as text and the font is
   // corrupted in a way that only shows up as unreadable output.


### PR DESCRIPTION
## Outcome

Reduces the production Worker upload from **3,236.92 KiB / 863.28 KiB gzip** to **1,882.33 KiB / 641.22 KiB gzip** while preserving the existing Thai receipt path.

That is a reduction of **1,354.59 KiB (41.9%) raw** and **222.06 KiB (25.7%) gzip**. The emitted Worker module itself falls from 3,134,585 to 1,747,479 bytes.

## Changes

- enable Wrangler minification and upload source maps separately for production diagnostics
- alias pdf-lib's unused built-in Latin-font metrics and PNG decoder to small fail-closed runtime guards
- retain `@pdf-lib/fontkit` and vendored Sarabun subsetting/shaping unchanged
- add tests for both guards and document how to re-enable either optional feature safely

## Why this is safe

The receipt draws only text and vector rules. It embeds Sarabun TTF fonts because PDF built-in fonts cannot encode Thai, and it embeds no PNG. Existing receipt tests still verify Thai shaping, parseability, metadata, byte-identical regeneration, font subsetting, every required field, Buddhist-era dates, both membership amounts and non-persistence.

If a future document tries to use a built-in PDF font or PNG, the corresponding guard throws a specific error instead of silently producing an incomplete document. Removing an alias then requires a deliberate bundle-size review.

## Verification

- `npm ci` — pass; npm 11.17.0, 0 vulnerabilities
- `pwsh -NoLogo -NoProfile -File ./scripts/validate-repository.ps1` — pass; 205 tracked files
- `npm run lint` — pass
- `npm run format:check` — pass
- `npm run typecheck` — pass
- `npm test` — pass; 35 files / 775 tests
- `npm run build` — pass; development Worker 1,882.33 KiB / 641.22 KiB gzip
- `npm run check:worker:production` — pass; production bindings resolved, same bundle size
- receipt-focused suite — pass; 29 tests
- executable alias smoke — pass; the production-style aliased bundle generated a parseable 12,818-byte Thai receipt

## Security and privacy

- No secret, credential, PII, provider payload, ID-card image or payment-slip image is used or included.
- Receipt PDFs remain in memory and are not persisted.
- Source maps are uploaded privately to Cloudflare rather than emitted as public assets.
- This changes deployment configuration, so the PR remains Draft pending human review under `AGENTS.md`.

## Deployment / rollback

Deployment uses the existing `main` pipeline. D1/R2 schema and data are unchanged. Rollback is a normal revert of this commit; removing `minify`, `upload_source_maps` and the two aliases restores the previous bundle behavior.

## Handoff

- Completed: implementation, fail-closed tests, full verification, before/after metafile measurement and documentation.
- Remaining: human review, mark ready, merge, approve the protected production deployment and confirm the health smoke test.
- Files changed: `wrangler.jsonc`, two guards under `src/worker/lib/pdf/`, receipt tests and `docs/deployment.md`.
- Risk: any future receipt feature using a built-in font or PNG must remove the relevant alias first; the guard tests make that failure explicit.
- Next safe action: review the config aliases and benchmark evidence, then mark ready and merge.

Closes #36

