### PR TITLE
chore: enable CodeQL security analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "23 20 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze JavaScript and TypeScript
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@42947a340483f03ba47bb1a039b2c519aab3df85 # v3
+        with:
+          languages: javascript-typescript
+          build-mode: none
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@42947a340483f03ba47bb1a039b2c519aab3df85 # v3
+        with:
+          category: /language:javascript-typescript


### PR DESCRIPTION
Closes #64

## Summary

- add JavaScript/TypeScript CodeQL analysis for pull requests, main pushes, weekly schedule and manual runs
- use build mode `none` for the repository language
- grant only read-content and write-security-events permissions
- pin checkout and CodeQL actions to full commit SHAs

## Security / privacy

CI analyzes repository source only. It receives no production environment, Cloudflare/provider credentials, PII or live artifacts.

## Verification

- repository baseline — passed (221 tracked files)
- ESLint — passed
- Prettier check — passed
- TypeScript build/typecheck — passed
- full Vitest — 38 files, 839/839 passed
- Vite production build — passed
- development and production Worker dry-runs — passed
- CodeQL PR analysis — required before merge and reported by GitHub checks

Bundled Node invoked manifest-defined binaries directly because the local runtime has no npm shim; no gate was skipped.

## Alert disposition

After merge, secret-scanning alerts #1 and #2 will be resolved as false positives because all locations are synthetic webhook-signing test fixtures. The values will not be copied into Issue/PR evidence.

## Rollback / handoff

Revert to remove the workflow; runtime and production data are unaffected. Completed: workflow and all local gates. Remaining: CodeQL check, squash merge, resolve the two alerts and verify the main analysis. Next safe action: merge after checks pass.
