### PR TITLE
chore: enforce protected owner approval

### DIFF
--- a/.github/workflows/human-review.yml
+++ b/.github/workflows/human-review.yml
@@ -1,0 +1,30 @@
+name: Owner approval
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+
+concurrency:
+  group: owner-approval-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  approval:
+    name: Human approval
+    if: ${{ github.event.pull_request.draft == false }}
+    environment: human-review
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Record protected-environment approval
+        run: echo "Repository owner approved this pull request for merge."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ This file is the repository contract for every human or AI agent. More specific 
 - Record durable decisions in `docs/`; record transient progress and handoffs in the Issue or PR, not in new ad-hoc files.
 - A handoff must state completed work, remaining work, files changed, commands and results, risks, assumptions, and the next safe action.
 - Do not merge your own high-risk PR without human review.
+- GitHub enforces the human decision with the required `Human approval` check backed by the protected `human-review` environment. Because this personal repository has one collaborator, the environment permits owner self-review; the approval must still come from the human owner and be recorded in the Issue or PR. An AI agent must not infer or manufacture that approval.
 
 ## Verification
 


### PR DESCRIPTION
Closes #63

## Summary

- add a `Human approval` check backed by the protected `human-review` GitHub environment
- run it for every ready PR and every synchronized push without checking out or executing PR code
- document the single-owner control and prohibition on inferred/AI-manufactured approval
- retain strict quality checks, CodeQL and squash-only merges

## Governance decision

GitHub reports one repository collaborator. Native required PR approvals or `prevent_self_review=true` would deadlock all future work. The protected-environment approval is the enforceable single-owner alternative: every fresh PR head requires an explicit owner decision that becomes a check run. The owner explicitly authorized this current change, merge and deploy on 2026-08-24.

## Verification

- repository baseline — passed (222 tracked files)
- ESLint — passed
- Prettier check — passed
- TypeScript build/typecheck — passed
- full Vitest — 38 files, 839/839 passed
- Vite production build — passed
- development and production Worker dry-runs — passed
- protected environment configuration read back with owner reviewer and no deployment branch restriction
- CI, CodeQL and initial `Human approval` check are required before merge

Bundled Node invoked manifest-defined binaries directly because the local runtime has no npm shim; no gate was skipped.

## Security / rollback

The workflow has read-only contents permission and never checks out PR code. Roll back by removing the required context, reverting this PR and deleting the `human-review` environment.

## Handoff

Completed: workflow, repository contract, environment setup and all local gates. Remaining: approve this pre-authorized initial gate, CI/CodeQL, squash merge, add the required context to the main ruleset and verify it. Next safe action: merge only after every check passes.
