### PR TITLE
fix: enter awaiting-payment state before slip verification

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -156,6 +156,8 @@ COMPLETED, CANCELLED and REFUNDED are terminal
 - **Idempotent** การขอสถานะที่เป็นอยู่แล้วเป็น no-op ไม่บันทึก audit event ซ้ำ และไม่ทำ side effect ซ้ำ
 - **Concurrency-safe** การเขียนเป็น compare-and-set บนสถานะที่อ่านมาจริง ไม่ใช่บนชุด predecessor ทั้งหมด เพื่อให้ `from` ใน audit event เป็นค่าที่เคยเป็นจริงเสมอ
 
+การยืนยันประเภทสมาชิกเป็นจุดที่ application service บันทึกยอดจาก catalogue แล้วเปลี่ยน `DRAFT -> AWAITING_PAYMENT` ผ่าน state machine ก่อนคืนหน้า payment ทำให้หน้าที่ผู้สมัครเห็นกับสถานะที่ payment service ตรวจเป็นสัญญาเดียวกัน สำหรับใบสมัคร production เก่าที่เคยบันทึกประเภทสมาชิกแต่ขาด transition จากบั๊ก #55 การส่งสลิปครั้งถัดไปซ่อมเฉพาะสถานะ `DRAFT` รูปแบบนี้ผ่าน transition เดิม **ก่อน** เรียก provider; draft ที่ไม่มีประเภทสมาชิกและสถานะอื่นยัง fail closed เหมือนเดิม
+
 ## Numbering
 
 `VRA-{พ.ศ.}-{running}` และ `VRA-RC-{พ.ศ.}-{running}` โดย prefix และความยาว sequence เป็น config ปี พ.ศ. คำนวณจากเวลา Asia/Bangkok ไม่ใช่จากวัน UTC ใบสมัครที่ส่งเวลา 23:30 UTC ของวันที่ 31 ธันวาคม จึงได้เลขของปีถัดไป

--- a/src/worker/routes/applications.ts
+++ b/src/worker/routes/applications.ts
@@ -15,6 +15,7 @@ import {
   ACCESS_TOKEN_HEADER,
   createApplicationAccess,
 } from '../services/application-access';
+import { createStateMachine } from '../services/state-machine';
 import { buildApplicationWorkflow } from '../services/workflow-factory';
 
 /**
@@ -111,6 +112,7 @@ async function buildServices(env: AppContext['Bindings'], db: AppContext['Variab
     await createCitizenIdProtection(keyMaterial),
     access,
     createAuditLog(db),
+    createStateMachine(db),
   );
   return { access, service };
 }

--- a/src/worker/services/application.ts
+++ b/src/worker/services/application.ts
@@ -13,6 +13,7 @@ import type { AuditLog } from './audit';
 import { generateAccessToken } from './application-access';
 import type { ApplicationAccess } from './application-access';
 import { membershipPlan } from './membership';
+import type { StateMachine } from './state-machine';
 
 /**
  * Application lifecycle up to payment.
@@ -202,6 +203,7 @@ export function createApplicationService(
   protection: CitizenIdProtection,
   access: ApplicationAccess,
   audit: AuditLog,
+  stateMachine: StateMachine,
 ): ApplicationService {
   const requireEditable = async (applicationId: string): Promise<ApplicationRecord> => {
     const record = await db.applications.findById(applicationId);
@@ -280,6 +282,18 @@ export function createApplicationService(
         });
       }
 
+      if (input.address) {
+        validateAddress(input.address);
+        try {
+          await db.addresses.upsert(applicationId, toAddressRow(input.address));
+        } catch (error) {
+          // A CHECK violation here means a value the schema rejects, e.g. a
+          // malformed postcode that slipped past validation.
+          if (error instanceof UniqueConstraintError) throw error;
+          throw new ApiError('VALIDATION_FAILED', MESSAGES.mailPostcode, { cause: error });
+        }
+      }
+
       if (input.membershipType) {
         // Resolved from the catalogue. An amount from the client is not read at
         // all, so there is nothing to ignore.
@@ -291,17 +305,15 @@ export function createApplicationService(
           actorType: 'APPLICANT',
           metadata: { membershipType: plan.type, amountSatang: plan.amountSatang },
         });
-      }
 
-      if (input.address) {
-        validateAddress(input.address);
-        try {
-          await db.addresses.upsert(applicationId, toAddressRow(input.address));
-        } catch (error) {
-          // A CHECK violation here means a value the schema rejects, e.g. a
-          // malformed postcode that slipped past validation.
-          if (error instanceof UniqueConstraintError) throw error;
-          throw new ApiError('VALIDATION_FAILED', MESSAGES.mailPostcode, { cause: error });
+        // Confirming the plan is the applicant's explicit move into payment.
+        // Without this transition the UI can show bank instructions while the
+        // payment service still (correctly) refuses a DRAFT application.
+        const transition = await stateMachine.transition(applicationId, 'AWAITING_PAYMENT', {
+          actorType: 'APPLICANT',
+        });
+        if (transition.kind !== 'APPLIED' && transition.kind !== 'ALREADY_IN_TARGET_STATE') {
+          throw new ApiError('CONFLICT', MESSAGES.notEditable);
         }
       }
 

--- a/src/worker/services/payment.ts
+++ b/src/worker/services/payment.ts
@@ -156,9 +156,28 @@ export function createPaymentService(
 
   return {
     async verify(input) {
-      const application = await db.applications.findById(input.applicationId);
+      let application = await db.applications.findById(input.applicationId);
       if (!application) {
         throw new ApiError('NOT_FOUND', 'ไม่พบใบสมัครนี้ กรุณาเริ่มขั้นตอนใหม่');
+      }
+
+      // Compatibility repair for applications created before Issue #55. The
+      // old membership PATCH stored the server-resolved plan but forgot the
+      // DRAFT -> AWAITING_PAYMENT transition, leaving an applicant trapped on
+      // a payment page that could never accept their slip. Repair only that
+      // exact shape, through the normal state machine, before provider work.
+      const legacyDraftHasNoPayment =
+        application.status === 'DRAFT' &&
+        application.membershipType !== null &&
+        (await db.payments.findByApplicationId(input.applicationId)).length === 0;
+      if (legacyDraftHasNoPayment) {
+        await stateMachine.transition(input.applicationId, 'AWAITING_PAYMENT', {
+          actorType: 'APPLICANT',
+        });
+        application = await db.applications.findById(input.applicationId);
+        if (!application) {
+          throw new ApiError('NOT_FOUND', 'ไม่พบใบสมัครนี้ กรุณาเริ่มขั้นตอนใหม่');
+        }
       }
 
       // Refuse before calling the provider if a payment is not expected.

--- a/tests/worker/applications.test.ts
+++ b/tests/worker/applications.test.ts
@@ -272,10 +272,39 @@ describe('PATCH /api/applications/:id', () => {
     );
 
     await expect(
-      response.json<{ application: { membershipAmountSatang: number } }>(),
+      response.json<{ application: { membershipAmountSatang: number; status: string } }>(),
     ).resolves.toMatchObject({
-      application: { membershipAmountSatang: membershipPlan('LIFETIME').amountSatang },
+      application: {
+        membershipAmountSatang: membershipPlan('LIFETIME').amountSatang,
+        status: 'AWAITING_PAYMENT',
+      },
     });
+  });
+
+  it('moves into payment once and keeps membership changes idempotent there', async () => {
+    const created = await createApplication();
+
+    const first = await exports.default.fetch(
+      patchRequest(created.application.id, created.accessToken, { membershipType: 'FIVE_YEAR' }),
+    );
+    const second = await exports.default.fetch(
+      patchRequest(created.application.id, created.accessToken, { membershipType: 'LIFETIME' }),
+    );
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    await expect(second.json()).resolves.toMatchObject({
+      application: {
+        status: 'AWAITING_PAYMENT',
+        membershipAmountSatang: membershipPlan('LIFETIME').amountSatang,
+      },
+    });
+
+    const events = await repository().events.listByApplicationId(created.application.id);
+    const paymentTransitions = events.filter(
+      (event) => event.eventType === 'STATUS_CHANGED' && event.metadata?.to === 'AWAITING_PAYMENT',
+    );
+    expect(paymentTransitions).toHaveLength(1);
   });
 
   it('rejects a client-supplied amount instead of ignoring it', async () => {

--- a/tests/worker/payment.test.ts
+++ b/tests/worker/payment.test.ts
@@ -470,13 +470,55 @@ describe('a payment that is not expected', () => {
     expect(events.map((event) => event.eventType)).toContain('PAYMENT_PRESENTED_WHEN_NOT_EXPECTED');
   });
 
-  it('distinguishes not-yet-there from already-paid', async () => {
+  it('repairs a legacy draft whose server-resolved membership was already stored', async () => {
     const repo = repository();
-    // Still a draft: the applicant has not reached the payment step.
     const id = await seedApplication(repo);
     await repo.applications.setMembership(id, 'FIVE_YEAR', FIVE_YEAR_SATANG);
 
-    const error = await service(repo)
+    await expect(service(repo).verify({ applicationId: id, evidence: QR })).resolves.toMatchObject({
+      amountSatang: FIVE_YEAR_SATANG,
+    });
+    await expect(repo.applications.findById(id)).resolves.toMatchObject({
+      status: 'PAYMENT_VERIFIED',
+    });
+  });
+
+  it('repairs the legacy status before contacting the provider', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+    await repo.applications.setMembership(id, 'FIVE_YEAR', FIVE_YEAR_SATANG);
+
+    const error = await service(repo, { failWith: 'PROVIDER_TIMEOUT' })
+      .verify({ applicationId: id, evidence: QR })
+      .catch((reason: unknown) => reason);
+
+    expect((error as PaymentRejectedError).reason).toBe('PROVIDER_UNAVAILABLE');
+    await expect(repo.applications.findById(id)).resolves.toMatchObject({
+      status: 'AWAITING_PAYMENT',
+    });
+  });
+
+  it('does not repair an inconsistent draft that already has a recorded payment', async () => {
+    const repo = repository();
+    const id = await readyToPay(repo);
+    await service(repo).verify({ applicationId: id, evidence: QR });
+    await repo.applications.updateStatusIf(id, ['PAYMENT_VERIFIED'], 'DRAFT');
+
+    const error = await service(repo, {
+      transaction: { transactionRef: 'SECOND-TXN', receiverAccountDigits: '7890' },
+    })
+      .verify({ applicationId: id, evidence: QR })
+      .catch((reason: unknown) => reason);
+
+    expect((error as PaymentRejectedError).reason).toBe('ALREADY_PAID');
+    await expect(repo.payments.findByApplicationId(id)).resolves.toHaveLength(1);
+  });
+
+  it('still refuses a draft with no membership before contacting the provider', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+
+    const error = await service(repo, { failWith: 'SLIP_NOT_FOUND' })
       .verify({ applicationId: id, evidence: QR })
       .catch((reason: unknown) => reason);
 


### PR DESCRIPTION
## Linked Issue

Refs #55
Refs #19

## Production regression

The owner reached the payment page in production, attached a slip, and received `NOT_AWAITING_PAYMENT`. The wizard had stored the membership choice and displayed bank instructions, but the application service never performed `DRAFT -> AWAITING_PAYMENT`. Payment verification correctly failed closed before SlipOK, while tests had hidden the missing link by transitioning fixtures manually.

## Outcome

- Confirming `membershipType` now stores the server-resolved amount and transitions through the concurrency-safe state machine to `AWAITING_PAYMENT` before the payment page is returned.
- Re-selecting a plan while already awaiting payment remains editable and produces no duplicate status transition.
- A pre-fix production `DRAFT` with a membership type and no recorded payment is repaired through the same state machine on the next payment submission, before the provider is called. The currently affected browser session can therefore solve the refreshed Turnstile challenge and retry the same slip after deployment.
- A draft without membership, a draft with an existing payment, and every other unexpected state still fail before the provider.

## Verification

| Command / check | Result |
| --- | --- |
| `npm ci` | Pass — 280 packages, 0 vulnerabilities |
| Targeted application/payment tests | Pass — 2 files, 70 tests |
| `npm run lint` | Pass |
| `npm run format:check` | Pass |
| `npm run typecheck` | Pass |
| `npm test` | Pass — 36 files, 806 tests |
| `npm run build` | Pass — client and Worker dry run |
| `npm run check:worker:production` | Pass |
| `pwsh -NoLogo -NoProfile -File ./scripts/validate-repository.ps1` | Pass — 215 tracked files |

Regression coverage proves:

- Membership PATCH returns and persists `AWAITING_PAYMENT`.
- Changing the plan while awaiting payment records only one status transition.
- A synthetic legacy draft with a membership can verify a mocked payment and reach `PAYMENT_VERIFIED`.
- The repair happens before the provider call, because a mocked provider outage leaves the application safely in `AWAITING_PAYMENT` for retry.
- Drafts without membership remain rejected before a configured provider failure can surface.
- An inconsistent draft with a payment record is not repaired and is reported `ALREADY_PAID`, preventing a second payment.

## Security / privacy

High risk: this changes the payment state boundary and requires human review before merge/deploy.

The compatibility repair can only perform the already-allowed `DRAFT -> AWAITING_PAYMENT` transition when the database contains a server-resolved membership type and no payment row. It does not create a payment, call SlipOK before the state is ready, or bypass amount, receiver, duplicate, timestamp, Turnstile, rate-limit, application-token, or state-machine checks. Slip images remain in request memory only and tests use synthetic QR evidence with the mock provider.

## Deployment / rollback

No schema migration, secret, binding, or configuration change. Deploy through the reviewed `main` workflow. Rollback restores the blocker for both new and already affected drafts, so use it only for a more severe payment regression.

## Handoff

- Completed: root cause, Issue #55, correct transition for new flows, constrained compatibility repair, tests, architecture, all local gates.
- Files changed: application route/service, payment service, two focused worker test files, architecture.
- Remaining: GitHub CI, human review, merge/deploy, owner retry in the still-open browser session.
- Assumption: the affected session remains open because the wizard deliberately stores no PII or capability token in browser storage. If the tab was refreshed or closed, the session cannot be resumed by design.
- Next safe action: review the two transition points and the no-existing-payment guard; after CI passes, authorize merge/deploy.