### PR TITLE
fix: require capability for member photo upload

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -382,7 +382,7 @@ checklist ยืนยันเป็นสามข้อ ไม่ใช่ข
 
 ตามการตัดสินใจของเจ้าของระบบใน #52 รูปที่เลือกถูกส่งทั้งเฟรมโดยไม่มี crop UI และไม่มีการตัด pixel ทั้งภาพจาก iApp และภาพอัปโหลดใหม่ยังมี preview กับ checklist เดิม ภาพขนาดใหญ่ถูกย่อตามสัดส่วนและ encode เป็น JPEG บน canvas จึงตัด EXIF/GPS ก่อนออกจากเครื่อง ส่วน JPEG ที่เล็กพอจะไม่ถูก encode ซ้ำ แต่ Worker strip metadata ก่อนเก็บอีกชั้นหนึ่ง Worker ไม่บังคับ aspect ratio แล้ว แต่ยังบังคับขนาดไฟล์ ช่วงความละเอียด magic bytes และ JPEG-only storage
 
-`POST /api/member-photo` เป็น public endpoint ที่มีทั้งค่า Worker/R2 และข้อมูลส่วนบุคคล จึงใช้ Turnstile เหมือน OCR และ payment หน้า photo render challenge ของตัวเองและส่ง token ใน header เท่านั้น token จาก OCR หรือการสร้างใบสมัครถูกล้างเมื่อใช้หรือออกจากขั้น เพื่อไม่ให้ challenge แบบ single-use ถูกนำกลับมาใช้เงียบ ๆ
+`POST /api/member-photo` เป็น public endpoint ที่มีทั้งค่า Worker/R2 และข้อมูลส่วนบุคคล จึงใช้ Turnstile เหมือน OCR และ payment พร้อมตรวจ applicant capability token ของใบสมัครก่อนอ่าน bytes หรือเขียน D1/R2 หน้า photo render challenge ของตัวเองและส่ง Turnstile token ใน header เท่านั้น token จาก OCR หรือการสร้างใบสมัครถูกล้างเมื่อใช้หรือออกจากขั้น เพื่อไม่ให้ challenge แบบ single-use ถูกนำกลับมาใช้เงียบ ๆ
 
 ### สลิป
 

--- a/src/worker/routes/member-photo.ts
+++ b/src/worker/routes/member-photo.ts
@@ -2,12 +2,15 @@ import { Hono } from 'hono';
 import { z } from 'zod';
 import type { AppContext } from '../context';
 import { PHOTO_SOURCES } from '../db';
+import { requireSecret } from '../env';
+import { createKeyedHasher } from '../lib/crypto';
 import { validateImageBytes } from '../lib/files';
 import { ApiError } from '../lib/http';
 import { assertWithinRateLimit, clientIdentifier, PHOTO_POLICY } from '../security/rate-limit';
 import { assertHumanRequest } from '../security/turnstile';
 import { parseWithSchema } from '../security/validation';
 import { createAuditLog } from '../services/audit';
+import { ACCESS_TOKEN_HASH_INFO, createApplicationAccess } from '../services/application-access';
 import { createMemberPhotoService } from '../services/member-photo';
 
 /**
@@ -37,6 +40,11 @@ const MESSAGES = {
   tooLarge: 'ไฟล์รูปมีขนาดใหญ่เกินกำหนด กรุณาย่อขนาดรูป',
 } as const;
 
+async function accessFor(env: AppContext['Bindings'], db: AppContext['Variables']['db']) {
+  const keyMaterial = requireSecret(env, 'PII_ENCRYPTION_KEY');
+  return createApplicationAccess(db, await createKeyedHasher(keyMaterial, ACCESS_TOKEN_HASH_INFO));
+}
+
 export const memberPhotoRoutes = new Hono<AppContext>().post('/member-photo', async (c) => {
   await assertHumanRequest(c.var.security.turnstile, c.req.raw);
   await assertWithinRateLimit(
@@ -63,6 +71,12 @@ export const memberPhotoRoutes = new Hono<AppContext>().post('/member-photo', as
     source: form.get('source'),
     confirmed: form.get('confirmed'),
   });
+
+  // The UUID appears in browser history and support material, so it is not an
+  // applicant credential. Authorize the capability before reading image bytes
+  // or changing D1/R2, just like every other post-creation applicant route.
+  const access = await accessFor(c.env, c.var.db);
+  await access.authorize(c.req.raw, metadata.applicationId);
 
   const file = form.get('photo');
   if (!(file instanceof File)) {

--- a/tests/worker/member-photo.test.ts
+++ b/tests/worker/member-photo.test.ts
@@ -1,5 +1,10 @@
 import { env, exports } from 'cloudflare:workers';
 import { describe, expect, it } from 'vitest';
+import { createKeyedHasher } from '../../src/worker/lib/crypto';
+import {
+  ACCESS_TOKEN_HASH_INFO,
+  ACCESS_TOKEN_HEADER,
+} from '../../src/worker/services/application-access';
 import { createAuditLog } from '../../src/worker/services/audit';
 import { createMemberPhotoService } from '../../src/worker/services/member-photo';
 import { createStateMachine } from '../../src/worker/services/state-machine';
@@ -10,9 +15,12 @@ import {
   repository,
   seedApplication,
   TEST_CITIZEN_ID,
+  TEST_KEY,
 } from '../support/fixtures';
 
 const GPS_MARKER = 'GPSLatitude=13.7563';
+const TEST_ACCESS_TOKEN = 'a'.repeat(64);
+const OTHER_ACCESS_TOKEN = 'b'.repeat(64);
 
 function service(repo = repository()) {
   return createMemberPhotoService(repo, env.MEMBER_PHOTOS, createAuditLog(repo));
@@ -27,6 +35,19 @@ async function objectText(key: string): Promise<string> {
   const object = await env.MEMBER_PHOTOS.get(key);
   const bytes = new Uint8Array(await object!.arrayBuffer());
   return new TextDecoder('latin1').decode(bytes);
+}
+
+async function seedAccessibleApplication(
+  repo: ReturnType<typeof repository>,
+  citizenId: string = TEST_CITIZEN_ID,
+  token: string = TEST_ACCESS_TOKEN,
+): Promise<string> {
+  const id = await seedApplication(repo, citizenId);
+  const hasher = await createKeyedHasher(TEST_KEY, ACCESS_TOKEN_HASH_INFO);
+  await env.DB.prepare('update applications set access_token_hash = ? where id = ?')
+    .bind(await hasher.hash(token), id)
+    .run();
+  return id;
 }
 
 describe('storing a member photo', () => {
@@ -346,6 +367,7 @@ function photoRequest(form: FormData, headers: Record<string, string> = {}): Req
     headers: {
       'cf-connecting-ip': '203.0.113.30',
       [TURNSTILE_TOKEN_HEADER]: 'test-token',
+      [ACCESS_TOKEN_HEADER]: TEST_ACCESS_TOKEN,
       ...headers,
     },
     body: form,
@@ -355,7 +377,7 @@ function photoRequest(form: FormData, headers: Record<string, string> = {}): Req
 describe('POST /api/member-photo', () => {
   it('stores the photo and reports the shape without leaking the key', async () => {
     const repo = repository();
-    const id = await seedApplication(repo);
+    const id = await seedAccessibleApplication(repo);
 
     const response = await exports.default.fetch(photoRequest(photoForm(id)));
 
@@ -369,7 +391,7 @@ describe('POST /api/member-photo', () => {
 
   it('refuses a request with no Turnstile token', async () => {
     const repo = repository();
-    const id = await seedApplication(repo);
+    const id = await seedAccessibleApplication(repo);
 
     const response = await exports.default.fetch(
       photoRequest(photoForm(id), { [TURNSTILE_TOKEN_HEADER]: '' }),
@@ -379,9 +401,36 @@ describe('POST /api/member-photo', () => {
     await expect(objectKeys()).resolves.toEqual([]);
   });
 
+  it('refuses a request with no applicant capability token', async () => {
+    const repo = repository();
+    const id = await seedAccessibleApplication(repo);
+
+    const response = await exports.default.fetch(
+      photoRequest(photoForm(id), { [ACCESS_TOKEN_HEADER]: '' }),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(objectKeys()).resolves.toEqual([]);
+    await expect(repo.applications.findById(id)).resolves.toMatchObject({ photoKey: null });
+  });
+
+  it('refuses a capability token issued for another application', async () => {
+    const repo = repository();
+    const id = await seedAccessibleApplication(repo);
+    await seedAccessibleApplication(repo, OTHER_TEST_CITIZEN_ID, OTHER_ACCESS_TOKEN);
+
+    const response = await exports.default.fetch(
+      photoRequest(photoForm(id), { [ACCESS_TOKEN_HEADER]: OTHER_ACCESS_TOKEN }),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(objectKeys()).resolves.toEqual([]);
+    await expect(repo.applications.findById(id)).resolves.toMatchObject({ photoKey: null });
+  });
+
   it('refuses when the confirmation is absent', async () => {
     const repo = repository();
-    const id = await seedApplication(repo);
+    const id = await seedAccessibleApplication(repo);
 
     const response = await exports.default.fetch(
       photoRequest(photoForm(id, { confirmed: 'false' })),
@@ -393,7 +442,7 @@ describe('POST /api/member-photo', () => {
 
   it('refuses an unknown photo source', async () => {
     const repo = repository();
-    const id = await seedApplication(repo);
+    const id = await seedAccessibleApplication(repo);
 
     const response = await exports.default.fetch(
       photoRequest(photoForm(id, { source: 'SCANNED' })),
@@ -404,7 +453,7 @@ describe('POST /api/member-photo', () => {
 
   it('refuses a file that is not really an image', async () => {
     const repo = repository();
-    const id = await seedApplication(repo);
+    const id = await seedAccessibleApplication(repo);
     const pdf = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34]);
 
     const response = await exports.default.fetch(photoRequest(photoForm(id, { bytes: pdf })));
@@ -415,7 +464,7 @@ describe('POST /api/member-photo', () => {
 
   it('refuses a PNG, because its metadata is not rewritten', async () => {
     const repo = repository();
-    const id = await seedApplication(repo);
+    const id = await seedAccessibleApplication(repo);
 
     const response = await exports.default.fetch(
       photoRequest(photoForm(id, { bytes: makePng(600, 800) })),
@@ -426,7 +475,7 @@ describe('POST /api/member-photo', () => {
 
   it('stores a full square photo without requiring a 3:4 crop', async () => {
     const repo = repository();
-    const id = await seedApplication(repo);
+    const id = await seedAccessibleApplication(repo);
 
     const response = await exports.default.fetch(
       photoRequest(photoForm(id, { bytes: makeMemberPhoto({ width: 800, height: 800 }) })),
@@ -438,15 +487,21 @@ describe('POST /api/member-photo', () => {
 
   it('stores a low-resolution iApp face but rejects identical upload bytes', async () => {
     const repo = repository();
-    const idFaceApplication = await seedApplication(repo, TEST_CITIZEN_ID);
-    const uploadApplication = await seedApplication(repo, OTHER_TEST_CITIZEN_ID);
+    const idFaceApplication = await seedAccessibleApplication(repo, TEST_CITIZEN_ID);
+    const uploadApplication = await seedAccessibleApplication(
+      repo,
+      OTHER_TEST_CITIZEN_ID,
+      OTHER_ACCESS_TOKEN,
+    );
     const bytes = makeMemberPhoto({ width: 150, height: 200 });
 
     const idFaceResponse = await exports.default.fetch(
       photoRequest(photoForm(idFaceApplication, { source: 'ID_CARD', bytes })),
     );
     const uploadResponse = await exports.default.fetch(
-      photoRequest(photoForm(uploadApplication, { source: 'UPLOAD', bytes })),
+      photoRequest(photoForm(uploadApplication, { source: 'UPLOAD', bytes }), {
+        [ACCESS_TOKEN_HEADER]: OTHER_ACCESS_TOKEN,
+      }),
     );
 
     expect(idFaceResponse.status).toBe(200);
@@ -461,7 +516,7 @@ describe('POST /api/member-photo', () => {
 
   it('refuses a request with no file', async () => {
     const repo = repository();
-    const id = await seedApplication(repo);
+    const id = await seedAccessibleApplication(repo);
 
     const response = await exports.default.fetch(photoRequest(photoForm(id, { omitFile: true })));
 


### PR DESCRIPTION
Closes #60

## Summary

- authorize the application capability before reading photo bytes or writing D1/R2
- return the same not-found response for missing, wrong, or unknown credentials
- add endpoint coverage proving unauthorized requests make no storage changes
- document the photo endpoint trust boundary

## Security / privacy

High-risk authorization fix. Application UUIDs remain non-secret; only the keyed capability authorizes the write. No PII, image, provider payload, or secret is logged or committed.

## Verification

- `pwsh -NoLogo -NoProfile -File ./scripts/validate-repository.ps1` — passed (220 tracked files)
- ESLint — passed
- Prettier check — passed
- TypeScript build/typecheck — passed
- Vitest targeted — 29/29 passed
- Vitest full — 38 files, 834/834 passed
- Vite production web build — passed
- Wrangler development Worker dry-run — passed
- Wrangler production Worker dry-run — passed

The local environment exposes the bundled Node runtime without an npm shim, so the manifest-defined binaries were invoked directly with that Node executable; no package script or gate was skipped.

## Risk / rollback

Authorization behavior changes only for `POST /api/member-photo`. The current web client already sends the capability header. Roll back by reverting this PR and redeploying the previous Worker version; there is no migration or stored-data change.

## Handoff

Completed: implementation, tests, documentation and all required gates. Remaining: GitHub CI review, squash merge and production deploy. Files changed: `src/worker/routes/member-photo.ts`, `tests/worker/member-photo.test.ts`, `docs/architecture.md`. Assumption: existing clients follow the documented capability contract. Next safe action: merge after checks pass.
