### PR TITLE
fix: send iApp OCR image with a valid multipart filename

### DIFF
--- a/src/worker/providers/iapp/index.ts
+++ b/src/worker/providers/iapp/index.ts
@@ -36,6 +36,29 @@ const FRONT_ENDPOINT = 'https://api.iapp.co.th/v3/store/ekyc/thai-national-id-ca
 const REQUEST_TIMEOUT_MS = 20_000;
 
 /**
+ * Gives the multipart part a neutral filename whose extension agrees with the
+ * validated content type. The original client filename is deliberately not
+ * available at this boundary: it may contain personal information, while some
+ * provider upload pipelines still use the extension to select an image
+ * decoder even when the part also has a Content-Type header.
+ */
+function multipartFilename(contentType: string): string {
+  switch (contentType) {
+    case 'image/jpeg':
+      return 'front.jpg';
+    case 'image/png':
+      return 'front.png';
+    case 'image/webp':
+      return 'front.webp';
+    default:
+      // The OCR route rejects unsupported magic bytes before this adapter is
+      // called. Keep an explicit non-image fallback so a future caller cannot
+      // make arbitrary bytes look like a JPEG merely through its filename.
+      return 'front.bin';
+  }
+}
+
+/**
  * Maps iApp HTTP status codes onto internal failure reasons.
  *
  * Anything unlisted becomes `PROVIDER_ERROR`, so a new code from the provider
@@ -170,7 +193,11 @@ export function createIappOcrProvider(options: IappOcrOptions): OcrProvider {
       // `get_bbox`, `get_image` and `get_original` are all left off: bounding
       // boxes and extra crops are data with no purpose here, and asking for
       // less is one fewer thing that could be stored by accident.
-      body.append('file', new Blob([image.bytes], { type: image.contentType }), 'front');
+      body.append(
+        'file',
+        new Blob([image.bytes], { type: image.contentType }),
+        multipartFilename(image.contentType),
+      );
 
       const timeout = AbortSignal.timeout(timeoutMs);
       let response: Response;

--- a/tests/unit/iapp-ocr.test.ts
+++ b/tests/unit/iapp-ocr.test.ts
@@ -236,11 +236,40 @@ describe('createIappOcrProvider', () => {
       const request = calls[0]!;
       expect(request.method).toBe('POST');
       expect(request.headers.get('apikey')).toBe('test-only-key');
+      expect(request.headers.get('content-type')).toMatch(/^multipart\/form-data; boundary=/);
       const form = await request.formData();
-      expect(form.get('file')).toBeInstanceOf(Blob);
+      const file = form.get('file');
+      expect(file).toBeInstanceOf(File);
+      if (!(file instanceof File)) throw new Error('expected multipart file');
+      expect(file.name).toBe('front.jpg');
+      expect(file.type).toBe('image/jpeg');
+      expect(new Uint8Array(await file.arrayBuffer())).toEqual(image.bytes);
       // Extra crops and bounding boxes are data with no purpose here, so they
       // are not requested at all.
       expect(form.get('options')).toBeNull();
+    } finally {
+      restore();
+    }
+  });
+
+  it.each([
+    ['image/jpeg', 'front.jpg'],
+    ['image/png', 'front.png'],
+    ['image/webp', 'front.webp'],
+  ])('matches the neutral upload filename to %s', async (contentType, expectedFilename) => {
+    const { provider, calls, restore } = providerWith(
+      () => new Response(JSON.stringify(IAPP_RESPONSE), { status: 200 }),
+    );
+
+    try {
+      await provider.readThaiIdCardFront({ ...image, contentType });
+
+      const form = await calls[0]!.formData();
+      const file = form.get('file');
+      expect(file).toBeInstanceOf(File);
+      if (!(file instanceof File)) throw new Error('expected multipart file');
+      expect(file.name).toBe(expectedFilename);
+      expect(file.type).toBe(contentType);
     } finally {
       restore();
     }


### PR DESCRIPTION
## Linked Issue

Refs #50
Refs #19

## Outcome

Corrects the iApp OCR multipart transport so the generated neutral upload filename carries an extension that matches the validated MIME type. Production evidence shows the current Worker request reaches iApp but receives HTTP 500, while a direct upload of the same image returns HTTP 200. The missing extension is the concrete request-contract difference identified in the adapter.

Issue #50 remains open until the owner confirms the same card succeeds in production; this PR does not claim live verification from mocked tests.

## Scope

- Changed: iApp multipart filename generation and transport regression tests.
- Explicitly not changed: endpoint, API-key handling, OCR response mapping, image lifecycle, logging, client upload behavior, or production secrets.

## Verification

| Command / check | Result |
| --- | --- |
| `npm ci` | Pass — 280 packages, 0 vulnerabilities |
| `npm test -- tests/unit/iapp-ocr.test.ts` | Pass — 39 tests |
| `npm run lint` | Pass |
| `npm run format:check` | Pass |
| `npm run typecheck` | Pass |
| `npm test` | Pass — 36 files, 795 tests |
| `npm run build` | Pass |
| `npm run check:worker:production` | Pass — production dry-run |
| `pwsh -NoLogo -NoProfile -File ./scripts/validate-repository.ps1` | Pass — 215 tracked files |

## Security and privacy

- [x] No secrets, real PII, ID-card images, payment-slip images, or raw provider responses are included.
- [x] Logs contain only allowlisted technical metadata; this change adds no logging.
- [x] Tests use synthetic bytes and a mocked provider.
- [x] OCR handles a full ID-card image and is high risk; human review is required before merge/deploy.

Impact and mitigations:

The adapter still receives only in-memory bytes and discards them after the provider request. It generates `front.jpg`, `front.png`, or `front.webp` from the server-validated MIME rather than forwarding the applicant''s original filename, which avoids leaking filename metadata. Unsupported types use `front.bin` instead of being mislabeled as an image.

## Deployment / migration / rollback

No migration or configuration change. Deployment follows the existing GitHub Deploy workflow after reviewed merge. Rollback is a Worker version rollback to the preceding production version. The owner must then retest with the same image without posting the image or response payload to GitHub.

## UI evidence

Not applicable: server-side multipart transport only.

## Human / AI handoff

- Completed: implemented MIME-matched neutral filenames; added assertions for multipart boundary, API-key header, filename, MIME, bytes, and absence of unnecessary options; all local gates pass.
- Remaining: obtain human review, merge/deploy, and owner production verification.
- Changed paths: `src/worker/providers/iapp/index.ts`, `tests/unit/iapp-ocr.test.ts`.
- Commands and results: recorded in the verification table above.
- Risks / assumptions: the missing filename extension is the strongest observed request difference, but only a production retest can prove it is the provider''s 500 trigger. A successful HTTP 200 may expose a separate live response-mapping mismatch tracked by #19.
- Next safe action: review the transport diff and CI results; do not merge until the high-risk human review is explicit.
