### PR TITLE
fix: stop Android forcing the camera when choosing an image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ Thumbs.db
 .vscode/*
 !.vscode/extensions.json
 !.vscode/settings.json
+
+# A tool on Windows expanded `%SystemDrive%` as a literal path once and left a
+# copy of Windows' own cache files under the repository root. Ignored so a
+# `git add -A` cannot commit them; the directory itself is safe to delete.
+/%SystemDrive%/

--- a/src/web/components/ImagePicker.tsx
+++ b/src/web/components/ImagePicker.tsx
@@ -9,22 +9,24 @@ import type { ReactNode } from 'react';
  * reachable, announces itself correctly, and works when scripting is partly
  * broken. A `<button>` driving a hidden input has to reimplement all three.
  *
- * `capture="environment"` asks a phone for the rear camera, which is what you
- * point at a card or a slip. It is a hint - a desktop browser ignores it and
- * opens the file picker, which is the right behaviour there.
+ * **There is deliberately no `capture` attribute.** An earlier version set it,
+ * on the belief that it merely hints at the rear camera. On Android Chrome it
+ * does not hint: it opens the camera and removes the album and file options
+ * altogether. That broke the step it mattered most on - a payment slip is
+ * usually already a screenshot in the album, so an applicant on Android could
+ * not submit one at all. Without the attribute the operating system offers the
+ * camera, the album and the files, and the applicant picks.
  */
 
 export interface ImagePickerProps {
   label: string;
   hint?: ReactNode;
-  /** `environment` for documents; omit to let the applicant pick any file. */
-  capture?: 'environment' | 'user';
   disabled?: boolean;
   onSelect: (file: File) => void;
   error?: string | undefined;
 }
 
-export function ImagePicker({ label, hint, capture, disabled, onSelect, error }: ImagePickerProps) {
+export function ImagePicker({ label, hint, disabled, onSelect, error }: ImagePickerProps) {
   const id = useId();
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -41,7 +43,6 @@ export function ImagePicker({ label, hint, capture, disabled, onSelect, error }:
         className="vra-picker__input"
         type="file"
         accept="image/jpeg,image/png,image/webp"
-        {...(capture ? { capture } : {})}
         disabled={disabled}
         aria-invalid={error ? true : undefined}
         onChange={(event) => {

--- a/src/web/steps/CardStep.tsx
+++ b/src/web/steps/CardStep.tsx
@@ -30,8 +30,13 @@ export function CardStep({ busy, error, onSelect, onManualEntry, turnstileSlot }
         </Alert>
       ) : null}
 
+      <p className="vra-muted">
+        ใช้ภาพที่มีอยู่แล้วในเครื่องก็ได้ หรือถ่ายใหม่ก็ได้ — เมื่อกดเลือกไฟล์
+        เครื่องของท่านจะให้เลือกได้ทั้งกล้อง อัลบั้ม และไฟล์
+      </p>
+
       <ol className="vra-tips">
-        <li>วางบัตรบนพื้นเรียบสีเข้ม ถ่ายจากด้านบนตรง ๆ</li>
+        <li>ถ้าถ่ายใหม่ วางบัตรบนพื้นเรียบสีเข้ม ถ่ายจากด้านบนตรง ๆ</li>
         <li>ให้เห็นบัตรทั้งใบ ไม่มีนิ้วบังตัวเลข</li>
         <li>หลีกเลี่ยงแสงสะท้อนบนบัตร</li>
       </ol>
@@ -39,7 +44,6 @@ export function CardStep({ busy, error, onSelect, onManualEntry, turnstileSlot }
       <ImagePicker
         label="เลือกหรือถ่ายภาพด้านหน้าบัตรประชาชน"
         hint="ระบบใช้ภาพนี้เพื่ออ่านข้อมูลเท่านั้น และไม่เก็บภาพบัตรไว้"
-        capture="environment"
         disabled={busy}
         onSelect={onSelect}
       />

--- a/src/web/steps/PaymentStep.tsx
+++ b/src/web/steps/PaymentStep.tsx
@@ -94,7 +94,7 @@ export function PaymentStep({
 
       <ImagePicker
         label="เลือกภาพสลิปการโอนเงิน"
-        capture="environment"
+        hint="ใช้ภาพหน้าจอ (screenshot) จากแอปธนาคารได้เลย ไม่ต้องถ่ายใหม่"
         disabled={busy || reading}
         onSelect={onSlipSelected}
       />

--- a/src/web/steps/PhotoStep.tsx
+++ b/src/web/steps/PhotoStep.tsx
@@ -102,8 +102,7 @@ export function PhotoStep({
       {state.photoSource === 'UPLOAD' ? (
         <ImagePicker
           label="เลือกหรือถ่ายรูปใหม่"
-          hint="ถ่ายหน้าตรง เห็นใบหน้าชัด ฉากหลังเรียบ"
-          capture="user"
+          hint="ใช้รูปที่มีอยู่แล้วได้ ขอให้เห็นหน้าตรง ใบหน้าชัด ฉากหลังเรียบ"
           disabled={busy}
           onSelect={onUpload}
         />

--- a/tests/web/wizard.test.tsx
+++ b/tests/web/wizard.test.tsx
@@ -133,6 +133,51 @@ describe('the privacy notice', () => {
   });
 });
 
+describe('choosing an image', () => {
+  it('never sets the capture attribute, so the album stays available', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByRole('button', { name: 'เริ่มสมัครสมาชิก' }));
+
+    // On Android Chrome `capture` opens the camera and removes the album and
+    // file options. A payment slip is usually already a screenshot, so the
+    // attribute made that step impossible to complete on Android.
+    const inputs = document.querySelectorAll('input[type="file"]');
+    expect(inputs.length).toBeGreaterThan(0);
+    for (const input of inputs) {
+      expect(input.hasAttribute('capture')).toBe(false);
+    }
+  });
+
+  it('still accepts a file that was chosen', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByRole('button', { name: 'เริ่มสมัครสมาชิก' }));
+
+    const input = document.querySelector<HTMLInputElement>('input[type="file"]')!;
+    await user.upload(
+      input,
+      new File([new Uint8Array([0xff, 0xd8, 0xff])], 'card.jpg', {
+        type: 'image/jpeg',
+      }),
+    );
+
+    // The OCR call is what proves the selection reached the wizard.
+    await waitFor(() => expect(calls.some((call) => call.url === '/api/ocr')).toBe(true));
+  });
+
+  it('says an existing photo is fine', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByRole('button', { name: 'เริ่มสมัครสมาชิก' }));
+
+    expect(screen.getByText(/ใช้ภาพที่มีอยู่แล้วในเครื่องก็ได้/)).toBeInTheDocument();
+  });
+});
+
 describe('the card step', () => {
   it('offers manual entry before anything has failed', async () => {
     const user = userEvent.setup();


### PR DESCRIPTION
Closes #46

## What was wrong

`ImagePicker` set `capture` on its `<input type="file">`, and the comment I wrote beside it said the attribute "is a hint — a desktop browser ignores it and opens the file picker". The first half is true on a desktop and **wrong on a phone**: on Android Chrome `capture` opens the camera and removes the album and file options altogether.

It broke the step it mattered most on. A payment slip is almost always already a screenshot from a banking app, so an applicant on Android **could not submit one at all** — short of photographing another screen, which makes the QR harder to read and pushes them onto the image fallback. That is the opposite of the design: the browser is supposed to read the QR so the slip never leaves the device (Issue #1 §18). So the bug did not just annoy people, it worked against the privacy property the payment step exists to protect.

The member photo (`capture="user"`) and the ID card (`capture="environment"`) were hurt the same way, less severely — people often have a suitable photo or a scan already.

## The fix

The attribute is gone from all three uses, and the `capture` prop is gone from `ImagePicker` so it cannot be added back without meaning to. Without it the operating system offers the camera, the album and the files, and the applicant chooses.

The copy now matches what is actually possible, which it did not before:

- the card step says an existing photo is fine and that the chooser offers camera, album and files, and its tips are prefixed "ถ้าถ่ายใหม่" instead of reading as instructions for taking one
- the payment step says a screenshot from the banking app can be used directly — this is the one people needed told
- the photo step says an existing picture is fine

The comment in `ImagePicker` now records what the attribute really does on Android, so the next person does not reintroduce it on the same reasoning I used.

## Tests

3 new; 778 pass in total.

- every `<input type="file">` in the wizard has no `capture` attribute — verified by mutation: putting it back fails this test
- a chosen file still reaches the wizard (asserted through the OCR call it triggers), so removing the attribute did not break selection
- the card step tells the applicant an existing photo is fine

## Security / privacy impact

No downside, and an indirect improvement. Letting an applicant pick the screenshot they already have puts them back on the primary path, where the browser decodes the QR and only the payload is sent — instead of being forced onto the fallback that uploads the slip image.

`Permissions-Policy: camera=()` from #25 is unaffected and still correct: a file input hands off to the operating system's camera app and needs no web permission, which is why the policy could deny the feature in the first place.

## Also in this commit

`.gitignore` now ignores `/%SystemDrive%/`. A tool on Windows expanded the variable literally at some point and left a copy of Windows' own cache files under the repository root — a `git add -A` was about to commit five `.db` files from `ProgramData/Microsoft/Windows/Caches`. Ignored rather than deleted, since they are not mine to remove; the directory is safe to delete by hand.

## Gate

`format:check`, `lint`, `typecheck`, `test` (778 across both projects) and `validate-repository.ps1` (212 tracked files) all pass.

## What I could not verify

Android itself. The behaviour is well documented and the attribute is now absent, which is the whole mechanism — but the confirmation that the album and file options are back has to come from a real device. Worth a check on your phone at the payment step.
