### PR TITLE
fix: erase payment review manager identity

### DIFF
--- a/docs/retention-policy.md
+++ b/docs/retention-policy.md
@@ -27,6 +27,8 @@ Effective date: 21 August 2026
 | Rate-limit counters                                                                         | จบ window                               | ลบ opportunistically เมื่อมี request ใหม่                                                                                             | ตาม window                                      |
 | Worker logs                                                                                 | ตาม Cloudflare plan                     | ใช้เฉพาะ allowlisted technical metadata; ไม่ export เป็น archive ถาวร                                                                 | ค่า platform ที่สั้นที่สุดที่ operations ใช้ได้ |
 
+`payment_reviews.resolved_by` ใช้ค่าว่างหลัง erasure แทน `NULL` เพราะ schema กำหนดว่า review สถานะ `APPROVED` ต้องมีค่า non-null ขณะเดียวกันค่าว่างไม่สามารถระบุตัวผู้จัดการได้และคงหลักฐานสถานะการอนุมัติไว้ตามรอบบัญชี
+
 สถานะที่ยังดำเนินการ (`PAYMENT_VERIFIED`, `SUBMITTED`, `MANAGER_NOTIFIED`, `NBTC_PROCESSING`, `REFUND_REQUIRED`) ไม่ถูกลบอัตโนมัติ ให้ operations ตรวจรายการค้างและแก้ workflow ก่อน
 
 ## Implementation

--- a/src/worker/services/retention.ts
+++ b/src/worker/services/retention.ts
@@ -116,6 +116,12 @@ async function erasePii(
         .bind(row.id),
       db
         .prepare(
+          `update payment_reviews set resolved_by = ''
+           where application_id = ? and resolved_by is not null`,
+        )
+        .bind(row.id),
+      db
+        .prepare(
           `insert into application_events (
              id, application_id, event_type, metadata_json, actor_type, actor_id, created_at
            )

--- a/tests/worker/retention.test.ts
+++ b/tests/worker/retention.test.ts
@@ -78,6 +78,11 @@ async function insertPersonalChildren(applicationId: string, createdAt: string):
          id, application_id, event_type, actor_type, actor_id, created_at
        ) values (?, ?, 'STATUS_CHANGED', 'MANAGER', 'manager@example.test', ?)`,
     ).bind(`event-${applicationId}`, applicationId, createdAt),
+    env.DB.prepare(
+      `insert into payment_reviews (
+         application_id, reason, status, requested_at, resolved_at, resolved_by
+       ) values (?, 'SLIP_UNREADABLE', 'APPROVED', ?, ?, 'manager@example.test')`,
+    ).bind(applicationId, createdAt, createdAt),
   ]);
 }
 
@@ -207,6 +212,11 @@ describe('production retention lifecycle', () => {
         "select actor_id from application_events where id = 'event-completed'",
       ).first(),
     ).toEqual({ actor_id: null });
+    expect(
+      await env.DB.prepare(
+        "select status, resolved_by from payment_reviews where application_id = 'completed'",
+      ).first(),
+    ).toEqual({ status: 'APPROVED', resolved_by: '' });
     expect(
       await env.DB.prepare(
         "select count(*) as count from application_events where application_id = 'completed' and event_type = 'PII_ERASED'",


### PR DESCRIPTION
Closes #61

## Summary

- erase `payment_reviews.resolved_by` during the existing 90-day PII stage
- preserve the approved review/accounting state using the schema-compatible empty sentinel
- prove the identity exists before retention and is erased afterwards
- document why approved rows cannot use `NULL`

## Security / privacy

High-risk retention change. It removes a manager Access identity that was previously retained beyond policy. No applicant/provider data or secret is introduced.

## Verification

- repository baseline — passed (220 tracked files)
- ESLint — passed
- Prettier check — passed
- TypeScript build/typecheck — passed
- targeted retention tests — 5/5 passed
- full Vitest — 38 files, 834/834 passed
- Vite production build — passed
- development and production Worker dry-runs — passed

Bundled Node invoked the manifest-defined binaries directly because this local runtime has no npm shim; no gate was skipped.

## Risk / rollback

The update runs only in the existing 90-day erasure batch. Revert and redeploy to roll back code; no migration or immediate bulk mutation is performed.

## Handoff

Completed: implementation, policy note, targeted/full tests and all gates. Remaining: CI review, squash merge and production deployment. Files changed: `src/worker/services/retention.ts`, `tests/worker/retention.test.ts`, `docs/retention-policy.md`. Next safe action: merge after checks pass.
