### PR TITLE
fix: enforce application completeness before payment

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -328,6 +328,8 @@ PAYMENT_VERIFIED → ออกเลขที่ใบสมัคร → RECEIP
 - `GET /api/applications/:id/confirmation` อ่านสถานะแต่ละขั้น (หัวข้อ 66) **อ่านอย่างเดียว** — การ resume จาก GET จะทำให้การ refresh หน้า, prefetch หรือ link preview ส่งอีเมลได้
 - `POST /api/applications/:id/finalize` เดินขั้นที่ค้างให้จบ ใช้ capability token เดิมกับที่ยืนยันการชำระเงิน และมี rate limit เพราะเรียก provider ได้ ฝั่งผู้จัดการจะได้ action เทียบเท่าที่ไม่ต้องใช้ token ของผู้สมัครใน #16
 
+ก่อนบันทึกประเภทสมาชิกและเปลี่ยนเป็น `AWAITING_PAYMENT` Worker อ่านข้อมูลที่ persist แล้วและตรวจซ้ำว่ามีชื่อ-นามสกุล อีเมล โทรศัพท์ ที่อยู่ตามบัตร/ที่อยู่จัดส่งพร้อมรหัสไปรษณีย์ และรูปสมาชิกที่เลือกครบ การตรวจนี้เป็น business boundary ฝั่ง server ไม่อาศัยเพียง validation ของ wizard และ payment service ตรวจ invariant เดิมอีกครั้งก่อนเรียก provider เพื่อปิดทางของ record เก่าหรือ client ที่เรียก API เอง
+
 ## Admin
 
 **ทุก route ตรวจ Access JWT ในตัว Worker เอง ไม่ใช่พึ่งการตั้งค่าที่ edge เท่านั้น** Access ที่วางไว้หน้า `/admin*` และ `/api/admin/*` คือ setting เดียวใน dashboard — ถ้ามันถูกลบ, ถูกผูกกับ hostname ผิด หรือ path ไม่ตรง ทุก endpoint จะกลายเป็นสาธารณะทันที การตรวจซ้ำในนี้ทำให้ความผิดพลาดใน dashboard มีราคาเท่ากับ downtime ไม่ใช่ข้อมูลรั่ว

--- a/src/worker/services/application.ts
+++ b/src/worker/services/application.ts
@@ -29,6 +29,8 @@ const MESSAGES = {
   notEditable: 'ใบสมัครนี้อยู่ในขั้นตอนที่ไม่สามารถแก้ไขข้อมูลได้แล้ว',
   mailPostcode: 'กรุณากรอกรหัสไปรษณีย์สำหรับที่อยู่จัดส่งเอกสาร',
   mailRecipient: 'กรุณากรอกชื่อผู้รับและที่อยู่สำหรับจัดส่งเอกสาร',
+  incomplete:
+    'กรุณากรอกข้อมูลผู้สมัคร ข้อมูลติดต่อ ที่อยู่จัดส่ง และเลือกรูปสมาชิกให้ครบก่อนชำระเงิน',
 } as const;
 
 /** Statuses in which the applicant may still change their own data. */
@@ -198,6 +200,44 @@ function toAddressRow(address: ApplicantAddressInput): AddressInput {
   };
 }
 
+function hasText(value: string | null): boolean {
+  return value !== null && value.trim().length > 0;
+}
+
+/**
+ * Enforces the server-side business boundary before any payment work.
+ *
+ * The browser validates each wizard step for usability, but a capability holder
+ * may call the API directly. Required data is therefore checked again against
+ * the persisted record instead of trusting that the normal UI was followed.
+ */
+export async function assertApplicationCompleteForPayment(
+  db: Repository,
+  applicationId: string,
+): Promise<ApplicationRecord> {
+  const [application, address] = await Promise.all([
+    db.applications.findById(applicationId),
+    db.addresses.findByApplicationId(applicationId),
+  ]);
+  if (!application) throw new ApiError('NOT_FOUND', MESSAGES.notFound);
+
+  const identityComplete = hasText(application.firstName) && hasText(application.lastName);
+  const contactComplete = hasText(application.email) && hasText(application.phone);
+  const addressComplete =
+    address !== null &&
+    hasText(address.idAddress) &&
+    hasText(address.idProvince) &&
+    hasText(address.mailAddress) &&
+    hasText(address.mailProvince) &&
+    hasText(address.mailPostcode);
+  const photoComplete = hasText(application.photoKey);
+
+  if (!identityComplete || !contactComplete || !addressComplete || !photoComplete) {
+    throw new ApiError('VALIDATION_FAILED', MESSAGES.incomplete);
+  }
+  return application;
+}
+
 export function createApplicationService(
   db: Repository,
   protection: CitizenIdProtection,
@@ -295,6 +335,8 @@ export function createApplicationService(
       }
 
       if (input.membershipType) {
+        await assertApplicationCompleteForPayment(db, applicationId);
+
         // Resolved from the catalogue. An amount from the client is not read at
         // all, so there is nothing to ignore.
         const plan = membershipPlan(input.membershipType);

--- a/src/worker/services/payment.ts
+++ b/src/worker/services/payment.ts
@@ -3,6 +3,7 @@ import type { PaymentRecord, Repository } from '../db';
 import { ApiError } from '../lib/http';
 import type { SlipEvidence, SlipVerificationProvider } from '../providers';
 import type { AuditLog } from './audit';
+import { assertApplicationCompleteForPayment } from './application';
 import { membershipPlan } from './membership';
 import type { StateMachine } from './state-machine';
 
@@ -170,6 +171,12 @@ export function createPaymentService(
         application.status === 'DRAFT' &&
         application.membershipType !== null &&
         (await db.payments.findByApplicationId(input.applicationId)).length === 0;
+      if (
+        (application.status === 'AWAITING_PAYMENT' && application.membershipType !== null) ||
+        legacyDraftHasNoPayment
+      ) {
+        await assertApplicationCompleteForPayment(db, input.applicationId);
+      }
       if (legacyDraftHasNoPayment) {
         await stateMachine.transition(input.applicationId, 'AWAITING_PAYMENT', {
           actorType: 'APPLICANT',

--- a/tests/worker/application-workflow.test.ts
+++ b/tests/worker/application-workflow.test.ts
@@ -435,7 +435,7 @@ async function createApplication(citizenId: string): Promise<CreatedBody> {
         'cf-connecting-ip': '203.0.113.77',
         [TURNSTILE_TOKEN_HEADER]: 'test-token',
       },
-      body: JSON.stringify({ citizenId }),
+      body: JSON.stringify({ citizenId, firstName: 'ทดสอบ', lastName: 'พร้อมชำระ' }),
     }),
   );
   expect(response.status).toBe(201);
@@ -447,15 +447,37 @@ async function readyToPay(repo: Repository, citizenId: string) {
   const created = await createApplication(citizenId);
   const id = created.application.id;
 
-  await exports.default.fetch(
+  const details = await exports.default.fetch(
     new Request(`http://localhost/api/applications/${id}`, {
       method: 'PATCH',
       headers: { 'content-type': 'application/json', [ACCESS_TOKEN_HEADER]: created.accessToken },
-      body: JSON.stringify({ email: APPLICANT_EMAIL, phone: '0800000000' }),
+      body: JSON.stringify({
+        email: APPLICANT_EMAIL,
+        phone: '0800000000',
+        address: {
+          idAddress: '999 หมู่ 9',
+          idSubdistrict: 'ตัวอย่าง',
+          idDistrict: 'ตัวอย่าง',
+          idProvince: 'กรุงเทพมหานคร',
+          mailSameAsId: true,
+          mailPostcode: '10200',
+        },
+      }),
     }),
   );
-  await repo.applications.setMembership(id, 'FIVE_YEAR', FIVE_YEAR_SATANG);
-  await createStateMachine(repo).transition(id, 'AWAITING_PAYMENT');
+  expect(details.status).toBe(200);
+  await repo.applications.setPhoto(id, {
+    key: `member-photos/${id}.jpg`,
+    source: 'UPLOAD',
+  });
+  const membership = await exports.default.fetch(
+    new Request(`http://localhost/api/applications/${id}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json', [ACCESS_TOKEN_HEADER]: created.accessToken },
+      body: JSON.stringify({ membershipType: 'FIVE_YEAR' }),
+    }),
+  );
+  expect(membership.status).toBe(200);
 
   return { id, token: created.accessToken };
 }

--- a/tests/worker/applications.test.ts
+++ b/tests/worker/applications.test.ts
@@ -66,6 +66,42 @@ async function createApplication(citizenId = CITIZEN_ID, ip = '203.0.113.40') {
   return response.json<CreatedBody>();
 }
 
+async function prepareForMembership(
+  options: { identity?: boolean; contact?: boolean; address?: boolean; photo?: boolean } = {},
+) {
+  const include = {
+    identity: options.identity ?? true,
+    contact: options.contact ?? true,
+    address: options.address ?? true,
+    photo: options.photo ?? true,
+  };
+  const response = await exports.default.fetch(
+    createRequest({
+      citizenId: CITIZEN_ID,
+      ...(include.identity ? { firstName: 'ทดสอบ', lastName: 'พร้อมชำระ' } : {}),
+    }),
+  );
+  expect(response.status).toBe(201);
+  const created = await response.json<CreatedBody>();
+
+  if (include.contact || include.address) {
+    const update = await exports.default.fetch(
+      patchRequest(created.application.id, created.accessToken, {
+        ...(include.contact ? { email: 'member@example.test', phone: '0800000000' } : {}),
+        ...(include.address ? { address: VALID_ADDRESS } : {}),
+      }),
+    );
+    expect(update.status).toBe(200);
+  }
+  if (include.photo) {
+    await repository().applications.setPhoto(created.application.id, {
+      key: `member-photos/${created.application.id}.jpg`,
+      source: 'UPLOAD',
+    });
+  }
+  return created;
+}
+
 describe('POST /api/applications', () => {
   it('creates an application and returns the capability token once', async () => {
     const body = await createApplication();
@@ -265,7 +301,7 @@ describe('PATCH /api/applications/:id', () => {
   });
 
   it('resolves the membership amount on the server', async () => {
-    const created = await createApplication();
+    const created = await prepareForMembership();
 
     const response = await exports.default.fetch(
       patchRequest(created.application.id, created.accessToken, { membershipType: 'LIFETIME' }),
@@ -282,7 +318,7 @@ describe('PATCH /api/applications/:id', () => {
   });
 
   it('moves into payment once and keeps membership changes idempotent there', async () => {
-    const created = await createApplication();
+    const created = await prepareForMembership();
 
     const first = await exports.default.fetch(
       patchRequest(created.application.id, created.accessToken, { membershipType: 'FIVE_YEAR' }),
@@ -323,6 +359,31 @@ describe('PATCH /api/applications/:id', () => {
 
     const record = await repository().applications.findById(created.application.id);
     expect(record?.membershipAmountSatang).toBeNull();
+  });
+
+  it.each([
+    ['identity', { identity: false }],
+    ['contact', { contact: false }],
+    ['address', { address: false }],
+    ['member photo', { photo: false }],
+  ] as const)('refuses membership selection when %s data is incomplete', async (_label, missing) => {
+    const created = await prepareForMembership(missing);
+
+    const response = await exports.default.fetch(
+      patchRequest(created.application.id, created.accessToken, { membershipType: 'FIVE_YEAR' }),
+    );
+
+    expect(response.status).toBe(422);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: 'VALIDATION_FAILED' },
+    });
+    await expect(repository().applications.findById(created.application.id)).resolves.toMatchObject(
+      {
+        status: 'DRAFT',
+        membershipType: null,
+        membershipAmountSatang: null,
+      },
+    );
   });
 
   it('stores an address that copies the ID card', async () => {
@@ -442,7 +503,7 @@ describe('PATCH /api/applications/:id', () => {
   });
 
   it('records the membership choice in the audit trail', async () => {
-    const created = await createApplication();
+    const created = await prepareForMembership();
     await exports.default.fetch(
       patchRequest(created.application.id, created.accessToken, { membershipType: 'FIVE_YEAR' }),
     );

--- a/tests/worker/applications.test.ts
+++ b/tests/worker/applications.test.ts
@@ -366,25 +366,28 @@ describe('PATCH /api/applications/:id', () => {
     ['contact', { contact: false }],
     ['address', { address: false }],
     ['member photo', { photo: false }],
-  ] as const)('refuses membership selection when %s data is incomplete', async (_label, missing) => {
-    const created = await prepareForMembership(missing);
+  ] as const)(
+    'refuses membership selection when %s data is incomplete',
+    async (_label, missing) => {
+      const created = await prepareForMembership(missing);
 
-    const response = await exports.default.fetch(
-      patchRequest(created.application.id, created.accessToken, { membershipType: 'FIVE_YEAR' }),
-    );
+      const response = await exports.default.fetch(
+        patchRequest(created.application.id, created.accessToken, { membershipType: 'FIVE_YEAR' }),
+      );
 
-    expect(response.status).toBe(422);
-    await expect(response.json()).resolves.toMatchObject({
-      error: { code: 'VALIDATION_FAILED' },
-    });
-    await expect(repository().applications.findById(created.application.id)).resolves.toMatchObject(
-      {
+      expect(response.status).toBe(422);
+      await expect(response.json()).resolves.toMatchObject({
+        error: { code: 'VALIDATION_FAILED' },
+      });
+      await expect(
+        repository().applications.findById(created.application.id),
+      ).resolves.toMatchObject({
         status: 'DRAFT',
         membershipType: null,
         membershipAmountSatang: null,
-      },
-    );
-  });
+      });
+    },
+  );
 
   it('stores an address that copies the ID card', async () => {
     const created = await createApplication();

--- a/tests/worker/payment.test.ts
+++ b/tests/worker/payment.test.ts
@@ -55,6 +55,32 @@ function service(repo: Repository, slipOptions: MockSlipOptions = {}, now: () =>
   );
 }
 
+async function completeApplication(repo: Repository, id: string): Promise<void> {
+  await repo.applications.updateContact(id, {
+    email: 'applicant@example.test',
+    phone: '0800000000',
+    callsign: null,
+  });
+  await repo.addresses.upsert(id, {
+    idAddress: '999 หมู่ 9',
+    idSubdistrict: 'ตัวอย่าง',
+    idDistrict: 'ตัวอย่าง',
+    idProvince: 'กรุงเทพมหานคร',
+    mailSameAsId: true,
+    mailRecipient: null,
+    mailAddress: '999 หมู่ 9',
+    mailSubdistrict: 'ตัวอย่าง',
+    mailDistrict: 'ตัวอย่าง',
+    mailProvince: 'กรุงเทพมหานคร',
+    mailPostcode: '10200',
+    mailPhone: null,
+  });
+  await repo.applications.setPhoto(id, {
+    key: `member-photos/${id}.jpg`,
+    source: 'UPLOAD',
+  });
+}
+
 /** An application selected a membership and is awaiting payment. */
 async function readyToPay(
   repo: Repository,
@@ -62,6 +88,7 @@ async function readyToPay(
   membership: 'FIVE_YEAR' | 'LIFETIME' = 'FIVE_YEAR',
 ): Promise<string> {
   const id = await seedApplication(repo, citizenId);
+  await completeApplication(repo, id);
   await repo.applications.setMembership(
     id,
     membership,
@@ -486,6 +513,7 @@ describe('a payment that is not expected', () => {
   it('repairs a legacy draft whose server-resolved membership was already stored', async () => {
     const repo = repository();
     const id = await seedApplication(repo);
+    await completeApplication(repo, id);
     await repo.applications.setMembership(id, 'FIVE_YEAR', FIVE_YEAR_SATANG);
 
     await expect(service(repo).verify({ applicationId: id, evidence: QR })).resolves.toMatchObject({
@@ -499,6 +527,7 @@ describe('a payment that is not expected', () => {
   it('repairs the legacy status before contacting the provider', async () => {
     const repo = repository();
     const id = await seedApplication(repo);
+    await completeApplication(repo, id);
     await repo.applications.setMembership(id, 'FIVE_YEAR', FIVE_YEAR_SATANG);
 
     const error = await service(repo, { failWith: 'PROVIDER_TIMEOUT' })
@@ -506,6 +535,23 @@ describe('a payment that is not expected', () => {
       .catch((reason: unknown) => reason);
 
     expect((error as PaymentRejectedError).reason).toBe('PROVIDER_UNAVAILABLE');
+    await expect(repo.applications.findById(id)).resolves.toMatchObject({
+      status: 'AWAITING_PAYMENT',
+    });
+  });
+
+  it('refuses an incomplete awaiting-payment record before contacting the provider', async () => {
+    const repo = repository();
+    const id = await seedApplication(repo);
+    await repo.applications.setMembership(id, 'FIVE_YEAR', FIVE_YEAR_SATANG);
+    await createStateMachine(repo).transition(id, 'AWAITING_PAYMENT');
+
+    const error = await service(repo, { failWith: 'PROVIDER_TIMEOUT' })
+      .verify({ applicationId: id, evidence: QR })
+      .catch((reason: unknown) => reason);
+
+    expect(error).toMatchObject({ code: 'VALIDATION_FAILED' });
+    await expect(repo.payments.findByApplicationId(id)).resolves.toEqual([]);
     await expect(repo.applications.findById(id)).resolves.toMatchObject({
       status: 'AWAITING_PAYMENT',
     });


### PR DESCRIPTION
Closes #62

## Summary

- validate persisted identity, contact, mailing address and selected member photo before storing membership or entering payment
- repeat the invariant before legacy/current payment verification so incomplete records fail before provider calls
- preserve the existing membership-not-selected error precedence
- cover all missing-data classes and update route-level workflow fixtures to follow the production invariant

## Security / privacy

High-risk payment workflow change. Validation uses existing persisted records and returns one generic applicant-safe message; missing field details and PII are not logged.

## Verification

- repository baseline — passed (220 tracked files)
- ESLint — passed
- Prettier check — passed
- TypeScript build/typecheck — passed
- targeted application/payment/workflow tests — 101/101 passed
- full Vitest — 38 files, 839/839 passed
- Vite production build — passed
- development and production Worker dry-runs — passed

Bundled Node invoked manifest-defined binaries directly because the local runtime has no npm shim; no gate was skipped.

## Risk / rollback

Existing complete FIVE_YEAR/LIFETIME flows are unchanged. Incomplete legacy records fail closed before a paid provider call and remain editable where their status permits. Revert and redeploy to roll back; there is no migration.

## Handoff

Completed: invariant, legacy defense, tests, architecture note and all gates. Files changed: `src/worker/services/application.ts`, `src/worker/services/payment.ts`, three worker test files and `docs/architecture.md`. Remaining: CI review, squash merge and production deployment. Next safe action: merge after checks pass.
